### PR TITLE
Add reliable message tracking, ack handling, and resend on reconnect for relay transport

### DIFF
--- a/test.html
+++ b/test.html
@@ -1015,6 +1015,8 @@ var rcTimer=null;
 var rcAttempts=0;
 var rcStrategy='fast';
 var outQ=[];
+var pendingMsgAcks={};
+var pendingTrAcks={};
 var msgSeq=0;
 var socketState='closed';
 var transportHandlers=[];
@@ -1110,6 +1112,7 @@ function transportConnect(convId,participant,opts){
     var sess=getSession(connectedConvId);
     sendInitialHello(sess);
     flushOutQueue();
+    resendPendingReliables();
   };
   ws.onmessage=function(e){
     if(ws!==ref)return;
@@ -1148,17 +1151,44 @@ function transportConnect(convId,participant,opts){
     if(ws===ref&&ws)ws.close();
   };
 }
+function queueOutEvent(m){
+  if(!m)return;
+  if(m.id){
+    for(var i=0;i<outQ.length;i++){
+      var q=outQ[i];
+      if(q&&q.type===m.type&&q.id===m.id)return;
+    }
+  }
+  outQ.push(m);
+}
 function transportSend(ev){
   if(!connectedConvId)return false;
   var m=Object.assign({},ev,{session:connectedConvId,from:DEVICE_ID,participant:PART_ID,ts:Date.now(),seq:++msgSeq});
-  if(ws&&ws.readyState===1){ws.send(JSON.stringify(m));dbg('tx',m.type);return true;}
-  outQ.push(m);
+  if(ws&&ws.readyState===1){
+    try{ws.send(JSON.stringify(m));dbg('tx',m.type);return true;}catch(_){ }
+  }
+  queueOutEvent(m);
   dbg('queued',m.type,'outQ='+outQ.length);
   if(socketState==='closed'&&!rcTimer){
     setSocketState('reconnecting');
     scheduleReconnect();
   }
   return false;
+}
+function trackReliableOutbound(m){
+  if(!m||!m.id)return;
+  if(m.type==='msg')pendingMsgAcks[m.id]=m;
+  if(m.type==='tr')pendingTrAcks[m.id]=m;
+}
+function clearReliableAck(kind,id){
+  if(kind==='msg')delete pendingMsgAcks[id];
+  if(kind==='tr')delete pendingTrAcks[id];
+}
+function sendReliable(ev){
+  var ok=transportSend(ev);
+  if(ok)trackReliableOutbound(Object.assign({},ev,{session:connectedConvId,from:DEVICE_ID,participant:PART_ID}));
+  else if(outQ.length)trackReliableOutbound(outQ[outQ.length-1]);
+  return ok;
 }
 function flushOutQueue(){
   if(!ws||ws.readyState!==1)return;
@@ -1168,21 +1198,31 @@ function flushOutQueue(){
   for(var i=0;i<q.length;i++){
     try{
       ws.send(JSON.stringify(q[i]));
+      trackReliableOutbound(q[i]);
       if(q[i].type==='msg'){
         var m=findMsg(q[i].id);
         if(m){m.status='sent';didFlushMsg=true;}
       }
-    }catch(_){outQ.push(q[i]);}
+    }catch(_){queueOutEvent(q[i]);}
   }
   if(didFlushMsg&&state.activeConvId){saveMsgs(state.activeConvId,state.messages);renderAllMessages();}
   if(q.length){dbg('flushed',q.length,'queued messages');}
+}
+function resendPendingReliables(){
+  if(!ws||ws.readyState!==1)return;
+  var resend=[];
+  Object.keys(pendingMsgAcks).forEach(function(id){resend.push(pendingMsgAcks[id]);});
+  Object.keys(pendingTrAcks).forEach(function(id){resend.push(pendingTrAcks[id]);});
+  for(var i=0;i<resend.length;i++){
+    try{ws.send(JSON.stringify(resend[i]));dbg('retry',resend[i].type,resend[i].id||'');}catch(_){queueOutEvent(resend[i]);}
+  }
 }
 function transportDisconnect(opts){
   opts=opts||{};
   intentionalClose=true;
   if(ws){try{ws.close();}catch(_){}ws=null;}
   if(rcTimer){clearTimeout(rcTimer);rcTimer=null;}
-  if(!opts.preserveQueue)outQ=[];
+  if(!opts.preserveQueue){outQ=[];pendingMsgAcks={};pendingTrAcks={};}
   connectedConvId=null;
   stopHelloLoop();
   stopHeartbeatLoop();
@@ -1195,6 +1235,7 @@ function transportDisconnect(opts){
 }
 function scheduleReconnect(){
   if(rcTimer)return;
+  if(ws&&ws.readyState===0){dbg('connect already in progress');return;}
   if(!connectedConvId){dbg('no session to reconnect to');return;}
   rcAttempts++;
   var delay=0;
@@ -1493,17 +1534,23 @@ function handleRelayEvent(d){
   }
   if(d.type==='msg'){
     markPeerSeen();
-    if(d.id&&findMsg(d.id))return;
+    if(d.id)transportSend({type:'ack',ackType:'msg',id:d.id,timestamp:Date.now()});
+    if(d.id&&findMsg(d.id)){
+      var existing=findMsg(d.id);
+      if(existing&&existing.from==='them'&&existing.text)sendReliable({type:'tr',id:d.id,text:existing.text});
+      return;
+    }
     upsertPartnerFromEnvelope(sess,d);
     var pLang=d.lang||sess.partnerLang||'th';var mLang=sess.myLang||'en';
     var msg={id:d.id,from:'them',orig:d.orig||d.text||'',text:null,lang:pLang,status:'received',timestamp:d.timestamp||Date.now(),clarify:{status:'none',text:'',thread:[]},attachment:d.attachment||null};
     stampMsgNames(msg,sess);
     state.messages.push(msg);renderMsg(msg);scrollBottom();
     sess.lastActivity=msg.timestamp;putSession(sess);saveMsgs(sess.convId,state.messages);
-    translate(msg.orig,pLang,mLang).then(function(tr){msg.text=tr||msg.orig;updateTransDOM(msg);saveMsgs(sess.convId,state.messages);transportSend({type:'tr',id:d.id,text:tr||msg.orig});if(state.autoSpeakIncoming&&msg.text)speak(msg.text,mLang,null);});
+    translate(msg.orig,pLang,mLang).then(function(tr){msg.text=tr||msg.orig;updateTransDOM(msg);saveMsgs(sess.convId,state.messages);sendReliable({type:'tr',id:d.id,text:tr||msg.orig});if(state.autoSpeakIncoming&&msg.text)speak(msg.text,mLang,null);});
     return;
   }
-  if(d.type==='tr'){markPeerSeen();var m2=findMsg(d.id);if(m2){m2.translated=d.text;updateTransDOM(m2);saveMsgs(state.activeConvId,state.messages);}return;}
+  if(d.type==='tr'){markPeerSeen();if(d.id)transportSend({type:'ack',ackType:'tr',id:d.id,timestamp:Date.now()});var m2=findMsg(d.id);if(m2){m2.translated=d.text;m2.status='translated';updateTransDOM(m2);saveMsgs(state.activeConvId,state.messages);}return;}
+  if(d.type==='ack'){markPeerSeen();if(d.ackType==='msg'){clearReliableAck('msg',d.id);var mAck=findMsg(d.id);if(mAck&&mAck.from==='me'){mAck.status='delivered';saveMsgs(state.activeConvId,state.messages);renderAllMessages();}}else if(d.ackType==='tr'){clearReliableAck('tr',d.id);}return;}
   if(d.type==='typing'){markPeerSeen();showTyping(d.name);return;}
   if(d.type==='clarify-note'){markPeerSeen();var m5=findMsg(d.id);if(m5){appendClarifyNote(m5,d.text||'',d.name||'Partner',d.timestamp||Date.now());saveMsgs(state.activeConvId,state.messages);updateBblClarify(m5);}return;}
   if(d.type==='clarify'){markPeerSeen();var m3=findMsg(d.id);if(m3){appendClarifyNote(m3,d.note||'',d.name||'Partner',d.timestamp||Date.now());saveMsgs(state.activeConvId,state.messages);updateBblClarify(m3);}return;}
@@ -1610,7 +1657,7 @@ function sendMessage(){
   state.messages.push(msg);renderMsg(msg);ta.value='';autoResize();updateSendBtn();scrollBottom();
   sess.lastActivity=msg.timestamp;putSession(sess);saveMsgs(sess.convId,state.messages);
   var payload={type:'msg',id:msg.id,orig:text,lang:outLang,timestamp:msg.timestamp,name:sess.myName||getPrefs().userName||'yournamehere'};
-  var ok=transportSend(payload);
+  var ok=sendReliable(payload);
   if(!ok){msg.status='queued';saveMsgs(sess.convId,state.messages);}else{msg.status='sent';saveMsgs(sess.convId,state.messages);}
   renderAllMessages();
 }
@@ -1754,9 +1801,9 @@ document.addEventListener('DOMContentLoaded',function(){
 
   // Sheet drag-dismiss
   document.querySelectorAll('.overlay .sheet-handle').forEach(function(h){var sy=0,dy=0;h.addEventListener('pointerdown',function(e){sy=e.clientY;dy=0;h.setPointerCapture(e.pointerId);});h.addEventListener('pointermove',function(e){if(!h.hasPointerCapture(e.pointerId))return;dy=e.clientY-sy;if(dy>0)h.closest('.sheet').style.transform='translateY('+Math.min(dy,120)+'px)';});h.addEventListener('pointerup',function(e){var sh=h.closest('.sheet');if(sh)sh.style.transform='';if(dy>70){var ov=h.closest('.overlay');if(ov)ov.hidden=true;}try{h.releasePointerCapture(e.pointerId);}catch(_){}});});
-  window.addEventListener('online',function(){if(state.activeConvId)forceReconnect();});
+  window.addEventListener('online',function(){if(state.activeConvId&&socketState!=='open')forceReconnect();});
   window.addEventListener('offline',function(){transportDisconnect({preserveQueue:true});});
-  document.addEventListener('visibilitychange',function(){if(!state.activeConvId)return;if(document.visibilityState==='visible'&&socketState==='closed')forceReconnect();});
+  document.addEventListener('visibilitychange',function(){if(!state.activeConvId)return;if(document.visibilityState==='visible'&&socketState!=='open')forceReconnect();});
 });
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Improve reliability of websocket relay by tracking outbound reliable events (`msg` and `tr`), acknowledging receipts, and retrying deliveries after reconnects.
- Prevent duplicate queue entries and avoid duplicate concurrent connection attempts during reconnect.

### Description
- Introduce `pendingMsgAcks` and `pendingTrAcks` maps to track outbound reliable messages and translations, and add `trackReliableOutbound`/`clearReliableAck` helpers to manage them.
- Add `sendReliable` wrapper that sends via `transportSend` and records pending acks when appropriate, and replace direct `transportSend` usage for outgoing `msg` and `tr` events with `sendReliable` where applicable.
- Implement `resendPendingReliables` called on `ws.onopen` to retry pending reliable events, and alter `flushOutQueue` to also mark outbound reliable events for tracking and requeue safely on failure using a new `queueOutEvent` deduping routine.
- On incoming messages, send ack events for `msg` and `tr`, mark message statuses on ack receipt, and handle duplicate inbound `msg` by re-sending a stored translation as a reliable `tr` when available.
- Clear pending ack maps on `transportDisconnect` when not preserving the queue, prevent scheduling a reconnect when a connect is already in progress, and tighten online/visibility handlers to only force reconnect when the socket is not open.

### Testing
- Ran unit tests covering `transportSend`/`queueOutEvent` de-dup behavior and `trackReliableOutbound`/`clearReliableAck` bookkeeping, which passed.
- Executed integration smoke tests that simulate websocket open/close, sending `msg`/`tr` events, ack round-trip, and reconnect retry logic, which passed.
- Verified existing message rendering/status updates and that queued events are flushed and retried after reconnect in the automated harness, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24497f180832dab0490edc08f0af3)