### PR TITLE
Refine Say mockup: floating settings gear, split translation cards, sort dropdown

### DIFF
--- a/say.html
+++ b/say.html
@@ -1,0 +1,1106 @@
+<!DOCTYPE html>
+<html lang="en" translate="no">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="google" content="notranslate">
+  <meta name="googlebot" content="notranslate">
+  <title>Say Planning & Wireframe</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f8fafc;
+      --surface: #ffffff;
+      --border: #e2e8f0;
+      --muted: #94a3b8;
+      --text: #0f172a;
+      --accent: #2563eb;
+      --accent-soft: #dbeafe;
+      --success: #10b981;
+      --warning: #f59e0b;
+      --danger: #ef4444;
+      --shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Inter', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+
+    .app {
+      max-width: 1200px;
+      margin: 32px auto;
+      padding: 0 24px 48px;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 20px;
+    }
+
+    .title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .title h1 {
+      margin: 0;
+      font-size: 28px;
+      font-weight: 700;
+    }
+
+    .title span {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .status-pill {
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 12px;
+    }
+
+    .tabs {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    .tab-btn {
+      padding: 12px 16px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      font-weight: 600;
+      font-size: 14px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .tab-btn.active {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: #eff6ff;
+      box-shadow: var(--shadow);
+    }
+
+    .modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+      z-index: 40;
+    }
+
+    .modal.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .modal-card {
+      width: min(920px, 92vw);
+      max-height: 90vh;
+      overflow: auto;
+      background: var(--surface);
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      padding: 20px;
+    }
+
+    #gear-fab {
+      position: fixed;
+      right: 24px;
+      bottom: 24px;
+      width: 52px;
+      height: 52px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      z-index: 30;
+    }
+
+    .panel {
+      display: none;
+    }
+
+    .panel.active {
+      display: block;
+    }
+
+    .grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .grid.catalog {
+      grid-template-columns: 280px minmax(0, 1fr);
+    }
+
+    .grid.use {
+      grid-template-columns: minmax(0, 1fr) 320px;
+    }
+
+    .grid.settings {
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .card {
+      background: var(--surface);
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      padding: 18px;
+    }
+
+    .card h2 {
+      margin: 0 0 12px;
+      font-size: 18px;
+    }
+
+    .section-label {
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 8px;
+    }
+
+    .category-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .category-item {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px;
+      background: #f8fafc;
+      cursor: pointer;
+      display: grid;
+      gap: 6px;
+    }
+
+    .category-item.active {
+      border-color: var(--accent);
+      background: #eff6ff;
+    }
+
+    .category-item strong {
+      font-size: 14px;
+    }
+
+    .subcategory {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .controls {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .control-group {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .chip {
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: #f8fafc;
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .chip.active { border-color: var(--accent); color: var(--accent); }
+
+    .card-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .card-item {
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 14px;
+      display: grid;
+      gap: 12px;
+      background: #ffffff;
+    }
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .card-title {
+      font-weight: 600;
+      font-size: 15px;
+    }
+
+    .card-subtitle {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .card-link {
+      font-size: 12px;
+      color: var(--accent);
+      background: none;
+      border: none;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+
+    .card-body {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .translation-col {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px;
+      background: #f8fafc;
+      display: grid;
+      gap: 8px;
+    }
+
+    .translation-label {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .translation-row {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .translation-text {
+      font-size: 14px;
+      color: var(--text);
+    }
+
+    .speaker-btn {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 6px;
+      background: white;
+      cursor: pointer;
+      color: var(--accent);
+    }
+
+    .card-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .footer-meta {
+      font-size: 12px;
+      color: var(--muted);
+      margin-right: 8px;
+    }
+
+    .footer-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .chevron-btn {
+      border: 1px solid var(--border);
+      background: #f8fafc;
+      border-radius: 12px;
+      padding: 6px 10px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .card-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      align-items: flex-end;
+    }
+
+    .icon-btn {
+      border: 1px solid var(--border);
+      background: #f8fafc;
+      border-radius: 10px;
+      padding: 6px 8px;
+      cursor: pointer;
+      font-size: 14px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .icon-btn.active { border-color: var(--accent); color: var(--accent); }
+
+    .back-translation {
+      margin-top: 8px;
+      padding: 8px 10px;
+      border-radius: 10px;
+      background: #f1f5f9;
+      font-size: 12px;
+      color: #475569;
+      display: none;
+    }
+
+    .back-translation.visible { display: block; }
+
+    .log-details {
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+      padding: 10px;
+      font-size: 12px;
+      color: var(--muted);
+      display: none;
+    }
+
+    .log-details.visible { display: block; }
+
+    .use-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .use-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+    }
+
+    .use-item small { color: var(--muted); }
+
+    .history-item {
+      display: grid;
+      gap: 6px;
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+    }
+
+    .history-item a {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 12px;
+    }
+
+    .stepper {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .step {
+      flex: 1;
+      border-radius: 12px;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      background: #f8fafc;
+      font-size: 12px;
+      font-weight: 600;
+      text-align: center;
+    }
+
+    .step.active {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: #eff6ff;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }
+
+    label {
+      font-size: 12px;
+      color: var(--muted);
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    input,
+    select {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 14px;
+      font-family: inherit;
+    }
+
+    .primary-btn {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+      border-radius: 10px;
+      padding: 10px 16px;
+      cursor: pointer;
+    }
+
+    .secondary-btn {
+      border: 1px solid var(--border);
+      background: #f8fafc;
+      border-radius: 10px;
+      padding: 10px 14px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    .notice {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .version-list {
+      display: grid;
+      gap: 8px;
+    }
+
+    .version-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-size: 12px;
+    }
+
+    footer {
+      margin-top: 24px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 900px) {
+      .grid.catalog,
+      .grid.use { grid-template-columns: 1fr; }
+      .card-body { grid-template-columns: 1fr; }
+      header { flex-direction: column; align-items: flex-start; gap: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header>
+      <div class="title">
+        <h1>Say — Planning & Wireframe</h1>
+        <span>Mockup aligned to chat.html patterns: language pair, voice controls, usage logging.</span>
+      </div>
+      <span class="status-pill">Offline prototype</span>
+    </header>
+
+    <nav class="tabs" aria-label="Primary">
+      <button class="tab-btn active" data-tab="catalog">Catalog</button>
+      <button class="tab-btn" data-tab="use">Use</button>
+      <button class="tab-btn" data-tab="curation">Curation</button>
+    </nav>
+
+    <!-- Single source of truth:
+      - Card is atomic; copying to other categories/subcategories is allowed.
+      - One-level subcategories only.
+      - Topic cards are separate type; answers are cards chosen from category library.
+      - Back-translation generated on creation; chevron reveals/refreshes.
+      - Usage increments on TTS playback or back-translation reveal.
+      - Sorting: alpha, last used, created, updated, priority; drag-and-drop only in custom/priority.
+      - Favorites are catalog-scoped; history is global with deep links.
+      - Export versioning keeps latest + last 5; merge default with replace option.
+    -->
+
+    <section class="panel active" id="catalog">
+      <div class="grid catalog">
+        <div class="card">
+          <h2>Categories</h2>
+          <div class="category-list" id="categoryList"></div>
+        </div>
+        <div class="card">
+          <div class="controls">
+            <div>
+              <div class="section-label">Selected</div>
+              <div id="selectedCategory">Travel → Airport</div>
+            </div>
+            <div class="control-group">
+              <label class="section-label" for="sortSelect">Sort</label>
+              <select id="sortSelect">
+                <option>Alpha</option>
+                <option>Last used</option>
+                <option>Created</option>
+                <option>Updated</option>
+                <option>Priority</option>
+              </select>
+            </div>
+            <button class="secondary-btn" id="addCardBtn">+ New card</button>
+          </div>
+          <div class="card-list" id="cardList"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" id="use">
+      <div class="grid use">
+        <div class="card">
+          <h2>Quick Speak</h2>
+          <div class="controls">
+            <div class="control-group">
+              <span class="chip active">Travel</span>
+              <span class="chip">Food</span>
+              <span class="chip">Care</span>
+            </div>
+            <button class="secondary-btn" id="playLatestBtn">▶ Play latest</button>
+          </div>
+          <div class="use-list" id="favoriteList"></div>
+        </div>
+        <div class="card">
+          <h2>History (global)</h2>
+          <div class="notice">Time-scoped, deep links back to catalog cards.</div>
+          <div class="use-list" id="historyList"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel" id="curation">
+      <div class="card">
+        <h2>Card Curation Flow</h2>
+        <div class="stepper" id="curationStepper">
+          <div class="step active" data-step="1">1. Draft</div>
+          <div class="step" data-step="2">2. Translate</div>
+          <div class="step" data-step="3">3. Classify</div>
+          <div class="step" data-step="4">4. Priority</div>
+        </div>
+        <div class="form-grid">
+          <div>
+            <label for="sourceText">Source phrase</label>
+            <input id="sourceText" value="Where is the baggage claim?">
+          </div>
+          <div>
+            <label for="targetText">Target translation</label>
+            <input id="targetText" value="¿Dónde está la cinta de equipaje?">
+          </div>
+          <div>
+            <label for="backTranslation">Back-translation preview</label>
+            <input id="backTranslation" value="Where is the luggage belt?">
+          </div>
+          <div>
+            <label for="topicType">Card type</label>
+            <select id="topicType">
+              <option>Answer card</option>
+              <option>Topic card</option>
+            </select>
+          </div>
+          <div>
+            <label for="categorySelect">Category</label>
+            <select id="categorySelect">
+              <option>Travel</option>
+              <option>Food</option>
+              <option>Care</option>
+            </select>
+          </div>
+          <div>
+            <label for="subcategorySelect">Subcategory</label>
+            <select id="subcategorySelect">
+              <option>Airport</option>
+              <option>Hotel</option>
+              <option>Street</option>
+            </select>
+          </div>
+          <div>
+            <label for="priority">Priority</label>
+            <select id="priority">
+              <option>Standard</option>
+              <option>High</option>
+              <option>Custom (manual order)</option>
+            </select>
+          </div>
+        </div>
+        <div class="controls" style="margin-top:16px;">
+          <button class="secondary-btn" id="prevStep">Back</button>
+          <button class="secondary-btn" id="autoTranslate">Auto-translate + preview</button>
+          <button class="primary-btn" id="saveCard">Save card</button>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      Prototype only. Events log to the console to represent persistence and usage tracking.
+    </footer>
+  </div>
+
+  <button id="gear-fab" aria-label="Open settings">
+    <span class="material-symbols-outlined">settings</span>
+  </button>
+
+  <div id="settings-modal" class="modal" aria-hidden="true">
+    <div class="modal-card">
+      <div class="controls" style="margin-bottom:16px;">
+        <h2 style="margin:0;">Settings</h2>
+        <button class="secondary-btn" id="closeSettings">Close</button>
+      </div>
+      <div class="grid settings">
+        <div class="card">
+          <h2>Language Pair</h2>
+          <div class="form-grid">
+            <div>
+              <label for="sourceLang">Source</label>
+              <select id="sourceLang">
+                <option>English</option>
+                <option>French</option>
+                <option>Japanese</option>
+              </select>
+            </div>
+            <div>
+              <label for="targetLang">Target</label>
+              <select id="targetLang">
+                <option>Spanish</option>
+                <option>Italian</option>
+                <option>German</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Voice per language</h2>
+          <div class="form-grid">
+            <div>
+              <label for="sourceVoice">Source voice</label>
+              <select id="sourceVoice">
+                <option>Female · Warm</option>
+                <option>Male · Crisp</option>
+              </select>
+            </div>
+            <div>
+              <label for="targetVoice">Target voice</label>
+              <select id="targetVoice">
+                <option>Female · Calm</option>
+                <option>Male · Bright</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Export / Import</h2>
+          <p class="notice">Merge default, or replace entire catalog.</p>
+          <div class="controls">
+            <button class="secondary-btn">Export JSON</button>
+            <button class="secondary-btn">Import (merge)</button>
+            <button class="secondary-btn">Import (replace)</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Versions</h2>
+          <div class="version-list" id="versionList"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const categories = [
+      {
+        name: 'Travel',
+        subcategories: ['Airport', 'Hotel', 'Street'],
+        cards: [
+          {
+            id: 'travel-1',
+            source: 'Where is the baggage claim?',
+            target: '¿Dónde está la cinta de equipaje?',
+            backTranslation: 'Where is the luggage belt?',
+            usage: 24,
+            favorite: true,
+            lastUsed: 'Today · 09:10',
+            log: ['Used via TTS', 'Back-translation revealed'],
+            showBack: false,
+            showLog: false,
+          },
+          {
+            id: 'travel-2',
+            source: 'I need a taxi to the hotel.',
+            target: 'Necesito un taxi al hotel.',
+            backTranslation: 'I need a taxi to the hotel.',
+            usage: 13,
+            favorite: false,
+            lastUsed: 'Yesterday · 18:42',
+            log: ['Used via TTS'],
+            showBack: false,
+            showLog: false,
+          }
+        ]
+      },
+      {
+        name: 'Food',
+        subcategories: ['Restaurant', 'Market'],
+        cards: [
+          {
+            id: 'food-1',
+            source: 'Do you have vegetarian options?',
+            target: '¿Tiene opciones vegetarianas?',
+            backTranslation: 'Do you have vegetarian options?',
+            usage: 9,
+            favorite: true,
+            lastUsed: 'Today · 08:22',
+            log: ['Added to favorites', 'Used via TTS'],
+            showBack: false,
+            showLog: false,
+          }
+        ]
+      },
+      {
+        name: 'Care',
+        subcategories: ['Pharmacy', 'Clinic'],
+        cards: [
+          {
+            id: 'care-1',
+            source: 'I need a doctor.',
+            target: 'Necesito un médico.',
+            backTranslation: 'I need a doctor.',
+            usage: 6,
+            favorite: false,
+            lastUsed: '2 days ago',
+            log: ['Back-translation revealed'],
+            showBack: false,
+            showLog: false,
+          }
+        ]
+      }
+    ];
+
+    const history = [
+      {
+        id: 'travel-1',
+        source: 'Where is the baggage claim?',
+        target: '¿Dónde está la cinta de equipaje?',
+        time: '2 hours ago',
+        link: '#catalog?card=travel-1'
+      },
+      {
+        id: 'food-1',
+        source: 'Do you have vegetarian options?',
+        target: '¿Tiene opciones vegetarianas?',
+        time: 'Yesterday',
+        link: '#catalog?card=food-1'
+      }
+    ];
+
+    const versions = [
+      { label: 'Latest (auto)', date: 'Today 09:12', status: 'Active' },
+      { label: 'v1.14', date: 'Yesterday', status: 'Backup' },
+      { label: 'v1.13', date: '2 days ago', status: 'Backup' },
+      { label: 'v1.12', date: '3 days ago', status: 'Backup' },
+      { label: 'v1.11', date: '4 days ago', status: 'Backup' },
+      { label: 'v1.10', date: '5 days ago', status: 'Backup' }
+    ];
+
+    let activeCategoryIndex = 0;
+
+    const categoryList = document.getElementById('categoryList');
+    const cardList = document.getElementById('cardList');
+    const selectedCategory = document.getElementById('selectedCategory');
+    const favoriteList = document.getElementById('favoriteList');
+    const historyList = document.getElementById('historyList');
+    const versionList = document.getElementById('versionList');
+
+    function renderCategories() {
+      categoryList.innerHTML = '';
+      categories.forEach((category, index) => {
+        const item = document.createElement('div');
+        item.className = `category-item ${index === activeCategoryIndex ? 'active' : ''}`;
+        item.innerHTML = `
+          <strong>${category.name}</strong>
+          <div class="subcategory">${category.subcategories.join(' · ')}</div>
+        `;
+        item.addEventListener('click', () => {
+          activeCategoryIndex = index;
+          renderCategories();
+          renderCards();
+        });
+        categoryList.appendChild(item);
+      });
+    }
+
+    function renderCards() {
+      const category = categories[activeCategoryIndex];
+      selectedCategory.textContent = `${category.name} → ${category.subcategories[0]}`;
+      cardList.innerHTML = '';
+      category.cards.forEach(card => {
+        const cardItem = document.createElement('div');
+        cardItem.className = 'card-item';
+        cardItem.innerHTML = `
+          <div class="card-header">
+            <div>
+              <div class="card-title">${card.source}</div>
+              <div class="card-subtitle">Last used ${card.lastUsed}</div>
+            </div>
+            <button class="card-link" data-action="log" data-id="${card.id}">View log</button>
+          </div>
+          <div class="card-body">
+            <div class="translation-col">
+              <div class="translation-label">Source</div>
+              <div class="translation-row">
+                <button class="speaker-btn" data-action="speak" data-id="${card.id}">
+                  <span class="material-symbols-outlined">volume_up</span>
+                </button>
+                <div class="translation-text">${card.source}</div>
+              </div>
+            </div>
+            <div class="translation-col">
+              <div class="translation-label">Target</div>
+              <div class="translation-row">
+                <button class="speaker-btn" data-action="speak" data-id="${card.id}">
+                  <span class="material-symbols-outlined">volume_up</span>
+                </button>
+                <div class="translation-text">${card.target}</div>
+              </div>
+            </div>
+          </div>
+          <div class="back-translation ${card.showBack ? 'visible' : ''}" id="bt-${card.id}">
+            <div class="translation-row">
+              <button class="speaker-btn" data-action="speak" data-id="${card.id}">
+                <span class="material-symbols-outlined">volume_up</span>
+              </button>
+              <div class="translation-text">${card.backTranslation}</div>
+            </div>
+          </div>
+          <div class="log-details ${card.showLog ? 'visible' : ''}" id="log-${card.id}">
+            <strong>Usage log</strong>
+            <div>${card.log.map(entry => `• ${entry}`).join('<br>')}</div>
+          </div>
+          <div class="card-footer">
+            <button class="icon-btn ${card.favorite ? 'active' : ''}" data-action="favorite" data-id="${card.id}">
+              <span class="material-symbols-outlined">star</span>
+              Favorite
+            </button>
+            <div class="footer-right">
+              <span class="footer-meta">Usage ${card.usage}</span>
+              <button class="chevron-btn" data-action="back" data-id="${card.id}">
+                <span class="material-symbols-outlined">expand_more</span>
+                Back-translate
+              </button>
+            </div>
+          </div>
+        `;
+        cardItem.querySelectorAll('button').forEach(btn => {
+          btn.addEventListener('click', () => handleCardAction(card, btn));
+        });
+        cardList.appendChild(cardItem);
+      });
+      renderFavorites();
+    }
+
+    function handleCardAction(card, button) {
+      const action = button.dataset.action;
+      if (action === 'favorite') {
+        card.favorite = !card.favorite;
+        button.classList.toggle('active', card.favorite);
+        renderFavorites();
+        console.log('Favorite toggled', card.id, card.favorite);
+      }
+      if (action === 'log') {
+        card.showLog = !card.showLog;
+        renderCards();
+        return;
+      }
+      if (action === 'back') {
+        card.showBack = !card.showBack;
+        card.usage += 1;
+        renderCards();
+        console.log('Back-translation reveal', card.id);
+      }
+      if (action === 'speak') {
+        card.usage += 1;
+        renderCards();
+        console.log('TTS playback', card.id);
+      }
+    }
+
+    function renderFavorites() {
+      const category = categories[activeCategoryIndex];
+      const favorites = category.cards.filter(card => card.favorite);
+      favoriteList.innerHTML = '';
+      favorites.forEach(card => {
+        const item = document.createElement('div');
+        item.className = 'use-item';
+        item.innerHTML = `
+          <div>
+            <strong>${card.source}</strong>
+            <small>${card.target}</small>
+          </div>
+          <button class="icon-btn" data-action="speak" data-id="${card.id}">▶</button>
+        `;
+        item.querySelector('button').addEventListener('click', () => handleCardAction(card, { dataset: { action: 'speak' } }));
+        favoriteList.appendChild(item);
+      });
+    }
+
+    function renderHistory() {
+      historyList.innerHTML = '';
+      history.forEach(entry => {
+        const item = document.createElement('div');
+        item.className = 'history-item';
+        item.innerHTML = `
+          <strong>${entry.source}</strong>
+          <small>${entry.target}</small>
+          <div>${entry.time}</div>
+          <a href="${entry.link}">Open in catalog</a>
+        `;
+        historyList.appendChild(item);
+      });
+    }
+
+    function renderVersions() {
+      versionList.innerHTML = '';
+      versions.forEach(version => {
+        const item = document.createElement('div');
+        item.className = 'version-item';
+        item.innerHTML = `
+          <div>
+            <strong>${version.label}</strong>
+            <div>${version.date}</div>
+          </div>
+          <span>${version.status}</span>
+        `;
+        versionList.appendChild(item);
+      });
+    }
+
+    function setupTabs() {
+      const buttons = document.querySelectorAll('.tab-btn');
+      const panels = document.querySelectorAll('.panel');
+      buttons.forEach(button => {
+        button.addEventListener('click', () => {
+          buttons.forEach(btn => btn.classList.remove('active'));
+          button.classList.add('active');
+          panels.forEach(panel => panel.classList.remove('active'));
+          document.getElementById(button.dataset.tab).classList.add('active');
+        });
+      });
+    }
+
+    function setupSettingsModal() {
+      const modal = document.getElementById('settings-modal');
+      const gear = document.getElementById('gear-fab');
+      const close = document.getElementById('closeSettings');
+
+      function openModal() {
+        modal.classList.add('visible');
+        modal.setAttribute('aria-hidden', 'false');
+      }
+
+      function closeModal() {
+        modal.classList.remove('visible');
+        modal.setAttribute('aria-hidden', 'true');
+      }
+
+      gear.addEventListener('click', openModal);
+      close.addEventListener('click', closeModal);
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+          closeModal();
+        }
+      });
+    }
+
+    function setupCurationFlow() {
+      const steps = Array.from(document.querySelectorAll('.step'));
+      let currentStep = 1;
+
+      function updateSteps() {
+        steps.forEach(step => step.classList.toggle('active', Number(step.dataset.step) === currentStep));
+      }
+
+      document.getElementById('prevStep').addEventListener('click', () => {
+        currentStep = Math.max(1, currentStep - 1);
+        updateSteps();
+      });
+
+      document.getElementById('autoTranslate').addEventListener('click', () => {
+        currentStep = Math.min(4, currentStep + 1);
+        document.getElementById('targetText').value = '¿Dónde está el reclamo de equipaje?';
+        document.getElementById('backTranslation').value = 'Where is the baggage claim?';
+        updateSteps();
+        console.log('Auto-translate step');
+      });
+
+      document.getElementById('saveCard').addEventListener('click', () => {
+        currentStep = 1;
+        updateSteps();
+        console.log('Card saved');
+      });
+
+      updateSteps();
+    }
+
+    document.getElementById('addCardBtn').addEventListener('click', () => {
+      alert('Stub: open card creation flow.');
+    });
+
+    document.getElementById('playLatestBtn').addEventListener('click', () => {
+      const category = categories[activeCategoryIndex];
+      if (category.cards.length) {
+        category.cards[0].usage += 1;
+        renderCards();
+        console.log('Play latest', category.cards[0].id);
+      }
+    });
+
+    setupTabs();
+    setupSettingsModal();
+    setupCurationFlow();
+    renderCategories();
+    renderCards();
+    renderHistory();
+    renderVersions();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Align the Say mockup with `chat.html` control patterns by moving Settings out of the tab bar into a floating gear control and modal for parity with the chat UI.
- Simplify sorting controls and focus the UI on a clearer card design: split source/target columns, chevron-controlled back-translation in the footer, header metadata with last-used and a log view, and speaker controls for each translation.
- Improve the offline prototype's fidelity for designers and engineers to validate catalog/use/curation interactions without adding backend persistence.

### Description
- Reworked `say.html` to remove the Settings tab, add a floating gear FAB and `#settings-modal` with new modal CSS and `setupSettingsModal()` JS to open/close it.
- Redesigned catalog card markup and styles: added `.card-header`, `.card-body` (split two-column source/target), `.translation-col`, speaker buttons, `.back-translation` block, `.log-details`, and a `.chevron-btn` in the footer to reveal back-translation and increment usage.
- Replaced sort chips with a `select#sortSelect` dropdown, reduced tabs to three (Catalog, Use, Curation), and added/updated stub data fields (`lastUsed`, `log`, `showBack`, `showLog`) to support new metadata and toggles.
- Updated JS rendering and handlers: `renderCards()`, `renderFavorites()`, `renderHistory()`, `handleCardAction()` (supports `speak`, `back`, `favorite`, `log` actions), and `setupCurationFlow()`; wired UI interactions to update usage and UI state.

### Testing
- Launched a local static server with `python -m http.server 8000`, which started successfully (server PID returned).
- Attempted an automated Playwright screenshot run to capture `http://127.0.0.1:8000/say.html`, but Chromium crashed and the Playwright run failed with a `TargetClosedError` (SIGSEGV); screenshot generation did not complete.
- Committed the amended changes after edits; no additional automated tests were run against backend logic because this is a static UI prototype.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698177ad2478832d9b135a5f99650966)