### PR TITLE
Add vsay.html — Talk+Say v3.4 single-file app with media share, phrasebook, and relay transport

### DIFF
--- a/vsay.html
+++ b/vsay.html
@@ -1,0 +1,4521 @@
+<!DOCTYPE html>
+<!-- Test Build · vSay baseline from Talk + Say v3.4 · 2026-04-02T00:00:00Z -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>vSay · session media share</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Lora:wght@400;600&display=swap" rel="stylesheet">
+<style>
+*{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent;}
+:root{
+  --teal:#2E8B8B;--teal-mid:#3A9E9E;--teal-light:#E6F4F4;
+  --ink:#1A1714;--ink-mid:#5A5552;--ink-dim:#9A9592;
+  --border:#E2DDD8;--paper:#F5F1EC;--cream:#FDFAF7;
+  --green:#2E7D4F;--green-light:#E8F5EE;
+  --amber:#C07830;--amber-light:#FBF0E4;
+  --red:#C0392B;--red-light:#FDEDEC;
+  --tag-bg:#EEE8FF;--tag-text:#6B4FBB;
+  --shadow:0 1px 4px rgba(0,0,0,0.08),0 4px 16px rgba(0,0,0,0.06);
+}
+html,body{height:100%;overflow:hidden;background:var(--cream);font-family:"DM Sans",sans-serif;color:var(--ink);}
+#app{position:fixed;inset:0;max-width:480px;margin:0 auto;background:var(--cream);display:flex;flex-direction:column;overflow:hidden;box-shadow:var(--shadow);}
+
+/* SCREENS */
+.screen{position:absolute;inset:0;display:flex;flex-direction:column;overflow:hidden;background:var(--cream);opacity:0;pointer-events:none;transition:opacity .18s;}
+.screen.active{opacity:1;pointer-events:auto;}
+
+/* FIELDS */
+.field-label{display:block;font-size:11px;font-weight:700;color:var(--ink-dim);text-transform:uppercase;letter-spacing:0.4px;margin:14px 0 5px;}
+.field-input{width:100%;border:1.5px solid var(--border);border-radius:10px;padding:10px 13px;font-size:15px;font-family:"DM Sans",sans-serif;color:var(--ink);background:#fff;outline:none;}
+.field-input:focus{border-color:var(--teal);}
+textarea.field-input{resize:none;}
+.field-select{width:100%;border:1.5px solid var(--border);border-radius:10px;padding:10px 13px;font-size:14px;font-family:"DM Sans",sans-serif;color:var(--ink);background:#fff;outline:none;-webkit-appearance:none;appearance:none;cursor:pointer;}
+
+/* ════ CHAT SHELL ════ */
+.icon-btn-sm{background:none;border:none;cursor:pointer;padding:5px;border-radius:8px;color:var(--ink-dim);line-height:0;transition:background .12s;}
+.icon-btn-sm:hover{background:var(--paper);color:var(--ink-mid);}
+
+/* LEFT PANEL */
+.left-panel{position:absolute;inset:0 auto 0 0;width:min(86vw,320px);background:var(--cream);border-right:1px solid var(--border);box-shadow:var(--shadow);transform:translateX(-105%);transition:transform .22s cubic-bezier(.4,0,.2,1);z-index:30;display:flex;flex-direction:column;}
+.left-panel.open{transform:translateX(0);}
+.left-scrim{position:absolute;inset:0;background:rgba(0,0,0,.2);z-index:29;display:none;}
+.left-scrim.show{display:block;}
+.left-top{padding:14px 16px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:0;}
+.left-gear{background:none;border:none;cursor:pointer;color:var(--ink-dim);padding:6px;border-radius:8px;line-height:0;}
+.left-body{flex:1;overflow-y:auto;padding:8px 12px 80px;position:relative;}
+.sess-card{display:flex;align-items:center;gap:10px;background:#fff;border:1px solid var(--border);border-radius:14px;padding:12px;margin-bottom:8px;cursor:pointer;user-select:none;}
+.sess-card:hover{border-color:var(--teal-mid);}
+.sess-card.active{border-color:var(--teal);box-shadow:0 0 0 2px var(--teal-light);}
+.sess-card.dragging{opacity:.6;}
+.sess-card-info{flex:1;min-width:0;}
+.sess-card-title{font-size:14px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;outline:none;border-radius:4px;padding:0 2px;}
+.sess-card-title:focus{background:var(--teal-light);color:var(--teal);white-space:normal;overflow:visible;}
+.sess-card-sub{font-size:11px;color:var(--ink-dim);margin-top:2px;}
+.sess-card-badge{font-size:10px;font-weight:700;background:var(--teal);color:#fff;padding:2px 7px;border-radius:10px;flex-shrink:0;}
+.sess-card-act{background:none;border:none;cursor:pointer;padding:5px;color:var(--ink-dim);border-radius:7px;line-height:0;font-size:13px;}
+.sess-card-act:hover{background:var(--paper);}
+.sess-card-act.del:hover{color:var(--red);background:var(--red-light);}
+.fab-plus{position:absolute;bottom:20px;right:16px;width:52px;height:52px;border-radius:50%;background:var(--teal);color:#fff;border:none;cursor:pointer;box-shadow:0 4px 16px rgba(46,139,139,.35);font-size:26px;font-weight:300;display:flex;align-items:center;justify-content:center;z-index:5;}
+.fab-plus:active{transform:scale(.92);}
+.recycle-header{display:flex;align-items:center;gap:6px;padding:8px 0;cursor:pointer;font-size:12px;font-weight:700;color:var(--ink-dim);text-transform:uppercase;letter-spacing:.4px;}
+.recycle-list{padding-left:4px;}
+.recycle-item{display:flex;align-items:center;gap:8px;padding:8px 10px;background:var(--paper);border-radius:10px;margin-bottom:5px;font-size:13px;color:var(--ink-mid);}
+.recycle-item button{background:none;border:none;cursor:pointer;font-size:12px;font-weight:600;padding:3px 8px;border-radius:6px;}
+.recycle-item .restore{color:var(--teal);}
+.recycle-item .purge{color:var(--red);}
+
+/* SHELL RIBBON */
+.shell-ribbon{display:flex;align-items:center;gap:4px;padding:8px 10px 4px;background:var(--cream);flex-shrink:0;}
+.ribbon-btn{background:none;border:none;cursor:pointer;color:var(--ink-dim);padding:7px 8px;border-radius:9px;line-height:0;transition:background .12s,color .12s;}
+.ribbon-btn:hover{background:var(--paper);color:var(--teal);}
+.ribbon-spacer{flex:1;}
+/* Toggle switch (used in settings drawer) */
+.toggle-switch{position:relative;display:inline-block;width:40px;height:22px;flex-shrink:0;}
+.toggle-switch input{opacity:0;width:0;height:0;}
+.toggle-slider{position:absolute;cursor:pointer;inset:0;background:var(--border);border-radius:22px;transition:.2s;}
+.toggle-slider:before{position:absolute;content:'';height:16px;width:16px;left:3px;bottom:3px;background:#fff;border-radius:50%;transition:.2s;}
+.toggle-switch input:checked+.toggle-slider{background:var(--teal);}
+.toggle-switch input:checked+.toggle-slider:before{transform:translateX(18px);}
+/* Settings drawer in left panel */
+.left-settings-drawer{overflow:hidden;max-height:0;transition:max-height .28s cubic-bezier(.4,0,.2,1);}
+.left-settings-drawer.open{max-height:72vh;overflow-y:auto;border-bottom:1px solid var(--border);}
+.left-gear.active{color:var(--teal);background:var(--teal-light);}
+.left-panel.settings-open .left-body{display:none;}
+.lsd-section{border-bottom:1px solid var(--border);}
+.lsd-section:last-child{border-bottom:none;}
+.lsd-section-title{font-size:10px;font-weight:700;color:var(--ink-dim);text-transform:uppercase;letter-spacing:.5px;padding:7px 14px 3px;}
+.lsd-row{display:flex;align-items:center;gap:10px;padding:9px 14px;}
+.lsd-row-link{cursor:pointer;}
+.lsd-row-link:hover{background:var(--paper);}
+.lsd-icon{color:var(--ink-dim);line-height:0;flex-shrink:0;width:16px;display:flex;align-items:center;justify-content:center;}
+.lsd-label{flex:1;font-size:13px;font-weight:500;color:var(--ink);}
+.lsd-ctrl{display:flex;align-items:center;gap:4px;flex-shrink:0;color:var(--ink-dim);}
+.lsd-table{width:100%;border-collapse:collapse;}
+.lsd-table thead td{font-size:10px;font-weight:700;color:var(--ink-dim);text-transform:uppercase;text-align:center;padding:2px 4px 6px;letter-spacing:.04em;}
+.lsd-table thead td:first-child{text-align:left;padding-left:14px;}
+.lsd-table tbody td{text-align:center;padding:3px 4px;}
+.lsd-table tbody td:first-child{text-align:left;font-size:12px;color:var(--ink-mid);padding-left:14px;vertical-align:middle;}
+.lsd-select{font-size:12px;border-radius:5px;border:1px solid var(--border);padding:2px 3px;background:var(--cream);color:var(--ink);width:44px;}
+.lsd-range{width:100%;accent-color:var(--teal);}
+.lsd-btn{border:none;border-radius:8px;padding:7px 10px;font-size:12px;font-weight:600;cursor:pointer;font-family:'DM Sans',sans-serif;transition:opacity .12s;}
+.lsd-btn.secondary{background:var(--paper);color:var(--ink-mid);border:1px solid var(--border);}
+.lsd-btn.danger{background:#fee2e2;color:#dc2626;border:1px solid #fca5a5;}
+.lsd-btn:hover{opacity:.8;}
+.data-mgmt-grid{width:100%;border-collapse:collapse;}
+.data-mgmt-grid th,.data-mgmt-grid td{padding:4px 6px;font-size:12px;text-align:center;}
+.data-mgmt-grid th{font-weight:700;color:var(--ink-dim);text-transform:uppercase;letter-spacing:.04em;padding-bottom:6px;}
+.data-mgmt-grid td:first-child{text-align:left;font-size:12px;color:var(--ink-mid);font-weight:500;padding-left:14px;}
+.preset-head-cell{background:var(--paper);color:var(--ink);border-radius:7px;}
+.shell-partner{display:flex;align-items:center;justify-content:center;gap:6px;text-align:center;padding:2px 16px 8px;font-family:"Lora",serif;font-size:16px;font-weight:600;border-bottom:1px solid var(--border);flex-shrink:0;min-height:39px;color:var(--ink);}
+.shell-participant{display:inline-flex;align-items:center;gap:6px;min-width:0;}
+.shell-participant::before{content:'';width:7px;height:7px;border-radius:50%;background:var(--ink-dim);flex-shrink:0;transition:background .2s ease;}
+.shell-participant.online::before{background:#22C55E;}
+.shell-participant.editable{border-radius:8px;padding:1px 6px;outline:none;border:1px solid transparent;}
+.shell-participant.editable:hover{background:var(--paper);border-color:var(--border);}
+.shell-participant.editable:focus{background:var(--teal-light);border-color:var(--teal);color:var(--teal);}
+.shell-participant-label{display:inline-block;min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.shell-partner-arrow{color:var(--ink-dim);font-weight:500;flex-shrink:0;}
+.shell-empty{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--ink-dim);font-size:14px;padding:40px;}
+.shell-empty-logo{font-family:"Lora",serif;font-size:48px;font-weight:600;color:var(--teal);opacity:.25;}
+
+/* MESSAGES */
+#messages{flex:1;overflow-y:auto;padding:10px 12px 6px;display:flex;flex-direction:column;gap:6px;-webkit-overflow-scrolling:touch;}
+.sys-msg{text-align:center;padding:7px 0;font-size:11px;color:var(--ink-dim);font-style:italic;}
+.day-lbl{text-align:center;padding:8px 0 2px;font-size:10px;color:var(--ink-dim);font-weight:700;text-transform:uppercase;letter-spacing:.5px;}
+.typing-bar{padding:2px 16px;font-size:12px;color:var(--ink-dim);min-height:20px;flex-shrink:0;}
+
+/* ════════════════════════════════════════════
+   UNIFIED BUBBLE — shared by chat + phrasebook
+   ════════════════════════════════════════════ */
+.msg-row{max-width:96%;width:var(--msg-width,75%);animation:fadeUp .17s ease-out;}
+.msg-row.mine{align-self:flex-end;}
+.msg-row.theirs{align-self:flex-start;}
+@keyframes fadeUp{from{transform:translateY(8px);opacity:0;}}
+
+.bubble-card{border-radius:14px;overflow:hidden;border:1px solid var(--border);width:100%;}
+/* mine/theirs .bubble-card colors generated by applyBubbleTheme() */
+
+/* Bubble header row */
+.bbl-hdr{display:flex;align-items:center;justify-content:space-between;padding:5px 10px;border-bottom:1px solid rgba(0,0,0,.06);gap:6px;overflow:hidden;}
+
+.bbl-sender{font-size:12px;font-weight:700;color:var(--ink-mid);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1;}
+
+.bbl-hdr-right{display:flex;align-items:center;gap:5px;flex-shrink:0;}
+.bbl-time{font-size:10px;opacity:.5;font-variant-numeric:tabular-nums;}
+
+.bbl-prov{font-size:9px;font-weight:700;color:var(--ink-dim);opacity:.5;background:rgba(0,0,0,.05);border-radius:4px;padding:1px 4px;}
+.msg-row.mine .bbl-prov{color:#fff;background:rgba(255,255,255,.15);}
+.queued-badge{font-size:9px;font-weight:700;color:var(--amber);opacity:.8;margin-left:3px;}
+.msg-status{font-size:13px;margin-left:3px;line-height:1;letter-spacing:.5px;}
+.msg-status.sent{color:var(--ink-dim);}
+.msg-status.delivered{color:var(--teal);}
+.msg-status.read{color:var(--green);}
+.msg-status.failed{color:var(--red);font-weight:700;}
+.msg-status-time{font-size:10px;opacity:.65;font-variant-numeric:tabular-nums;}
+.msg-status-dots{display:inline-flex;align-items:center;gap:3px;}
+.msg-status-dot{border:none;background:none;padding:0;cursor:pointer;font-size:12px;line-height:1;}
+.msg-status-dot.off{opacity:.35;color:var(--ink-dim);}
+.msg-status-dot.on-delivered{color:var(--teal);}
+.msg-status-dot.on-read{color:var(--green);}
+.status-popup{position:fixed;z-index:240;background:#fff;border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);padding:10px 12px;min-width:210px;}
+.status-popup[hidden]{display:none!important;}
+.status-popup-head{display:flex;justify-content:space-between;align-items:center;font-size:12px;font-weight:700;color:var(--ink);}
+.status-popup-close{border:none;background:none;color:var(--ink-dim);font-size:14px;cursor:pointer;line-height:1;}
+.status-popup-row{font-size:12px;color:var(--ink-mid);margin-top:6px;}
+
+/* Bubble body — two equal columns */
+.bbl-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.bbl-side{padding:10px 13px;display:flex;flex-direction:column;min-width:0;}
+.bbl-divider{background:rgba(0,0,0,.1);}
+
+.bbl-txt{font-size:15px;line-height:1.5;word-break:break-word;flex:1;}
+
+.bbl-txt.loading{min-height:18px;border-radius:4px;background:linear-gradient(90deg,transparent 30%,rgba(0,0,0,.06) 50%,transparent 70%);background-size:200% 100%;animation:shimmer 1.5s infinite;}
+@keyframes shimmer{to{background-position:-200% 0;}}
+
+/* Per-side Use + TTS row (body row 2) */
+.bbl-side-acts{display:flex;align-items:center;gap:6px;margin-top:6px;}
+.bbl-use{background:var(--teal-light);color:var(--teal);border:none;border-radius:7px;padding:3px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;}
+.bbl-use:hover{background:var(--teal);color:#fff;}
+
+
+.bbl-tts{background:none;border:none;cursor:pointer;opacity:.4;padding:3px;display:flex;align-items:center;color:inherit;line-height:0;transition:opacity .12s;}
+.bbl-tts:hover,.bbl-tts.playing{opacity:1;}
+
+
+/* Bubble footer */
+.bbl-foot{border-top:1px solid rgba(0,0,0,.06);}
+
+.bbl-foot-bar{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));padding:5px 8px;gap:4px;}
+.bbl-act{background:none;border:none;cursor:pointer;font-size:11px;font-weight:600;font-family:"DM Sans",sans-serif;width:100%;height:26px;line-height:26px;padding:0;border-radius:7px;color:var(--ink-dim);transition:background .12s;display:flex;align-items:center;justify-content:center;text-align:center;}
+.bbl-act:hover{background:rgba(0,0,0,.06);}
+
+
+.bbl-act.active-chip{background:rgba(0,0,0,.12);box-shadow:inset 0 0 0 1.5px rgba(0,0,0,.15);}
+
+
+/* Tag drawer */
+.tag-drawer{display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px 10px;}
+.tag-drawer.open{display:block;}
+
+.tag-drawer-input{width:100%;border:1.5px solid var(--border);border-radius:8px;padding:6px 8px;font-size:12px;font-family:"DM Sans",sans-serif;outline:none;margin-top:4px;background:#fff;color:var(--ink);}
+.tag-drawer-input:focus{border-color:var(--teal);}
+
+
+.tag-search-results{display:flex;flex-wrap:wrap;gap:5px;margin-top:6px;}
+.tag-res-chip{border:1px solid var(--border);background:#fff;border-radius:999px;padding:2px 8px;font-size:11px;cursor:pointer;color:var(--ink-mid);}
+.tag-res-chip:hover{border-color:var(--teal);color:var(--teal);}
+
+.pb-tags-row{display:flex;gap:4px;flex-wrap:wrap;}
+.pb-tag-pill{background:var(--tag-bg);color:var(--tag-text);border-radius:6px;padding:2px 7px;font-size:10px;font-weight:600;display:inline-flex;align-items:center;gap:4px;}
+.pb-tag-pill button{background:none;border:none;color:inherit;cursor:pointer;font-size:11px;line-height:1;}
+
+
+/* Clarify block */
+.clarify-block{display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px 10px;}
+.clarify-block.open{display:block;}
+
+.clarify-thread{display:grid;gap:6px;margin-bottom:8px;}
+.clarify-item{font-size:12px;line-height:1.4;}
+.clarify-item-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:2px;}
+.clarify-author{font-weight:700;font-size:11px;color:var(--ink-mid);}
+
+.clarify-ts{font-size:10px;opacity:.6;color:var(--ink-dim);}
+
+.clarify-body{font-size:12px;line-height:1.45;word-break:break-word;color:var(--ink);}
+
+.clarify-remove{background:none;border:none;cursor:pointer;color:var(--ink-dim);font-size:11px;font-weight:700;padding:0 2px;border-radius:4px;line-height:1;}
+.clarify-remove:hover{background:rgba(0,0,0,.08);color:var(--red);}
+
+
+.clarify-empty{font-size:12px;opacity:.7;font-style:italic;color:var(--ink-dim);}
+
+.clarify-compose{display:flex;gap:6px;margin-top:6px;}
+.clarify-input{flex:1;border:1px solid var(--border);border-radius:8px;padding:6px 8px;font-size:12px;font-family:"DM Sans",sans-serif;outline:none;background:#fff;color:var(--ink);}
+.clarify-input:focus{border-color:var(--teal);}
+
+
+.clarify-send{background:var(--teal-light);color:var(--teal);border:none;border-radius:7px;padding:5px 10px;font-size:11px;font-weight:700;cursor:pointer;}
+
+
+/* Back-translate panel */
+.bbl-backtrans{display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px;}
+.bbl-backtrans.open{display:block;}
+
+.bbl-back-row{display:flex;align-items:center;gap:8px;margin-bottom:6px;}
+.bbl-back-row:last-child{margin-bottom:0;}
+.bbl-back-text{line-height:1.45;flex:1;color:var(--ink-dim);font-style:italic;word-break:break-word;font-size:13px;}
+
+
+.bbl-stale-prompt{font-size:11px;color:var(--amber);font-weight:600;cursor:pointer;text-decoration:underline;}
+.bbl-vbtn{border:none;border-radius:8px;padding:5px 11px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.bbl-vbtn.good{background:var(--green-light);color:var(--green);}
+.bbl-vbtn.bad{background:var(--red-light);color:var(--red);}
+.bbl-verdict-pill{font-size:10px;font-weight:700;padding:2px 8px;border-radius:6px;flex-shrink:0;}
+.bbl-verdict-pill.good{background:var(--green-light);color:var(--green);}
+.bbl-verdict-pill.bad{background:var(--red-light);color:var(--red);}
+.bbl-verdict-pill.partial{background:var(--amber-light);color:var(--amber);}
+
+
+.retranslate-btn{background:var(--teal-light);border:none;border-radius:7px;padding:5px 11px;font-size:11px;font-weight:600;color:var(--teal);cursor:pointer;font-family:"DM Sans",sans-serif;}
+
+/* ════ COMPOSER — exact contract ════
+   Order: [mic] [textarea+flag-selector] [send]
+   No phrasebook icon in composer row. */
+.composer{display:flex;align-items:flex-end;gap:6px;padding:7px 10px max(7px,env(safe-area-inset-bottom));background:var(--cream);border-top:1px solid var(--border);flex-shrink:0;-webkit-overflow-scrolling:touch;}
+.composer-icon{background:none;border:none;cursor:pointer;color:var(--ink-dim);padding:8px 5px;flex-shrink:0;line-height:0;border-radius:8px;transition:color .12s;}
+.composer-icon:hover{color:var(--teal);}
+.composer-icon.active{color:var(--red);}
+.composer-wrap{flex:1;position:relative;}
+.composer-ta{width:100%;border:1.5px solid var(--border);border-radius:20px;padding:9px 14px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;resize:none;outline:none;min-height:40px;max-height:110px;line-height:1.4;-webkit-appearance:none;appearance:none;overflow:hidden;display:block;}
+.composer-ta:focus{border-color:var(--teal);}
+.send-btn{width:40px;height:40px;border-radius:50%;border:none;background:var(--teal);color:#fff;cursor:pointer;flex-shrink:0;display:flex;align-items:center;justify-content:center;transition:opacity .12s;}
+.send-btn:disabled{opacity:.3;}
+
+/* vSay floating media window */
+.vsay-float{position:absolute;left:12px;top:88px;width:220px;height:150px;background:#111;border-radius:14px;border:1px solid rgba(255,255,255,.2);box-shadow:var(--shadow);overflow:hidden;z-index:25;display:none;resize:both;min-width:180px;min-height:120px;max-width:92%;max-height:58%;}
+.vsay-float.show{display:block;}
+.vsay-float-header{display:flex;align-items:center;gap:6px;padding:6px 8px;background:rgba(0,0,0,.6);color:#fff;font-size:11px;font-weight:700;cursor:move;user-select:none;}
+.vsay-float-header-left{display:flex;align-items:center;gap:6px;}
+.vsay-onair{display:inline-flex;align-items:center;gap:4px;border:1px solid rgba(255,255,255,.25);border-radius:999px;padding:1px 7px;background:#2d1212;cursor:pointer;font-size:10px;}
+.vsay-onair-dot{width:7px;height:7px;border-radius:50%;background:#ef4444;box-shadow:0 0 0 1px rgba(0,0,0,.3);}
+.vsay-onair.live{background:#12321f;}
+.vsay-onair.live .vsay-onair-dot{background:#22c55e;}
+.vsay-hdr-btn{border:1px solid rgba(255,255,255,.18);background:#202020;color:#fff;border-radius:7px;padding:3px 6px;font-size:11px;cursor:pointer;font-family:"DM Sans",sans-serif;line-height:1;}
+.vsay-hdr-btn.active{background:#14532d;border-color:#166534;}
+.vsay-snap-group{display:flex;gap:4px;margin-left:auto;}
+.vsay-snap-btn{border:1px solid rgba(255,255,255,.2);background:#1f1f1f;color:#fff;border-radius:6px;padding:2px 4px;font-size:10px;cursor:pointer;}
+.vsay-float-body{position:relative;background:#000;height:calc(100% - 64px);display:flex;align-items:center;justify-content:center;}
+.vsay-float.collapsed{height:auto!important;resize:none;}
+.vsay-float.collapsed .vsay-float-body,.vsay-float.collapsed .vsay-float-actions{display:none;}
+#vsay-local-video,#vsay-remote-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;}
+.vsay-audio-chip{font-size:11px;color:#fff;opacity:.9;background:rgba(0,0,0,.45);padding:4px 8px;border-radius:999px;z-index:2;}
+.vsay-cc-line{position:absolute;left:8px;right:8px;bottom:8px;background:rgba(0,0,0,.58);color:#fff;font-size:11px;padding:5px 7px;border-radius:8px;z-index:3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.vsay-float-actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;padding:7px;background:#171717;border-top:1px solid rgba(255,255,255,.08);}
+.vsay-float-btn{border:1px solid rgba(255,255,255,.18);background:#202020;color:#fff;border-radius:8px;padding:6px 8px;font-size:11px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;display:flex;align-items:center;justify-content:center;gap:6px;}
+.vsay-float-btn.active{background:#14532d;border-color:#166534;}
+.vsay-float-btn svg{width:13px;height:13px;}
+
+/* ════ CATALOG SCREEN (phrasebook) ════ */
+.scr-header{display:flex;align-items:center;gap:10px;padding:12px 16px;border-bottom:1px solid var(--border);flex-shrink:0;background:var(--cream);}
+.scr-back{background:none;border:none;font-size:20px;cursor:pointer;color:var(--ink-mid);padding:4px 6px;border-radius:8px;line-height:1;}
+.scr-back:hover{background:var(--paper);}
+.scr-title{flex:1;font-family:"Lora",serif;font-size:17px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:8px;}
+.scr-title-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.pb-toolbar-actions{display:flex;align-items:center;gap:6px;}
+.export-list{display:grid;gap:8px;max-height:40dvh;overflow:auto;margin-top:10px;}
+.export-item{display:flex;align-items:flex-start;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:#fff;}
+.export-item-meta{font-size:11px;color:var(--ink-dim);margin-top:3px;}
+.export-actions{display:flex;gap:8px;align-items:center;justify-content:space-between;margin-top:12px;}
+.export-link-btn{background:none;border:none;color:var(--teal);font-size:12px;font-weight:700;cursor:pointer;padding:0;}
+.export-link-btn:hover{text-decoration:underline;}
+.export-mode-btn{display:flex;align-items:center;justify-content:center;gap:8px;width:100%;margin-top:10px;border:1.5px solid var(--border);border-radius:12px;background:#fff;color:var(--ink-mid);padding:10px 12px;font-size:13px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;transition:border-color .12s,background .12s,color .12s;}
+.export-mode-btn:hover{border-color:var(--teal);color:var(--teal);}
+.export-mode-btn.active{border-color:var(--teal);background:var(--teal-light);color:var(--teal);}
+.export-mode-meta{font-size:11px;color:var(--ink-dim);margin-top:6px;line-height:1.4;}
+.scr-action{background:var(--teal);color:#fff;border:none;border-radius:8px;padding:7px 14px;font-size:13px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.cat-toolbar{padding:8px 16px 6px;border-bottom:1px solid var(--border);flex-shrink:0;display:flex;gap:8px;align-items:center;}
+.cat-omni{width:100%;border:1.5px solid var(--border);border-radius:10px;padding:8px 12px;font-size:14px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;}
+.cat-omni:focus{border-color:var(--teal);}
+.search-wrap{position:relative;flex:1;}
+.search-clear{position:absolute;right:8px;top:50%;transform:translateY(-50%);border:none;background:none;color:var(--ink-dim);font-size:14px;cursor:pointer;padding:2px 4px;border-radius:6px;display:none;}
+.search-clear.show{display:block;}
+.search-clear:hover{background:var(--paper);color:var(--ink-mid);}
+
+/* Filter chip */
+.filter-chip-row{padding:4px 16px 6px;flex-shrink:0;display:flex;align-items:center;gap:6px;min-height:28px;}
+.filter-chip{display:inline-flex;align-items:center;gap:5px;background:var(--teal);color:#fff;border:none;border-radius:999px;padding:3px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.filter-chip-x{background:none;border:none;color:#fff;font-size:13px;cursor:pointer;line-height:1;padding:0 0 0 2px;opacity:.8;}
+.filter-chip-x:hover{opacity:1;}
+
+.pb-icon{background:none;border:none;cursor:pointer;padding:5px;border-radius:7px;color:var(--ink-dim);line-height:0;transition:background .12s;}
+.pb-icon:hover{background:var(--paper);color:var(--ink-mid);}
+.pb-icon.del:hover{color:var(--red);background:var(--red-light);}
+
+/* Phrasebook card list */
+.card-list{flex:1;overflow-y:auto;padding:8px 16px 80px;}
+
+/* ════ PHRASEBOOK BUBBLE CARD ════
+   Width and color inherit from applyBubbleTheme() via .msg-row.theirs rules.
+   No width or color overrides here — theme settings control both. */
+.pb-row-wrap{display:flex;justify-content:flex-start;margin-bottom:8px;}
+
+.settings-icon-btn{background:none;border:none;color:var(--ink-mid);cursor:pointer;padding:4px;border-radius:6px;line-height:0;}
+.settings-icon-btn:hover{background:var(--paper);}
+.settings-icon-btn.danger:hover{color:var(--red);background:var(--red-light);}
+.settings-icon-btn .data-action-icon{display:block;width:16px;height:16px;fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;vector-effect:non-scaling-stroke;}
+
+/* ════ SEARCH OVERLAY ════ */
+.search-overlay{position:fixed;inset:0;background:var(--cream);z-index:35;display:none;flex-direction:column;}
+.search-overlay.open{display:flex;}
+.search-head{padding:12px 16px;border-bottom:1px solid var(--border);display:flex;gap:8px;align-items:center;}
+.search-input{flex:1;border:1.5px solid var(--border);border-radius:12px;padding:10px 14px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;}
+.search-input:focus{border-color:var(--teal);}
+.search-close{background:none;border:none;font-size:18px;cursor:pointer;color:var(--ink-mid);padding:6px;}
+.search-results{flex:1;overflow-y:auto;padding:8px 16px;}
+.search-result{padding:10px;border-bottom:1px solid var(--border);font-size:13px;cursor:pointer;}
+.search-result:hover{background:var(--paper);}
+.search-result-type{font-size:10px;font-weight:700;color:var(--teal);text-transform:uppercase;letter-spacing:.4px;margin-bottom:3px;}
+
+/* ════ OVERLAYS ════ */
+.overlay{position:fixed;inset:0;background:rgba(26,23,20,.46);display:flex;align-items:flex-end;justify-content:center;z-index:200;animation:fadeIn .15s;}
+.overlay[hidden]{display:none!important;}
+/* Onboarding gate modal (non-blocking replacement for prompt onboarding) */
+.onboarding-modal{position:fixed;inset:0;background:rgba(26,23,20,.52);display:flex;align-items:center;justify-content:center;z-index:260;padding:20px;}
+.onboarding-modal[hidden]{display:none!important;}
+.onboarding-card{width:min(100%,360px);background:var(--cream);border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow);padding:18px 16px;display:flex;flex-direction:column;gap:10px;}
+.onboarding-title-wrap{position:relative;border-radius:12px;overflow:hidden;min-height:108px;display:flex;align-items:center;}
+.onboarding-title-wrap::before{content:'';position:absolute;inset:0;background-image:linear-gradient(rgba(253,250,247,.58),rgba(253,250,247,.58)),url('https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Flags_of_the_World_%28gallery%29.png/640px-Flags_of_the_World_%28gallery%29.png');background-size:cover;background-position:center;opacity:.58;}
+.onboarding-title{position:relative;font-size:16px;font-weight:700;line-height:1.35;color:var(--ink);padding:14px;}
+.onboarding-error{font-size:12px;color:var(--red);min-height:16px;}
+@keyframes fadeIn{from{opacity:0;}}
+.sheet{background:var(--cream);border-radius:22px 22px 0 0;width:100%;max-width:480px;max-height:92dvh;overflow-y:auto;animation:slideUp .22s ease-out;}
+@keyframes slideUp{from{transform:translateY(36px);opacity:.7;}}
+.sheet-handle{width:34px;height:4px;background:var(--border);border-radius:2px;margin:10px auto 0;}
+.sheet-body{padding:18px 22px 28px;}
+.sheet-title{font-family:"Lora",serif;font-size:19px;font-weight:600;margin-bottom:14px;}
+.sheet-btn-row{display:flex;gap:8px;margin-top:14px;}
+.sheet-btn{flex:1;border:none;border-radius:11px;padding:12px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.sheet-btn.primary{background:var(--teal);color:#fff;}
+.sheet-btn.secondary{background:var(--paper);color:var(--ink-mid);border:1.5px solid var(--border);}
+.sheet-btn.danger{background:var(--red);color:#fff;}
+.sheet-btn:disabled{opacity:.4;cursor:not-allowed;}
+
+/* TAG PICKER */
+.tag-grid{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;}
+.tp-tag-chip{padding:5px 11px;border:1.5px solid var(--border);border-radius:18px;font-size:12px;font-weight:600;background:#fff;color:var(--ink-mid);cursor:pointer;font-family:"DM Sans",sans-serif;transition:all .12s;display:inline-flex;align-items:center;gap:6px;}
+.tp-tag-chip.selected{background:var(--teal);color:#fff;border-color:var(--teal);}
+.tp-tag-remove{background:none;border:none;color:inherit;cursor:pointer;font-size:12px;line-height:1;opacity:.7;}
+.tp-tag-remove:hover{opacity:1;}
+
+/* NEW CARD */
+.nc-field-row{display:flex;gap:8px;align-items:flex-start;}
+
+/* EMOJI GRID */
+.emoji-grid{display:flex;flex-wrap:wrap;gap:6px;margin:6px 0 10px;}
+.emoji-opt{font-size:22px;cursor:pointer;padding:5px;border-radius:8px;border:2px solid transparent;transition:border-color .12s;}
+.emoji-opt.selected{border-color:var(--teal);}
+
+/* INLINE SAVE CONFIRM */
+.save-confirm{font-size:11px;font-weight:700;color:var(--green);padding:4px 0 0;display:none;}
+.save-confirm.show{display:block;}
+.save-confirm a{color:var(--teal);cursor:pointer;text-decoration:underline;margin-left:4px;}
+
+/* TOAST */
+/* Input field consistency */
+[contenteditable][data-placeholder]:empty:before{content:attr(data-placeholder);color:var(--ink-dim);opacity:.5;pointer-events:none;}
+.field-input,.field-select,.composer-ta,.clarify-input,.tag-drawer-input,.cat-omni,.search-input,.nc-field-row input{background:#fff!important;color:var(--ink)!important;}
+.field-input::placeholder,.composer-ta::placeholder,.clarify-input::placeholder,.tag-drawer-input::placeholder,.cat-omni::placeholder,.search-input::placeholder{color:var(--ink-dim);opacity:.7;}
+input::placeholder,textarea::placeholder{color:var(--ink-dim);opacity:.7;}
+
+#toast{position:fixed;bottom:100px;left:50%;transform:translateX(-50%) translateY(20px);background:rgba(26,23,20,.88);color:#fff;font-size:13px;font-weight:600;padding:9px 18px;border-radius:22px;z-index:1000;opacity:0;transition:opacity .2s,transform .2s;pointer-events:none;white-space:nowrap;}
+#toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
+
+</style>
+</head>
+<body>
+<div id="app">
+
+<!-- ══ MAIN CHAT SHELL ══ -->
+<div id="chat-screen" class="screen active" style="display:flex;flex-direction:column;opacity:1;pointer-events:auto;">
+  <div class="left-scrim" id="left-scrim" onclick="closeLeftPanel()"></div>
+  <aside class="left-panel" id="left-panel">
+    <div class="left-top">
+      <button class="left-gear" id="left-gear-btn" onclick="toggleSettingsDrawer()" title="Settings">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
+
+    <!-- Settings drawer — slides down below gear row -->
+    <div class="left-settings-drawer" id="left-settings-drawer">
+      <!-- Appearance -->
+      <div class="lsd-section">
+        <div class="lsd-section-title">Appearance</div>
+        <table class="lsd-table" style="padding:0 0 4px;">
+          <thead>
+            <tr><th></th><th colspan="2" class="preset-head-cell">Preset</th></tr>
+            <tr><th></th><th>Me</th><th>Partner</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td></td>
+              <td colspan="2">
+                <select id="set-bbl-preset" class="lsd-select" style="width:100%;background:var(--paper);color:var(--ink);" onchange="applyBubblePreset(this.value)">
+                  <option value="light">Light</option>
+                  <option value="medium" selected>Medium</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td>Tone</td>
+              <td><select id="set-bbl-preset-me" class="lsd-select" style="width:100%;" onchange="applyPresetChoice('me',this.value)"></select></td>
+              <td><select id="set-bbl-preset-partner" class="lsd-select" style="width:100%;" onchange="applyPresetChoice('partner',this.value)"></select></td>
+            </tr>
+            <tr>
+              <td>Bubble</td>
+              <td><input type="color" id="set-src-bg" value="#2E8B8B" style="width:34px;height:24px;border:none;border-radius:5px;cursor:pointer;padding:0;" oninput="applySrcBg(this.value)"></td>
+              <td><input type="color" id="set-tgt-bg" value="#F5F1EC" style="width:34px;height:24px;border:none;border-radius:5px;cursor:pointer;padding:0;" oninput="applyTgtBg(this.value)"></td>
+            </tr>
+            <tr>
+              <td>Font</td>
+              <td><input type="color" id="set-src-font" value="#ffffff" style="width:34px;height:24px;border:none;border-radius:5px;cursor:pointer;padding:0;" oninput="applySrcFontColor(this.value)"></td>
+              <td><input type="color" id="set-tgt-font" value="#1A1714" style="width:34px;height:24px;border:none;border-radius:5px;cursor:pointer;padding:0;" oninput="applyTgtFontColor(this.value)"></td>
+            </tr>
+            <tr>
+              <td>Size</td>
+              <td><select id="set-bbl-size" class="lsd-select" onchange="applyGlobalSize(this.value)"><option>12</option><option>13</option><option>14</option><option selected>15</option><option>16</option><option>17</option><option>18</option><option>19</option><option>20</option></select></td>
+              <td><select id="set-target-size" class="lsd-select" onchange="applyTargetSize(this.value)"><option>12</option><option>13</option><option>14</option><option selected>15</option><option>16</option><option>17</option><option>18</option><option>19</option><option>20</option></select></td>
+            </tr>
+            <tr>
+              <td>Width</td>
+              <td style="padding:3px 8px 3px 4px;"><input type="range" min="50" max="95" step="5" id="set-bbl-width" class="lsd-range" oninput="applyGlobalWidth(this.value)"></td>
+              <td style="padding:3px 8px 3px 4px;"><input type="range" min="50" max="95" step="5" id="set-tgt-width" class="lsd-range" oninput="applyTgtWidth(this.value)"></td>
+            </tr>
+          </tbody>
+        </table>
+        <div style="padding:4px 14px 10px;"><button class="lsd-btn secondary" style="width:100%;" onclick="resetAllBubbleDefaults()">Reset appearance</button></div>
+      </div>
+      <!-- Data -->
+      <div class="lsd-section">
+        <div class="lsd-section-title">Data</div>
+        <table class="data-mgmt-grid" style="margin-bottom:6px;">
+          <thead><tr><th></th><th>Data</th><th>Settings</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>Export</td>
+              <td><button class="settings-icon-btn" onclick="exportSessionsData()" title="Export data" aria-label="Export data"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 4v10"/><path d="M8 10l4 4 4-4"/><path d="M4 20h16"/></svg></button></td>
+              <td><button class="settings-icon-btn" onclick="exportAppSettings()" title="Export settings" aria-label="Export settings"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 4v10"/><path d="M8 10l4 4 4-4"/><path d="M4 20h16"/></svg></button></td>
+            </tr>
+            <tr>
+              <td>Import</td>
+              <td><button class="settings-icon-btn" onclick="importSessionsData()" title="Import data" aria-label="Import data"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 20V10"/><path d="M8 14l4-4 4 4"/><path d="M4 4h16"/></svg></button></td>
+              <td><button class="settings-icon-btn" onclick="importAppSettings()" title="Import settings" aria-label="Import settings"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 20V10"/><path d="M8 14l4-4 4 4"/><path d="M4 4h16"/></svg></button></td>
+            </tr>
+            <tr>
+              <td>Clear</td>
+              <td><button class="settings-icon-btn danger" onclick="clearDataOnly()" title="Clear data" aria-label="Clear data"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg></button></td>
+              <td><button class="settings-icon-btn danger" onclick="clearAppSettings()" title="Clear settings" aria-label="Clear settings"><svg class="data-action-icon" aria-hidden="true" viewBox="0 0 24 24"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg></button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!-- Footer: reset + info -->
+      <div class="lsd-section" style="border-bottom:none;">
+        <div style="padding:8px 14px 10px;display:flex;flex-direction:column;gap:6px;">
+          <button class="lsd-btn danger" style="width:100%;" onclick="resetAllSettings()">Reset all settings</button>
+          <div style="display:flex;gap:6px;">
+            <button class="lsd-btn secondary" style="flex:1;" onclick="openInfoModal('about')">About</button>
+            <button class="lsd-btn secondary" style="flex:1;" onclick="openInfoModal('privacy')">Privacy</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="left-body" id="left-body">
+      <div id="session-list"></div>
+      <div id="recycle-bin"></div>
+      <button class="fab-plus" onclick="createNewSession()" title="New chat">+</button>
+    </div>
+  </aside>
+
+  <!-- Ribbon -->
+  <div class="shell-ribbon">
+    <button class="ribbon-btn" onclick="openLeftPanel()" title="Sessions">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <button class="ribbon-btn" onclick="openPhrasebookModal()" title="Phrasebook">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+    </button>
+    <button class="ribbon-btn" id="ribbon-lang-btn" onclick="openLanguagePanel()" title="Your language">🌐</button>
+    <button class="ribbon-btn" onclick="toggleMediaFloat()" title="Media window">🎥</button>
+    <span class="ribbon-spacer"></span>
+    <label class="toggle-switch" title="Auto-read">
+      <input type="checkbox" id="ribbon-autoread" onchange="setAutoReadFromRibbon(this.checked)">
+      <span class="toggle-slider"></span>
+    </label>
+  </div>
+  <!-- Partner name -->
+  <div class="shell-partner" id="shell-partner-name"><span class="shell-participant editable" id="shell-self-name" contenteditable="true" spellcheck="false" title="Edit your name for this chat" onfocus="this.dataset.editing='1'" onblur="this.dataset.editing='0';saveOwnerName(this)" onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}"><span class="shell-participant-label">new chat</span></span><span class="shell-partner-arrow" id="shell-partner-arrow" hidden>↔</span><span class="shell-participant" id="shell-peer-name" title="Not seen yet" hidden><span class="shell-participant-label">?</span></span></div>
+
+  <!-- Empty state -->
+  <div class="shell-empty" id="shell-empty">
+    <div class="shell-empty-logo">talk</div>
+    <div style="color:var(--ink-dim);font-size:14px;text-align:center;">Select a conversation or start a new one</div>
+    <button onclick="createNewSession()" style="background:var(--teal);color:#fff;border:none;border-radius:11px;padding:11px 24px;font-size:14px;font-weight:600;cursor:pointer;font-family:'DM Sans',sans-serif;">New Chat</button>
+  </div>
+
+  <!-- Messages -->
+  <div id="messages" style="display:none;"></div>
+  <div class="typing-bar" id="typing-bar"></div>
+
+  <!-- Composer: [mic] [textarea] [send] -->
+  <div class="composer" id="composer" style="display:none;">
+    <button class="composer-icon" id="stt-btn" onclick="toggleSTT()" title="Voice input">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+    </button>
+    <div class="composer-wrap">
+      <textarea class="composer-ta" id="msg-input" placeholder="Type or speak…" rows="1" oninput="composerInput()" onkeydown="composerKeydown(event)"></textarea>
+    </div>
+    <button class="send-btn" id="send-btn" onclick="sendMessage()" disabled>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+    </button>
+  </div>
+
+  <div class="vsay-float" id="vsay-float-window" aria-live="polite">
+    <div class="vsay-float-header" id="vsay-float-header">
+      <div class="vsay-float-header-left">
+        <button class="vsay-hdr-btn" id="vsay-collapse-btn" onclick="toggleMediaCollapse()">❮</button>
+        <button class="vsay-onair" id="vsay-onair-btn" onclick="toggleOnAirMaster()"><span class="vsay-onair-dot"></span><span>On Air</span></button>
+      </div>
+      <span id="vsay-float-title">Media share</span>
+      <button class="vsay-hdr-btn" id="vsay-cc-btn" onclick="toggleClosedCaption()">CC</button>
+      <div class="vsay-snap-group">
+        <button class="vsay-snap-btn" onclick="snapMediaWindow('left')">◧</button>
+        <button class="vsay-snap-btn" onclick="snapMediaWindow('center')">▣</button>
+        <button class="vsay-snap-btn" onclick="snapMediaWindow('right')">◨</button>
+      </div>
+      <button class="vsay-hdr-btn" onclick="closeMediaWindow()">✕</button>
+    </div>
+    <div class="vsay-float-body">
+      <video id="vsay-remote-video" autoplay playsinline hidden></video>
+      <video id="vsay-local-video" autoplay muted playsinline hidden></video>
+      <div class="vsay-audio-chip" id="vsay-audio-chip" hidden>Audio active</div>
+      <div class="vsay-cc-line" id="vsay-cc-line" hidden></div>
+    </div>
+    <div class="vsay-float-actions">
+      <button class="vsay-float-btn" id="vsay-share-video-btn" onclick="toggleLocalVideo()"></button>
+      <button class="vsay-float-btn" id="vsay-share-audio-btn" onclick="toggleLocalMic()"></button>
+    </div>
+  </div>
+
+</div>
+
+</div>
+
+<style>@keyframes spin{to{transform:rotate(360deg)}}</style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+
+<div id="catalog-screen" class="screen">
+  <div class="scr-header">
+    <div class="scr-title"><span class="scr-title-label" id="cat-screen-title">Phrasebook</span><button class="pb-icon" onclick="openCatalogFilterModal()" title="Catalog"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></button></div>
+    <button class="scr-back" style="color:#111;" onclick="closePhrasebookView()">×</button>
+  </div>
+  <div class="cat-toolbar">
+    <div class="pb-toolbar-actions">
+      <button class="pb-icon" style="padding:7px 10px;" onclick="openNewCard(getActivePhrasebookCatalogId()==='all'?null:getActivePhrasebookCatalogId())" title="New card">+</button>
+      <button class="pb-icon" style="padding:7px 10px;" onclick="openPrintPhrasebookModal()" title="Print"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg></button>
+      <button class="pb-icon" style="padding:7px 10px;" onclick="openPhrasebookImportPicker()" title="Import phrasebook"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></button>
+      <button class="pb-icon" style="padding:7px 10px;" onclick="openPhrasebookExportModal()" title="Export phrasebook"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>
+    </div>
+    <div class="search-wrap" style="flex:1;">
+      <input class="cat-omni" id="cat-search" placeholder="Search phrases and tags…" oninput="renderCatalogCards()">
+      <button class="search-clear" id="cat-search-clear" onclick="clearCatalogSearch()">×</button>
+    </div>
+  </div>
+  <div class="filter-chip-row" id="filter-chip-row"></div>
+  <div class="card-list" id="card-list"></div>
+  <div id="pb-recycle-bin" style="padding:0 16px 20px;"></div>
+</div>
+
+<!-- ══ SEARCH OVERLAY ══ -->
+<div class="search-overlay" id="search-overlay">
+  <div class="search-head">
+    <input class="search-input" id="omni-search" placeholder="Search sessions, phrases…" oninput="runOmniSearch()">
+    <button class="search-close" onclick="closeSearch()">✕</button>
+  </div>
+  <div class="search-results" id="search-results"></div>
+</div>
+
+</div><!-- #app -->
+
+<input id="settings-import-file" type="file" accept=".json,.csv,application/json,text/csv" style="display:none" onchange="handleImportFile(event)">
+
+<div class="onboarding-modal" id="onboarding-modal" hidden>
+  <div class="onboarding-card">
+    <div class="onboarding-title-wrap">
+      <div class="onboarding-title">Hi, let’s get ready to chat! What’s your name?</div>
+    </div>
+    <input class="field-input" id="onboarding-name" placeholder="Your name" maxlength="40">
+    <button class="sheet-btn primary" id="onboarding-continue-btn" onclick="submitOnboardingName()">Continue</button>
+    <div class="onboarding-error" id="onboarding-error"></div>
+  </div>
+</div>
+
+<!-- ══ OVERLAYS ══ -->
+
+<div class="overlay" id="new-card-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet" style="max-height:95dvh;"><div class="sheet-handle"></div><div class="sheet-body" style="padding:14px 16px 24px;">
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+      <span style="font-family:'Lora',serif;font-size:17px;font-weight:600;" id="nc-title">New phrase</span>
+      <button onclick="document.getElementById('new-card-overlay').hidden=true" style="background:none;border:none;font-size:20px;cursor:pointer;color:var(--ink-mid);">&times;</button>
+    </div>
+    <!-- Editable bubble card -->
+    <div class="msg-row theirs" style="width:100%;max-width:100%;">
+      <div class="bubble-card">
+        <div class="bbl-hdr">
+          <span class="bbl-sender" id="nc-header-label">New phrase</span>
+          <div class="bbl-hdr-right">
+            <select id="nc-src-lang" style="border:none;background:transparent;font-size:11px;font-weight:700;color:var(--ink-dim);cursor:pointer;padding:0;" onchange="ncLangChanged()"></select>
+            <span style="font-size:10px;color:var(--ink-dim);">&rarr;</span>
+            <select id="nc-tgt-lang" style="border:none;background:transparent;font-size:11px;font-weight:700;color:var(--ink-dim);cursor:pointer;padding:0;" onchange="ncLangChanged()"></select>
+          </div>
+        </div>
+        <div class="bbl-body">
+          <div class="bbl-side">
+            <div class="bbl-txt" contenteditable="true" id="nc-source" style="min-height:28px;outline:none;border-radius:4px;" data-placeholder="Source phrase…" oninput="ncSourceInput()"></div>
+            <div class="bbl-side-acts">
+              <button class="bbl-use" onclick="ncAutoTranslate()" id="nc-auto-btn" disabled style="font-size:10px;">Translate &rarr;</button>
+              <button class="bbl-tts" onclick="ncSpeak('source',this)" title="Listen to source phrase"><span aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg></span></button>
+            </div>
+          </div>
+          <div class="bbl-divider"></div>
+          <div class="bbl-side">
+            <div class="bbl-txt" contenteditable="true" id="nc-target" style="min-height:28px;outline:none;border-radius:4px;" data-placeholder="Translation…"></div>
+            <div class="bbl-side-acts">
+              <button class="bbl-tts" onclick="ncSpeak('target',this)" title="Listen to translation"><span aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg></span></button>
+            </div>
+          </div>
+        </div>
+        <div class="bbl-foot">
+          <div class="bbl-foot-bar">
+            <button class="bbl-act" data-role="nc-tags" onclick="toggleNcTagDrawer()" title="Tags">#</button>
+            <button class="bbl-act" data-role="nc-catalog" onclick="toggleNcCatalogPicker()" title="Catalog"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></button>
+            <button class="bbl-act" onclick="ncAutoTranslate();ncBackTranslate()" title="Back-translate"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg></button>
+            <button class="bbl-act bbl-act-save" onclick="saveNewCard()" title="Save" style="font-weight:700;">Save</button>
+          </div>
+          <!-- Tag drawer -->
+          <div id="nc-tag-drawer" style="display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px 10px;">
+            <div class="pb-tags-row" id="nc-tags-assigned"></div>
+            <input class="tag-drawer-input" id="nc-tag-input" placeholder="Find or add tag…" oninput="renderNcTagResults()" onkeydown="if(event.key==='Enter'){event.preventDefault();submitNcTagInput();}">
+            <div class="tag-search-results" id="nc-tag-results"></div>
+          </div>
+          <!-- Catalog picker -->
+          <div id="nc-catalog-drawer" style="display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px 10px;">
+            <select class="field-select" id="nc-catalog" style="font-size:12px;padding:6px 8px;margin-bottom:6px;"></select>
+            <button style="background:none;border:1.5px dashed var(--teal);border-radius:8px;padding:5px 10px;color:var(--teal);font-size:11px;font-weight:600;cursor:pointer;width:100%;" onclick="document.getElementById('new-card-overlay').hidden=true;openNewCatalog();">+ New catalog</button>
+            <div id="nc-lang-mismatch" style="display:none;margin-top:6px;font-size:11px;color:var(--amber);font-weight:600;"></div>
+          </div>
+          <!-- Back-translate result -->
+          <div id="nc-bt-result" style="display:none;border-top:1px solid rgba(0,0,0,.06);padding:8px 10px;">
+            <div style="display:flex;align-items:flex-start;gap:8px;">
+              <div style="font-size:12px;color:var(--ink-dim);font-style:italic;flex:1;line-height:1.45;" id="nc-bt-text"></div>
+              <button class="bbl-tts" onclick="ncSpeak('backtranslate',this)" title="Listen to back translation"><span aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg></span></button>
+              <button class="bbl-vbtn good" id="nc-verdict-btn" onclick="cycleNcVerdict()" title="Cycle verdict">Verdict: none</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="tag-picker-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div style="display:flex;justify-content:space-between;margin-bottom:12px;">
+      <span style="font-family:'Lora',serif;font-size:17px;font-weight:600;">Tags</span>
+      <button onclick="closeTagPicker(false)" style="background:none;border:none;font-size:18px;cursor:pointer;color:var(--ink-mid);">×</button>
+    </div>
+    <input class="cat-omni" id="tp-search" placeholder="Search or create…" oninput="renderTagPicker()" style="margin-bottom:10px;">
+    <div class="tag-grid" id="tp-chips"></div>
+    <button id="tp-create-btn" onclick="createAndAddTag()" style="display:none;margin-top:6px;background:none;border:1.5px dashed var(--teal);border-radius:8px;padding:6px 12px;color:var(--teal);font-size:12px;font-weight:600;cursor:pointer;">+ Create</button>
+    <div class="sheet-btn-row"><button class="sheet-btn secondary" onclick="closeTagPicker(false)">Cancel</button><button class="sheet-btn primary" onclick="closeTagPicker(true)">Apply</button></div>
+  </div></div>
+</div>
+
+<div class="overlay" id="confirm-overlay" hidden>
+  <div style="background:var(--cream);border-radius:14px;padding:22px;width:calc(100% - 44px);max-width:340px;margin:auto;align-self:center;">
+    <div style="font-family:'Lora',serif;font-size:17px;font-weight:600;margin-bottom:7px;" id="confirm-title">Are you sure?</div>
+    <div style="font-size:13px;color:var(--ink-mid);line-height:1.5;margin-bottom:18px;" id="confirm-body"></div>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="confirmCancel()">Cancel</button>
+      <button class="sheet-btn danger" id="confirm-ok-btn" onclick="confirmOk()">Delete</button>
+    </div>
+  </div>
+</div>
+
+<div class="overlay" id="new-cat-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">New catalog</div>
+    <label class="field-label" style="margin-top:0;">Name *</label>
+    <input class="field-input" id="ncat-name" placeholder="e.g. Thailand Travel" maxlength="40" oninput="document.getElementById('ncat-save-btn').disabled=!this.value.trim()">
+    <label class="field-label">Language</label>
+    <select class="field-select" id="ncat-lang" style="font-size:13px;" onchange="ncatLangChanged()"></select>
+    <div style="margin-top:6px;display:flex;align-items:center;gap:8px;">
+      <span style="font-size:11px;color:var(--ink-dim);font-weight:600;">Icon:</span>
+      <span id="ncat-icon-preview" style="font-size:24px;">🇹🇭</span>
+    </div>
+    <label class="field-label">Description</label>
+    <input class="field-input" id="ncat-desc" placeholder="Optional" maxlength="100">
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="this.closest('.overlay').hidden=true">Cancel</button>
+      <button class="sheet-btn primary" id="ncat-save-btn" onclick="saveNewCatalog()" disabled>Create</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="share-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Share links</div>
+    <div style="font-size:12px;color:var(--ink-dim);font-weight:700;margin-bottom:6px;">Partner invite QR/link</div>
+    <div id="share-partner-qr" style="width:220px;height:220px;background:#fff;border:1px solid var(--border);border-radius:8px;margin:0 auto 8px;display:flex;align-items:center;justify-content:center;overflow:hidden;"></div>
+    <div style="background:var(--paper);border:1.5px solid var(--border);border-radius:12px;padding:14px 16px;word-break:break-all;">
+      <a style="color:var(--teal);font-size:14px;font-weight:600;" id="share-link-text" href="#" target="_blank">—</a>
+    </div>
+    <p style="font-size:12px;color:var(--ink-dim);margin:10px 0 12px;">Use this to invite your chat partner.</p>
+    <div style="font-size:12px;color:var(--ink-dim);font-weight:700;margin-bottom:6px;">Owner handoff QR/link (same owner, new device)</div>
+    <div id="share-owner-qr" style="width:220px;height:220px;background:#fff;border:1px solid var(--border);border-radius:8px;margin:0 auto 8px;display:flex;align-items:center;justify-content:center;overflow:hidden;"></div>
+    <div style="background:var(--paper);border:1.5px solid var(--border);border-radius:12px;padding:14px 16px;word-break:break-all;">
+      <a style="color:var(--teal);font-size:14px;font-weight:600;" id="share-handoff-link-text" href="#" target="_blank">—</a>
+    </div>
+    <p style="font-size:12px;color:var(--ink-dim);margin:10px 0 0;">Use this only when you are switching your own device.</p>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="this.closest('.overlay').hidden=true">Close</button>
+      <button class="sheet-btn primary" onclick="copyShareLink()">Copy link</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="session-note-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Session note</div>
+    <textarea class="field-input" id="session-note-text" rows="6" placeholder="Private note for this session" style="resize:vertical;"></textarea>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="closeSessionNote()">Cancel</button>
+      <button class="sheet-btn primary" onclick="saveSessionNote()">Save note</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="print-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Print phrasebook</div>
+    <label style="display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:13px;"><input type="checkbox" id="print-include-source" checked> Source text</label>
+    <label style="display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:13px;"><input type="checkbox" id="print-include-target" checked> Target text</label>
+    <label style="display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:13px;"><input type="checkbox" id="print-include-notes"> Notes / clarify</label>
+    <label style="display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:13px;"><input type="checkbox" id="print-include-back" checked> Back translate + verdict</label>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="document.getElementById('print-overlay').hidden=true">Cancel</button>
+      <button class="sheet-btn primary" onclick="printPhrasebookSelection()">Print</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="phrasebook-export-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Export phrasebook</div>
+    <label class="field-label" style="margin-top:0;">Format</label>
+    <select class="field-select" id="phrasebook-export-format">
+      <option value="json">JSON</option>
+      <option value="csv">CSV</option>
+    </select>
+    <button class="export-mode-btn" id="phrasebook-export-swap-btn" onclick="togglePhrasebookSwapExport()" title="Create swapped phrasebook">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3l4 4-4 4"/><path d="M3 7h18"/><path d="M7 21l-4-4 4-4"/><path d="M21 17H3"/></svg>
+      <span>Swap source &amp; target</span>
+    </button>
+    <div class="export-mode-meta" id="phrasebook-export-mode-meta">Export the selected cards as they are.</div>
+    <div class="export-actions">
+      <div style="font-size:12px;color:var(--ink-dim);" id="phrasebook-export-summary">0 selected</div>
+      <div style="display:flex;gap:12px;">
+        <button class="export-link-btn" onclick="setAllPhrasebookExportSelections(true)">Select all</button>
+        <button class="export-link-btn" onclick="setAllPhrasebookExportSelections(false)">Deselect all</button>
+      </div>
+    </div>
+    <div class="export-list" id="phrasebook-export-list"></div>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="closePhrasebookExportModal()">Cancel</button>
+      <button class="sheet-btn secondary" id="phrasebook-save-btn" onclick="saveSelectedPhrasebookData()">Save copy</button>
+      <button class="sheet-btn primary" id="phrasebook-export-btn" onclick="exportSelectedPhrasebookData()">Export</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="catalog-filter-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Select catalog</div>
+    <div id="catalog-filter-list" class="tag-grid"></div>
+    <div class="sheet-btn-row">
+      <button class="sheet-btn secondary" onclick="document.getElementById('catalog-filter-overlay').hidden=true">Close</button>
+      <button class="sheet-btn primary" onclick="document.getElementById('catalog-filter-overlay').hidden=true;openNewCatalog()">+ New catalog</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="overlay" id="info-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title" id="info-title">About</div>
+    <div style="font-size:13px;color:var(--ink-dim);line-height:1.6;" id="info-body"></div>
+    <div class="sheet-btn-row"><button class="sheet-btn primary" onclick="document.getElementById('info-overlay').hidden=true">Close</button></div>
+  </div></div>
+</div>
+
+
+<!-- ══ DIAG LOG MODAL ══ -->
+<div class="overlay" id="diag-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet" style="max-height:80dvh;"><div class="sheet-handle"></div>
+    <div style="padding:14px 20px 6px;display:flex;align-items:center;gap:8px;">
+      <span style="font-family:'Lora',serif;font-size:17px;font-weight:600;flex:1;">Diagnostics</span>
+      <button onclick="copyDiagLog()" style="background:var(--teal-light);color:var(--teal);border:none;border-radius:8px;padding:6px 14px;font-size:12px;font-weight:700;cursor:pointer;font-family:'DM Sans',sans-serif;">Copy</button>
+      <button onclick="clearDiagLog()" style="background:none;border:none;color:var(--ink-dim);font-size:12px;font-weight:600;cursor:pointer;font-family:'DM Sans',sans-serif;">Clear</button>
+      <button onclick="document.getElementById('diag-overlay').hidden=true" style="background:none;border:none;font-size:20px;cursor:pointer;color:var(--ink-mid);">×</button>
+    </div>
+    <div style="padding:0 20px 4px;font-size:11px;color:var(--ink-dim);" id="diag-sess-label"></div>
+    <div id="diag-log-body" style="font-family:monospace;font-size:11px;line-height:1.6;padding:8px 20px 24px;overflow-y:auto;max-height:60dvh;white-space:pre-wrap;color:var(--ink);background:var(--paper);margin:0 16px 16px;border-radius:10px;border:1px solid var(--border);"></div>
+  </div>
+</div>
+
+<div class="overlay" id="language-overlay" hidden onclick="if(event.target===this)this.hidden=true">
+  <div class="sheet"><div class="sheet-handle"></div><div class="sheet-body">
+    <div class="sheet-title">Your Language</div>
+    <div id="language-sheet-options"></div>
+    <div class="sheet-btn-row"><button class="sheet-btn secondary" onclick="document.getElementById('language-overlay').hidden=true">Close</button></div>
+  </div></div>
+</div>
+
+<div id="status-popup" class="status-popup" hidden>
+  <div class="status-popup-head">
+    <span>Status</span>
+    <button class="status-popup-close" onclick="closeStatusPopup()">×</button>
+  </div>
+  <div class="status-popup-row" id="status-popup-delivered"></div>
+  <div class="status-popup-row" id="status-popup-read"></div>
+</div>
+
+<div id="toast"></div>
+
+<script>
+'use strict';
+// ════════════════════════════════════════════════════════
+// CONSTANTS
+// ════════════════════════════════════════════════════════
+// RELAY_WS_URL defined in transport block
+
+// Storage bounds
+var MAX_QUEUE_DEPTH=40;
+var MSG_TTL_MS=300000;
+var MAX_RETRY_ATTEMPTS=8;
+var MAX_SESSIONS_STORED=50;
+var MAX_MSGS_PER_SESSION=300;
+var MAX_PHRASEBOOK_ENTRIES=500;
+var EPHEMERAL_EVENT_TYPES=['typing','ping','pong','hello','ack','history-sync'];
+var DURABLE_EVENT_TYPES=['msg','tr','clarify-note'];
+
+var LANGS=[
+  {code:'en',label:'English',flag:'🇺🇸'},{code:'th',label:'Thai',flag:'🇹🇭'},
+  {code:'es',label:'Spanish',flag:'🇪🇸'},{code:'ja',label:'Japanese',flag:'🇯🇵'},
+  {code:'ko',label:'Korean',flag:'🇰🇷'},{code:'zh',label:'Chinese',flag:'🇨🇳'},
+  {code:'ar',label:'Arabic',flag:'🇸🇦'},{code:'hi',label:'Hindi',flag:'🇮🇳'},
+  {code:'ru',label:'Russian',flag:'🇷🇺'},{code:'fr',label:'French',flag:'🇫🇷'},
+  {code:'de',label:'German',flag:'🇩🇪'},{code:'it',label:'Italian',flag:'🇮🇹'},
+  {code:'pt',label:'Portuguese',flag:'🇧🇷'},{code:'vi',label:'Vietnamese',flag:'🇻🇳'},
+  {code:'id',label:'Indonesian',flag:'🇮🇩'},{code:'ms',label:'Malay',flag:'🇲🇾'},
+  {code:'fil',label:'Filipino',flag:'🇵🇭'},{code:'nl',label:'Dutch',flag:'🇳🇱'},
+  {code:'sv',label:'Swedish',flag:'🇸🇪'},{code:'pl',label:'Polish',flag:'🇵🇱'},
+  {code:'tr',label:'Turkish',flag:'🇹🇷'}
+];
+var LANG_MAP={};LANGS.forEach(function(l){LANG_MAP[l.code]=l.label;});
+var TTS_LOCALE={en:'en-US',th:'th-TH',ja:'ja-JP',ko:'ko-KR',zh:'zh-CN',ar:'ar-SA',hi:'hi-IN',ru:'ru-RU',fr:'fr-FR',de:'de-DE',es:'es-ES',it:'it-IT',pt:'pt-BR',vi:'vi-VN',id:'id-ID',ms:'ms-MY',fil:'fil-PH',nl:'nl-NL',sv:'sv-SE',pl:'pl-PL',tr:'tr-TR'};
+var EMOJIS=['🗺','💬','🍜','✈️','🏨','🛒','🏥','🎌','📝','🎯','🌏','💡','🎭','🏖️','🍣','🛺','⛽','🎪'];
+var STARTER_TAGS=['casual','communication','dietary','emergency','essential','food','formal','hotel','medical','negotiating','restaurant','shopping','social','taxi','transport'];
+
+var ICON_TTS='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>';
+var ICON_SHARE='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>';
+var ICON_SAVE='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/></svg>';
+var ICON_CLARIFY='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a4 4 0 0 1-4 4H7l-4 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"/></svg>';
+var ICON_BACK='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>';
+var ICON_DELETE='<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+
+// Storage keys
+var SK={sessions:'ts3_sessions',activeConv:'ts3_active',prefs:'ts3_prefs',devId:'ts3_dev',partId:'ts3_part',order:'ts3_order',recycled:'ts3_recycled',notes:'ts3_notes',media:'ts3_media_share',mediaUi:'ts3_media_ui'};
+var SAY={catalogs:'say_catalogs',cards:'say_cards',tags:'say_tags'};
+
+function ls(k){try{return localStorage.getItem(k);}catch(e){return null;}}
+function lsW(k,v){try{localStorage.setItem(k,v);}catch(e){toast('Storage full');}}
+function lsDel(k){try{localStorage.removeItem(k);}catch(e){}}
+function lsJSON(k,def){try{var v=ls(k);return v?JSON.parse(v):def;}catch(e){return def;}}
+
+// Stable IDs
+function getDeviceId(){var id=ls(SK.devId);if(!id){id=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2,14));lsW(SK.devId,id);}return id;}
+function getPartId(){var id=ls(SK.partId);if(!id){id=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2,14));lsW(SK.partId,id);}return id;}
+var DEVICE_ID=getDeviceId();
+var PART_ID=getPartId();
+
+// ════════════════════════════════════════════════════════
+// STATE
+// ════════════════════════════════════════════════════════
+var state={
+  activeConvId:null,
+  messages:[],
+  connected:false,
+  currentCatId:'all',
+  openCardId:null,
+  tagPickerCtx:null,
+  tagPickerCardId:null,
+  ncTags:[],
+  confirmCallback:null,
+  autoSpeakIncoming:false,
+  _newCatEmoji:'📝',
+  pbBackOpen:{},
+  pbClarifyOpen:{},
+  pbClarifyDrafts:{},
+  pbTagDrawer:{},
+  chatTagOpen:{},
+  chatClarifyOpen:{},
+  chatBtOpen:{},
+  participants:{},
+  saveContext:null,
+  noteSessionId:null,
+  pendingInviteId:null,
+  pbExportSelection:{},
+  pbExportSwap:false,
+  pbExportBusy:false,
+  ncBacktranslate:null,
+  mediaShareBySession:{},
+  mediaRuntime:{stream:null,activeSessionId:'',remoteActive:false,floatVisible:true,videoOn:false,micOn:false,collapsed:false,ccOn:false,dragging:false,lastCcLine:''}
+};
+var pendingOnboardingFlow=null;
+var tagPickerSelectedTags=[];
+var tEngine='cloud',ttsActive=null;
+var typingTimer=null;
+var typingStopTimer=null;
+var localTypingActive=false;
+var SpeechRec=window.SpeechRecognition||window.webkitSpeechRecognition;
+var recognition=null,sttActive=false;
+
+
+
+function getSessionMediaMap(){return lsJSON(SK.media,{});}
+function saveSessionMediaMap(map){lsW(SK.media,JSON.stringify(map||{}));}
+function getMediaUiPrefs(){return lsJSON(SK.mediaUi,{width:220,height:150,snap:'left',left:12,top:88});}
+function saveMediaUiPrefs(v){lsW(SK.mediaUi,JSON.stringify(v||{}));}
+function hydrateSessionMediaMap(){state.mediaShareBySession=getSessionMediaMap();}
+function getActiveSessionMediaState(){var cid=state.activeConvId||'';if(!cid)return null;return state.mediaShareBySession[cid]||null;}
+function setSessionMediaState(cid,payload){if(!cid)return;var map=getSessionMediaMap();if(payload&&payload.active){map[cid]={active:true,videoOn:!!payload.videoOn,micOn:!!payload.micOn,ccOn:!!payload.ccOn,updatedAt:Date.now(),from:payload.from||DEVICE_ID};}
+  else delete map[cid];
+  state.mediaShareBySession=map;saveSessionMediaMap(map);
+}
+function getMediaShareLabel(sess){if(!sess)return 'Media share';var mine=firstRealName(sess.myHandle,sess.myName,'You')||'You';var peer=firstRealName(sess.partnerHandle,sess.peerName,'Partner')||'Partner';return mine+' ↔ '+peer;}
+function iconForVideo(on){return on?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23 7 16 12 23 17 23 7"></polygon><rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect></svg>':'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23 7 16 12 23 17 23 7"></polygon><rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect><line x1="2" y1="22" x2="22" y2="2"></line></svg>';}
+function iconForMic(on){return on?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path><path d="M19 10v2a7 7 0 0 1-14 0v-2"></path><line x1="12" y1="19" x2="12" y2="23"></line><line x1="8" y1="23" x2="16" y2="23"></line></svg>':'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1a3 3 0 0 0-3 3v5"></path><path d="M19 10v2a7 7 0 0 1-12.9 3.9"></path><line x1="12" y1="19" x2="12" y2="23"></line><line x1="8" y1="23" x2="16" y2="23"></line><line x1="2" y1="22" x2="22" y2="2"></line></svg>';}
+function closeMediaWindow(){state.mediaRuntime.floatVisible=false;renderMediaShareUI();}
+function toggleMediaFloat(show){if(typeof show==='boolean')state.mediaRuntime.floatVisible=show;else state.mediaRuntime.floatVisible=!state.mediaRuntime.floatVisible;renderMediaShareUI();}
+function toggleMediaCollapse(){state.mediaRuntime.collapsed=!state.mediaRuntime.collapsed;renderMediaShareUI();}
+function snapMediaWindow(mode){var win=document.getElementById('vsay-float-window');if(!win)return;var p=getMediaUiPrefs();p.snap=mode||'left';p.top=12;
+  if(p.snap==='left')p.left=12;
+  else if(p.snap==='center')p.left=Math.max(8,Math.round((document.getElementById('app').clientWidth-p.width)/2));
+  else p.left=Math.max(8,document.getElementById('app').clientWidth-p.width-12);
+  saveMediaUiPrefs(p);applyMediaWindowLayout();
+}
+function applyMediaWindowLayout(){var win=document.getElementById('vsay-float-window');if(!win)return;var p=getMediaUiPrefs();win.style.width=(p.width||220)+'px';win.style.height=(p.height||150)+'px';win.style.left=(p.left||12)+'px';win.style.top=(p.top||88)+'px';}
+function persistMediaWindowSize(){var win=document.getElementById('vsay-float-window');if(!win)return;var p=getMediaUiPrefs();p.width=Math.round(win.offsetWidth);p.height=Math.round(win.offsetHeight);p.left=parseInt(win.style.left||p.left||12,10);p.top=parseInt(win.style.top||p.top||88,10);saveMediaUiPrefs(p);}
+function setMediaCcLine(text){state.mediaRuntime.lastCcLine=String(text||'');var el=document.getElementById('vsay-cc-line');if(!el)return;el.textContent=state.mediaRuntime.lastCcLine;el.hidden=!state.mediaRuntime.lastCcLine;}
+async function syncLocalMediaStream(){
+  var needVideo=!!state.mediaRuntime.videoOn,needAudio=!!state.mediaRuntime.micOn;
+  if(!needVideo&&!needAudio){if(state.mediaRuntime.stream){state.mediaRuntime.stream.getTracks().forEach(function(t){try{t.stop();}catch(_){}});}state.mediaRuntime.stream=null;return;}
+  try{
+    var stream=await navigator.mediaDevices.getUserMedia({video:needVideo,audio:needAudio});
+    if(state.mediaRuntime.stream){state.mediaRuntime.stream.getTracks().forEach(function(t){try{t.stop();}catch(_){}});}state.mediaRuntime.stream=stream;
+  }catch(_){toast('Media permission blocked');if(needVideo)state.mediaRuntime.videoOn=false;if(needAudio)state.mediaRuntime.micOn=false;}
+}
+function announceMediaState(){if(!state.activeConvId)return;var payload={active:(state.mediaRuntime.videoOn||state.mediaRuntime.micOn),videoOn:!!state.mediaRuntime.videoOn,micOn:!!state.mediaRuntime.micOn,ccOn:!!state.mediaRuntime.ccOn,from:DEVICE_ID};state.mediaRuntime.activeSessionId=payload.active?state.activeConvId:'';
+  setSessionMediaState(state.activeConvId,payload.active?payload:null);transportSend({type:'media-share',transient:true,mediaAction:payload.active?'share':'unshare',videoOn:payload.videoOn,micOn:payload.micOn,ccOn:payload.ccOn});}
+async function toggleLocalVideo(){state.mediaRuntime.videoOn=!state.mediaRuntime.videoOn;await syncLocalMediaStream();announceMediaState();renderMediaShareUI();}
+async function toggleLocalMic(){state.mediaRuntime.micOn=!state.mediaRuntime.micOn;await syncLocalMediaStream();announceMediaState();renderMediaShareUI();}
+function toggleOnAirMaster(){var enabled=state.mediaRuntime.videoOn||state.mediaRuntime.micOn;state.mediaRuntime.videoOn=!enabled;state.mediaRuntime.micOn=!enabled;syncLocalMediaStream().then(function(){announceMediaState();renderMediaShareUI();});}
+function stopSessionMediaShare(opts){var silent=opts&&opts.silent;var wasOn=(state.mediaRuntime.videoOn||state.mediaRuntime.micOn);state.mediaRuntime.videoOn=false;state.mediaRuntime.micOn=false;syncLocalMediaStream().then(function(){announceMediaState();renderMediaShareUI();if(wasOn&&!silent)toast('Media off');});}
+var mediaCCRecognition=null;
+function stopCcRecognition(){if(mediaCCRecognition){try{mediaCCRecognition.onresult=null;mediaCCRecognition.onend=null;mediaCCRecognition.stop();}catch(_){}mediaCCRecognition=null;}}
+function toggleClosedCaption(){state.mediaRuntime.ccOn=!state.mediaRuntime.ccOn;var btn=document.getElementById('vsay-cc-btn');if(btn)btn.classList.toggle('active',state.mediaRuntime.ccOn);
+  if(!state.mediaRuntime.ccOn){stopCcRecognition();announceMediaState();return;}
+  if(!SpeechRec){toast('CC not supported in this browser');state.mediaRuntime.ccOn=false;return;}
+  mediaCCRecognition=new SpeechRec();mediaCCRecognition.continuous=true;mediaCCRecognition.interimResults=true;mediaCCRecognition.lang='en-US';
+  mediaCCRecognition.onresult=function(ev){var txt='';for(var i=ev.resultIndex;i<ev.results.length;i++)txt+=ev.results[i][0].transcript+' ';txt=txt.trim();if(!txt)return;setMediaCcLine(txt);transportSend({type:'media-cc',transient:true,text:txt,sourceLang:'en'});};
+  mediaCCRecognition.onend=function(){if(state.mediaRuntime.ccOn){try{mediaCCRecognition.start();}catch(_){}}};
+  try{mediaCCRecognition.start();}catch(_){toast('Unable to start CC');state.mediaRuntime.ccOn=false;}
+  announceMediaState();renderMediaShareUI();
+}
+async function applyRemoteCc(d,sess){if(!d||!sess)return;var myLang=getEffectiveReplyLang(sess,'owner','en');var srcLang=normalizeLangSetting(d.sourceLang||'en')||'en';var raw=String(d.text||'').trim();if(!raw)return;
+  var out=raw;if(srcLang!==myLang){try{out=await translate(raw,srcLang,myLang)||raw;}catch(_){out=raw;}}
+  setMediaCcLine(out);if(out)speak(out,myLang,null);
+}
+function applyRemoteMediaShareState(d,sess){if(!sess||!d)return;
+  if(d.mediaAction==='unshare')setSessionMediaState(sess.convId,null);
+  else if(d.mediaAction==='share')setSessionMediaState(sess.convId,{active:true,videoOn:!!d.videoOn,micOn:!!d.micOn,ccOn:!!d.ccOn,from:d.from||''});
+  if(state.activeConvId===sess.convId)renderMediaShareUI();
+}
+function renderMediaShareUI(){
+  var win=document.getElementById('vsay-float-window');if(!win)return;
+  var title=document.getElementById('vsay-float-title');
+  var vBtn=document.getElementById('vsay-share-video-btn');
+  var aBtn=document.getElementById('vsay-share-audio-btn');
+  var onAir=document.getElementById('vsay-onair-btn');
+  var ccBtn=document.getElementById('vsay-cc-btn');
+  var cBtn=document.getElementById('vsay-collapse-btn');
+  var localVideo=document.getElementById('vsay-local-video');
+  var remoteVideo=document.getElementById('vsay-remote-video');
+  var audioChip=document.getElementById('vsay-audio-chip');
+  var sess=getSession(state.activeConvId||'');
+  var current=getActiveSessionMediaState();
+  var localVideoOn=!!state.mediaRuntime.videoOn,localMicOn=!!state.mediaRuntime.micOn;
+  var remoteVideoOn=!!(current&&current.videoOn&&!localVideoOn),remoteMicOn=!!(current&&current.micOn&&!localMicOn);
+  if(title)title.textContent=getMediaShareLabel(sess);
+  if(vBtn){vBtn.classList.toggle('active',localVideoOn);vBtn.innerHTML=iconForVideo(localVideoOn)+'<span>'+(localVideoOn?'Video on':'Video off')+'</span>';}
+  if(aBtn){aBtn.classList.toggle('active',localMicOn);aBtn.innerHTML=iconForMic(localMicOn)+'<span>'+(localMicOn?'Mic on':'Mic off')+'</span>';}
+  if(onAir)onAir.classList.toggle('live',localVideoOn||localMicOn);
+  if(ccBtn)ccBtn.classList.toggle('active',state.mediaRuntime.ccOn);
+  if(cBtn)cBtn.textContent=state.mediaRuntime.collapsed?'❯':'❮';
+  win.classList.toggle('collapsed',state.mediaRuntime.collapsed);
+  if(localVideo){if(localVideoOn&&state.mediaRuntime.stream){localVideo.hidden=false;localVideo.srcObject=state.mediaRuntime.stream;}else{localVideo.hidden=true;localVideo.srcObject=null;}}
+  if(remoteVideo){remoteVideo.hidden=!remoteVideoOn;remoteVideo.srcObject=null;}
+  if(audioChip){audioChip.hidden=!(localMicOn||remoteMicOn);audioChip.textContent=localMicOn?'Mic active':'Remote audio active';}
+  if(state.activeConvId&&state.mediaRuntime.floatVisible)win.classList.add('show');else win.classList.remove('show');
+}
+function initMediaWindowInteractions(){
+  var win=document.getElementById('vsay-float-window');var head=document.getElementById('vsay-float-header');if(!win||!head)return;
+  applyMediaWindowLayout();
+  var drag={on:false,x:0,y:0,left:0,top:0};
+  head.addEventListener('pointerdown',function(e){if(e.target.closest('button'))return;drag.on=true;drag.x=e.clientX;drag.y=e.clientY;drag.left=parseInt(win.style.left||12,10);drag.top=parseInt(win.style.top||88,10);head.setPointerCapture(e.pointerId);});
+  head.addEventListener('pointermove',function(e){if(!drag.on)return;var nl=drag.left+(e.clientX-drag.x);var nt=drag.top+(e.clientY-drag.y);win.style.left=Math.max(4,nl)+'px';win.style.top=Math.max(4,nt)+'px';});
+  head.addEventListener('pointerup',function(e){if(!drag.on)return;drag.on=false;try{head.releasePointerCapture(e.pointerId);}catch(_){}persistMediaWindowSize();});
+  if(window.ResizeObserver){var ro=new ResizeObserver(function(){persistMediaWindowSize();});ro.observe(win);}else{win.addEventListener('mouseup',persistMediaWindowSize);}
+}
+// ════════════════════════════════════════════════════════
+// STORAGE HELPERS
+// ════════════════════════════════════════════════════════
+function normalizeSession(sess){
+  var raw=(sess&&typeof sess==='object')?sess:{};
+  var p=getPrefs();
+  var now=Date.now();
+  var createdAt=Number(raw.createdAt)||now;
+  var lastActivity=Number(raw.lastActivity)||createdAt;
+  var myHandle=firstRealName(raw.myHandle,raw.myName,p.globalName,p.userName)||p.userName||'yournamehere';
+  var partnerHandle=firstRealName(raw.partnerHandle,raw.peerName)||'';
+  var out={
+    convId:raw.convId||uid(),
+    myHandle:myHandle,
+    partnerHandle:partnerHandle,
+    myName:myHandle,
+    peerName:partnerHandle,
+    createdAt:createdAt,
+    lastActivity:lastActivity,
+    ownerIdentityId:String(raw.ownerIdentityId||raw.myIdentityId||PART_ID||DEVICE_ID||uid()),
+    partnerIdentityId:String(raw.partnerIdentityId||''),
+    ownerLangMode:(raw.ownerLangMode==='fixed'||raw.ownerLangMode==='auto')?raw.ownerLangMode:((normalizeLangSetting(p.myLang)||'')?'fixed':'auto'),
+    ownerFixedLang:normalizeLangSetting(raw.ownerFixedLang!==undefined?raw.ownerFixedLang:p.myLang)||'',
+    ownerLastSentLang:normalizeLangSetting(raw.ownerLastSentLang)||'',
+    ownerEffectiveReplyLang:normalizeLangSetting(raw.ownerEffectiveReplyLang)||'',
+    partnerLangMode:(raw.partnerLangMode==='fixed'||raw.partnerLangMode==='auto')?raw.partnerLangMode:'auto',
+    partnerFixedLang:normalizeLangSetting(raw.partnerFixedLang)||'',
+    partnerLastSentLang:normalizeLangSetting(raw.partnerLastSentLang)||'',
+    partnerEffectiveReplyLang:normalizeLangSetting(raw.partnerEffectiveReplyLang)||'',
+    peerLastSeenAt:Number(raw.peerLastSeenAt)||0
+  };
+  if(Number(raw.lastViewedAt))out.lastViewedAt=Number(raw.lastViewedAt);
+  if(raw.inviterDeviceId)out.inviterDeviceId=raw.inviterDeviceId;
+  if(Number(raw.inviteCreatedAt))out.inviteCreatedAt=Number(raw.inviteCreatedAt);
+  var rt=getRoomRuntime(out.convId);
+  if(rt&&out.peerLastSeenAt)rt.peerLastSeenAt=out.peerLastSeenAt;
+  return out;
+}
+function getAllSessions(){return lsJSON(SK.sessions,[]).map(normalizeSession).filter(function(s){return !!s.convId;});}
+function saveSessions(l){lsW(SK.sessions,JSON.stringify((l||[]).map(normalizeSession).slice(0,MAX_SESSIONS_STORED)));}
+function getSessionOrder(){return lsJSON(SK.order,[]);}
+function saveSessionOrder(o){lsW(SK.order,JSON.stringify(o));}
+function normalizeSessionOrder(order,appendMissing){var validIds=getAllSessions().map(function(s){return s&&s.convId;}).filter(Boolean);var validSet=new Set(validIds);var out=[];(Array.isArray(order)?order:[]).forEach(function(id){if(validSet.has(id)&&out.indexOf(id)<0)out.push(id);});if(appendMissing!==false)validIds.forEach(function(id){if(out.indexOf(id)<0)out.push(id);});return out;}
+function getRecycled(){return lsJSON(SK.recycled,[]);}
+function saveRecycled(r){lsW(SK.recycled,JSON.stringify(r));}
+function getSessionNotes(){return lsJSON(SK.notes,{});}
+function saveSessionNotes(n){lsW(SK.notes,JSON.stringify(n||{}));}
+function getActiveConvId(){return ls(SK.activeConv)||null;}
+function setActiveConvId(id){if(id)lsW(SK.activeConv,id);else lsDel(SK.activeConv);}
+function getSession(cid){return getAllSessions().find(function(s){return s.convId===cid;})||null;}
+function putSession(sess){
+  if(!sess)return null;
+  var next=normalizeSession(sess);
+  var ss=getAllSessions();
+  var idx=ss.findIndex(function(s){return s.convId===next.convId;});
+  if(idx>=0)ss[idx]=next;else ss.unshift(next);
+  saveSessions(ss);
+  setActiveConvId(next.convId);
+  return next;
+}
+function getSessionLabel(sess){
+  var s=sess?normalizeSession(sess):null;
+  var me=firstRealName(s&&s.myHandle,s&&s.myName);
+  var peer=firstRealName(s&&s.partnerHandle,s&&s.peerName);
+  if(peer)return me?(me+' / '+peer):peer;
+  var ts=s&&s.createdAt?new Date(s.createdAt).toLocaleString([],{month:'short',day:'2-digit',hour:'2-digit',minute:'2-digit'}):'';
+  if(me)return me+' / Invite Pending'+(ts?(' — '+ts):'');
+  return 'new chat';
+}
+
+function normalizeBacktranslatePayload(payload,fallbacks){
+  var now=Date.now();
+  var base=(payload&&typeof payload==='object')?payload:{};
+  var fb=fallbacks||{};
+  return {
+    sourceLang:base.sourceLang||fb.sourceLang||'',
+    targetLang:base.targetLang||fb.targetLang||'',
+    inputText:base.inputText||fb.inputText||'',
+    resultText:base.resultText||base.result||fb.resultText||fb.result||'',
+    verdict:base.verdict||fb.verdict||'',
+    contentHash:base.contentHash||fb.contentHash||'',
+    updatedAt:base.updatedAt||fb.updatedAt||now
+  };
+}
+
+function btContentHash(inputText,targetText){
+  return String(inputText||'').trim()+'||'+String(targetText||'').trim();
+}
+
+function normalizeMsgSchema(msg,defaults){
+  var m=(msg&&typeof msg==='object')?msg:{};
+  var defs=defaults||{};
+  var sourceLang=m.sourceLang||m.lang||defs.sourceLang||'en';
+  var sourceText=m.sourceText||m.orig||m.text||'';
+  var targetLang=m.targetLang||defs.targetLang||'';
+  var map=(m.translations&&typeof m.translations==='object')?m.translations:{};
+  var legacyTarget=m.targetText||m.translated||'';
+  if(targetLang&&legacyTarget&&!map[targetLang])map[targetLang]=legacyTarget;
+  if(targetLang&&!legacyTarget&&typeof map[targetLang]==='string')legacyTarget=map[targetLang];
+  m.sourceLang=sourceLang;
+  m.sourceText=sourceText;
+  m.targetLang=targetLang;
+  m.targetText=legacyTarget||'';
+  m.translations=map;
+  if(m.sourceText&&!m.translations[m.sourceLang])m.translations[m.sourceLang]=m.sourceText;
+  if(m.targetLang&&m.targetText&&!m.translations[m.targetLang])m.translations[m.targetLang]=m.targetText;
+  // Immutable snapshot: stamp once, never overwrite
+  if(!m._snapLang){m._snapLang={src:sourceLang,tgt:targetLang,stamped:Date.now()};}
+  // compat shims
+  if(!m.lang)m.lang=m.sourceLang;
+  if(!m.orig)m.orig=m.sourceText;
+  if(!m.text)m.text=m.from==='me'?m.sourceText:(m.targetText||m.sourceText);
+  if(!m.translated&&m.targetText)m.translated=m.targetText;
+  // Back-translate: preserve contentHash for stale detection
+  var existingBt=m.backtranslate&&typeof m.backtranslate==='object'?m.backtranslate:{};
+  m.backtranslate=normalizeBacktranslatePayload(existingBt,{
+    sourceLang:m.targetLang||'',
+    targetLang:m.sourceLang||'',
+    inputText:m.targetText||'',
+    resultText:'',
+    verdict:'',
+    contentHash:btContentHash(m.sourceText,m.targetText),
+    updatedAt:existingBt.updatedAt||Date.now()
+  });
+  return m;
+}
+
+function getMsgs(cid){
+  var sess=getSession(cid)||{};
+  var raw=lsJSON('ts3_m_'+cid,[]);
+  var changed=false;
+  var norm=(raw||[]).map(function(msg){
+    var before=JSON.stringify(msg||{});
+    var ownerEff=resolveEffectiveLang(sess,'owner');
+    var partnerEff=resolveEffectiveLang(sess,'partner');
+    var next=normalizeMsgSchema(msg,{sourceLang:(msg&&msg.from==='me')?(ownerEff||'en'):(msg&&msg.lang)||partnerEff||'en',targetLang:(msg&&msg.from==='me')?(partnerEff||'en'):(ownerEff||'en')});
+    if(before!==JSON.stringify(next))changed=true;
+    return next;
+  });
+  var sorted=sortMessagesChronologically(norm);
+  if(JSON.stringify(sorted)!==JSON.stringify(norm)){norm=sorted;changed=true;}
+  if(changed)saveMsgs(cid,norm);
+  return norm;
+}
+function saveMsgs(cid,m){lsW('ts3_m_'+cid,JSON.stringify(sortMessagesChronologically(m).slice(-MAX_MSGS_PER_SESSION)));}
+function getMsgTranslatedText(msg,targetLang,fallback){
+  var map=ensureMsgTranslations(msg);
+  if(targetLang&&typeof map[targetLang]==='string'&&map[targetLang].trim()){
+    return {text:map[targetLang],langUsed:targetLang};
+  }
+  return {text:fallback||'',langUsed:targetLang||msg&&msg.targetLang||''};
+}
+function deleteSessData(cid){lsDel('ts3_m_'+cid);}
+function markViewed(cid){var ss=getAllSessions();var s=ss.find(function(x){return x.convId===cid;});if(s){s.lastViewedAt=Date.now();saveSessions(ss);}}
+
+function getCatalogs(){return lsJSON(SAY.catalogs,[]);}
+function saveCatalogs(c){lsW(SAY.catalogs,JSON.stringify(c));}
+
+function normalizeCard(c){
+  var now=Date.now();
+  var card=c||{};
+  card.tags=(card.tags||[]).map(normalizeTag).filter(Boolean);
+  card.backtranslate=normalizeBacktranslatePayload(card.backtranslate,{
+    sourceLang:card.targetLang||'en',
+    targetLang:card.sourceLang||'en',
+    inputText:card.target||card.source||'',
+    resultText:card.backTranslation||'',
+    verdict:(card.backFlagged?'flag':(card.backApproved?'good':'')),
+    contentHash:btContentHash(card.source,card.target),
+    updatedAt:card.updatedAt||now
+  });
+  card.clarifyChain=Array.isArray(card.clarifyChain)?card.clarifyChain:[];
+  card.updatedAt=card.updatedAt||card.createdAt||now;
+  card.createdAt=card.createdAt||now;
+  return card;
+}
+function getCards(){return lsJSON(SAY.cards,[]).map(normalizeCard);}
+// Fix 7: Phrasebook recently-deleted holding area (30-day recovery)
+function getPbRecycled(){return lsJSON('say_recycled',[]);}
+function savePbRecycled(r){lsW('say_recycled',JSON.stringify(r));}
+function softDeleteCard(id){
+  var cards=getCards();var card=cards.find(function(c){return c.id===id;});
+  if(!card){toast('Not found');return;}
+  var recycled=getPbRecycled();
+  recycled.push({card:card,deletedAt:Date.now()});
+  savePbRecycled(recycled);
+  saveCards(cards.filter(function(c){return c.id!==id;}));
+  renderCatalogCards();
+  toast('Deleted \u2014 see Recently Deleted to undo');
+}
+function restorePbCard(id){
+  var recycled=getPbRecycled();
+  var entry=recycled.find(function(r){return r.card&&r.card.id===id;});
+  if(!entry){toast('Not found');return;}
+  savePbRecycled(recycled.filter(function(r){return !r.card||r.card.id!==id;}));
+  var cards=getCards();cards.unshift(normalizeCard(entry.card));saveCards(cards);
+  renderCatalogCards();renderPbRecycleBin();
+  toast('Restored');
+}
+function permDeletePbCard(id){
+  savePbRecycled(getPbRecycled().filter(function(r){return !r.card||r.card.id!==id;}));
+  renderPbRecycleBin();
+  toast('Permanently deleted');
+}
+function renderPbRecycleBin(){
+  var bin=document.getElementById('pb-recycle-bin');if(!bin)return;
+  var r=getPbRecycled();var now=Date.now();
+  r=r.filter(function(x){return(now-(x.deletedAt||0))<30*86400000;});
+  savePbRecycled(r);
+  if(!r.length){bin.innerHTML='';return;}
+  bin.innerHTML='<div class="recycle-header" onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display===\'none\'?\'block\':\'none\';">\u25b8 Recently Deleted ('+r.length+')</div><div class="recycle-list" style="display:none;">'+r.map(function(x){
+    var title=(x.card&&x.card.source)||'phrase';
+    return '<div class="recycle-item"><span style="flex:1;">'+escHtml(title.slice(0,30))+'</span><button class="restore" onclick="restorePbCard(\''+x.card.id+'\')">Restore</button><button class="purge" onclick="permDeletePbCard(\''+x.card.id+'\')">Delete</button></div>';
+  }).join('')+'</div>';
+}
+function saveCards(c){
+  var pruned=(c||[]).map(normalizeCard);
+  if(pruned.length>MAX_PHRASEBOOK_ENTRIES){
+    pruned.sort(function(a,b){return(b.updatedAt||0)-(a.updatedAt||0);});
+    pruned=pruned.slice(0,MAX_PHRASEBOOK_ENTRIES);
+  }
+  lsW(SAY.cards,JSON.stringify(pruned));
+}
+function cardPairKey(source,sourceLang,target,targetLang){return [(sourceLang||'en').trim().toLowerCase(),(source||'').trim(),(targetLang||'en').trim().toLowerCase(),(target||'').trim()].join('||');}
+function upsertCardLastWins(nextCard,broadcast){var cards=getCards();var key=cardPairKey(nextCard.source,nextCard.sourceLang,nextCard.target,nextCard.targetLang);cards=cards.filter(function(c){return cardPairKey(c.source,c.sourceLang,c.target,c.targetLang)!==key;});var nc=normalizeCard(nextCard);cards.unshift(nc);saveCards(cards);if(broadcast!==false&&state.activeConvId){transportSend({type:'card',card:nc});addDiagLog('TX card source='+String(nc.source||'').slice(0,20));}}
+
+function getTags(){return lsJSON(SAY.tags,STARTER_TAGS.slice());}
+function saveTags(t){lsW(SAY.tags,JSON.stringify([].concat(Array.from(new Set(t))).sort()));}
+function addTagToRegistry(t){var tags=getTags();if(tags.indexOf(t)<0){tags.push(t);saveTags(tags);}}
+
+function getPrefs(){var p=lsJSON(SK.prefs,{userName:'yournamehere',globalName:'',myLang:'',partnerLang:'en',phrasebookSourceLang:'en',phrasebookTargetLang:'en',autoSpeakIncoming:false,autoDetectLang:true,noOpOnSameLanguage:true,forceOppositePartyLanguage:false,sourceTheme:'default',targetTheme:'default',accentColor:'#2E8B8B',targetAccentColor:'#1A1714',phrasebookAccentColor:'#2E8B8B',bubbleWidth:75,bubbleFontSize:15,targetBubbleFontSize:15,bubblePreset:'medium',bubblePresetMeChoice:'pacific-blue',bubblePresetPartnerChoice:'almond-cream'});if(!p.globalName&&p.userName)p.globalName=p.userName;if(!hasOwn(p,'myLang'))p.myLang='';if(!p.bubblePreset)p.bubblePreset='medium';if(!p.bubblePresetMeChoice)p.bubblePresetMeChoice='pacific-blue';if(!p.bubblePresetPartnerChoice)p.bubblePresetPartnerChoice='almond-cream';return p;}
+function savePrefs(p){if(!p)return;var next=Object.assign({},p);if(!next.globalName&&next.userName)next.globalName=next.userName;if(!next.userName&&next.globalName)next.userName=next.globalName;if(!hasOwn(next,'myLang'))next.myLang='';else next.myLang=normalizeLangSetting(next.myLang)||'';if(hasOwn(next,'partnerLang'))next.partnerLang=normalizeLangSetting(next.partnerLang)||'';if(!next.bubblePreset)next.bubblePreset='medium';lsW(SK.prefs,JSON.stringify(next));}
+function persistPhrasebookLangSelection(){
+  var p=getPrefs();
+  var src=(document.getElementById('nc-src-lang')||{}).value||p.phrasebookSourceLang||p.myLang||'en';
+  var tgt=(document.getElementById('nc-tgt-lang')||{}).value||p.phrasebookTargetLang||p.partnerLang||'en';
+  p.phrasebookSourceLang=src;
+  p.phrasebookTargetLang=tgt;
+  savePrefs(p);
+}
+
+// ════════════════════════════════════════════════════════
+// PARTICIPANT STATE
+// ════════════════════════════════════════════════════════
+function ensureParticipantState(id){if(!id)return null;if(!state.participants[id])state.participants[id]={lastDetectedLang:'',preferredOutputLang:'',langTally:{}};return state.participants[id];}
+function setLastDetectedLang(id,lang){var ps=ensureParticipantState(id);if(ps)ps.lastDetectedLang=(lang||'').trim();}
+function setPreferredOutputLang(id,lang){var ps=ensureParticipantState(id);if(ps)ps.preferredOutputLang=(lang||'').trim();}
+function getParticipantOutputPref(id){var ps=ensureParticipantState(id);return(ps&&ps.preferredOutputLang)||'';}
+function getParticipantDetectedLang(id){var ps=ensureParticipantState(id);return(ps&&ps.lastDetectedLang)||'';}
+
+// Fix 2: Dominant language tracking — running tally per person
+function recordLangTally(participantId,lang){
+  if(!participantId||!lang)return;
+  var ps=ensureParticipantState(participantId);
+  if(!ps.langTally)ps.langTally={};
+  ps.langTally[lang]=(ps.langTally[lang]||0)+1;
+}
+function getDominantLang(participantId,fallback){
+  var ps=ensureParticipantState(participantId);
+  if(!ps||!ps.langTally)return fallback||'en';
+  var best=fallback||'en',bestCount=0;
+  Object.keys(ps.langTally).forEach(function(lang){
+    if(ps.langTally[lang]>bestCount){bestCount=ps.langTally[lang];best=lang;}
+  });
+  return best;
+}
+function getLangTallySummary(participantId){
+  var ps=ensureParticipantState(participantId);
+  if(!ps||!ps.langTally)return '';
+  return Object.keys(ps.langTally).map(function(l){return l+':'+ps.langTally[l];}).join(' ');
+}
+
+function hasOwn(obj,key){return !!(obj&&Object.prototype.hasOwnProperty.call(obj,key));}
+function normalizeLangSetting(v){
+  if(v===undefined||v===null)return undefined;
+  var t=String(v).trim().toLowerCase();
+  return t;
+}
+function normalizeAutoReplyTargetLang(v){
+  var t=normalizeLangSetting(v);
+  return t===undefined?'':t;
+}
+function getEffectiveReplyLang(sess,side,fallbackLang){
+  var s=sess?normalizeSession(sess):normalizeSession({});
+  var key=side==='partner'?'partnerEffectiveReplyLang':'ownerEffectiveReplyLang';
+  var saved=normalizeLangSetting(s[key])||'';
+  if(saved)return saved;
+  return resolveEffectiveLang(s,side,fallbackLang);
+}
+function setEffectiveReplyLang(sess,side,lang){
+  if(!sess)return;
+  var key=side==='partner'?'partnerEffectiveReplyLang':'ownerEffectiveReplyLang';
+  sess[key]=normalizeLangSetting(lang)||'';
+}
+function resolveEffectiveLang(sess,side,fallbackLang){
+  var s=sess?normalizeSession(sess):normalizeSession({});
+  var modeKey=side==='partner'?'partnerLangMode':'ownerLangMode';
+  var fixedKey=side==='partner'?'partnerFixedLang':'ownerFixedLang';
+  var lastKey=side==='partner'?'partnerLastSentLang':'ownerLastSentLang';
+  var mode=s[modeKey]==='fixed'?'fixed':'auto';
+  var fixed=normalizeLangSetting(s[fixedKey])||'';
+  var last=normalizeLangSetting(s[lastKey])||'';
+  if(mode==='fixed'&&fixed)return fixed;
+  return last||normalizeLangSetting(fallbackLang)||detectBrowserLang()||'en';
+}
+function resolveIncomingTargetLang(sess){
+  return getEffectiveReplyLang(sess,'owner','en');
+}
+function resolveTargetLang(sess){
+  return getEffectiveReplyLang(sess,'partner','en');
+}
+function shouldSkipSameLanguage(sourceLang,targetLang){return !!(sourceLang&&targetLang&&sourceLang===targetLang);}
+
+// ════════════════════════════════════════════════════════
+// IDENTITY HELPERS
+// ════════════════════════════════════════════════════════
+function isPlaceholderName(name){var v=(name||'').trim().toLowerCase();return !v||v==='new chat'||v==='partner'||v==='yournamehere';}
+function firstRealName(){for(var i=0;i<arguments.length;i++){var v=(arguments[i]||'').trim();if(v&&!isPlaceholderName(v))return v;}return '';}
+function getPreferredOwnerName(){var p=getPrefs();return firstRealName(p.globalName,p.userName)||'yournamehere';}
+function effectiveLangFromSession(sess){return getEffectiveReplyLang(sess,'owner','en');}
+function getEffectiveTargetLang(sess){return resolveTargetLang(sess);}
+
+function stampMsgNames(msg,sess){
+  var s=sess?normalizeSession(sess):normalizeSession({});
+  if(msg.from==='me'){
+    msg.displayFromName=firstRealName(s.myHandle,s.myName)||'Me';
+    msg.displayToName=firstRealName(s.partnerHandle,s.peerName)||'Partner';
+  }else if(msg.from==='them'){
+    if(!msg.displayFromName)msg.displayFromName=firstRealName(s.partnerHandle,s.peerName)||'Partner';
+    msg.displayToName=firstRealName(s.myHandle,s.myName)||'Me';
+  }
+  msg.nameVersion=1;
+}
+function stampExistingMessageNames(msgs,sess){var changed=false;(msgs||[]).forEach(function(m){if((m.from==='me'||m.from==='them')&&(!m.displayFromName||!m.displayToName||!m.nameVersion)){stampMsgNames(m,sess);changed=true;}});return changed;}
+
+function sortMessagesChronologically(msgs){
+  return (msgs||[]).map(function(msg,idx){return {msg:msg,idx:idx};}).sort(function(a,b){
+    var at=Number(a.msg&&a.msg.timestamp)||0;
+    var bt=Number(b.msg&&b.msg.timestamp)||0;
+    if(at!==bt)return at-bt;
+    return a.idx-b.idx;
+  }).map(function(entry){return entry.msg;});
+}
+
+function addSystemNote(convId,text,timestamp){
+  if(!convId)return;
+  var m={id:uid(),from:'system',text:text,timestamp:timestamp||Date.now()};
+  var msgs=(convId===state.activeConvId)?state.messages.slice():getMsgs(convId);
+  msgs.push(m);
+  msgs=sortMessagesChronologically(msgs);
+  if(convId===state.activeConvId){
+    state.messages=msgs;
+    renderAllMessages();
+  }
+  var sess=getSession(convId);if(sess){sess.lastActivity=m.timestamp;putSession(sess);}
+  saveMsgs(convId,msgs);
+}
+// ════════════════════════════════════════════════════════
+// UTILITIES
+// ════════════════════════════════════════════════════════
+var uid=function(){return Date.now().toString(36)+Math.random().toString(36).slice(2,8);};
+function toast(m){var el=document.getElementById('toast');if(!el)return;el.textContent=m;el.classList.add('show');clearTimeout(toast._t);toast._t=setTimeout(function(){el.classList.remove('show');},2600);}
+function escHtml(s){var d=document.createElement('div');d.textContent=String(s||'');return d.innerHTML;}
+function attrSafe(s){return JSON.stringify(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;');}
+function renderMd(s){if(!s)return'';return escHtml(s).replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>').replace(/\*(.+?)\*/g,'<em>$1</em>').replace(/\[([^\]]+)\]\(([^)]+)\)/g,'<a href="$2" target="_blank" rel="noopener">$1</a>');}
+function timeAgo(t){if(!t)return'';var d=Date.now()-t;if(d<60000)return'now';if(d<3600000)return Math.floor(d/60000)+'m';if(d<86400000)return Math.floor(d/3600000)+'h';return Math.floor(d/86400000)+'d';}
+function fmtTime(t){return new Date(t).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});}
+function fmtDateTime(t){if(!t)return'';return new Date(t).toLocaleString([],{year:'numeric',month:'short',day:'2-digit',hour:'2-digit',minute:'2-digit'});}
+var statusPopupState={msgId:null,anchorKey:''};
+function closeStatusPopup(){var pop=document.getElementById('status-popup');if(pop)pop.hidden=true;statusPopupState.msgId=null;statusPopupState.anchorKey='';}
+function openStatusPopup(msgId,anchorEl){
+  var msg=findMsg(msgId);
+  var deliveredEl=document.getElementById('status-popup-delivered');
+  var readEl=document.getElementById('status-popup-read');
+  var pop=document.getElementById('status-popup');
+  if(!msg||!deliveredEl||!readEl||!pop||!anchorEl)return;
+  var anchorKey=(anchorEl&&anchorEl.closest&&anchorEl.closest('.msg-row')&&anchorEl.closest('.msg-row').id)||String(msgId||'');
+  if(!pop.hidden&&statusPopupState.msgId===msgId&&statusPopupState.anchorKey===anchorKey){closeStatusPopup();return;}
+  deliveredEl.textContent='Delivered: '+(msg.deliveredAt?fmtDateTime(msg.deliveredAt):'Not delivered');
+  readEl.textContent='Read: '+(msg.readAt?fmtDateTime(msg.readAt):'Not read');
+  pop.hidden=false;
+  statusPopupState.msgId=msgId;
+  statusPopupState.anchorKey=anchorKey;
+  var r=anchorEl.getBoundingClientRect();
+  var pr=pop.getBoundingClientRect();
+  var left=r.left+(r.width/2)-(pr.width/2);
+  var top=r.bottom+8;
+  var maxLeft=window.innerWidth-pr.width-8;
+  var maxTop=window.innerHeight-pr.height-8;
+  pop.style.left=Math.max(8,Math.min(left,maxLeft))+'px';
+  pop.style.top=Math.max(8,Math.min(top,maxTop))+'px';
+}
+document.addEventListener('click',function(e){
+  var pop=document.getElementById('status-popup');
+  if(!pop||pop.hidden)return;
+  if(e.target.closest('#status-popup'))return;
+  if(e.target.closest('.msg-status-dot'))return;
+  closeStatusPopup();
+});
+function langLabel(c){return LANG_MAP[c]||c||'?';}
+function langFlag(c){var l=LANGS.find(function(x){return x.code===c;});return l?l.flag:'';}
+function findMsg(id){return state.messages.find(function(m){return m.id===id;});}
+function ensureMsgTranslations(msg){if(!msg||typeof msg!=='object')return{};if(!msg.translations||typeof msg.translations!=='object')msg.translations={};return msg.translations;}
+function setMsgTranslation(msg,targetLang,text){if(!msg||!targetLang||typeof text!=='string'||!text.trim())return false;var map=ensureMsgTranslations(msg);if(map[targetLang]===text)return false;map[targetLang]=text;return true;}
+function mergeMsgTranslations(msg,incoming){if(!msg||!incoming||typeof incoming!=='object')return false;var changed=false;Object.keys(incoming).forEach(function(lang){if(setMsgTranslation(msg,lang,incoming[lang]))changed=true;});return changed;}
+function applyMsgTarget(msg,targetLang,targetText){
+  if(!msg||!targetLang)return false;
+  var changed=false;
+  if(setMsgTranslation(msg,targetLang,targetText||''))changed=true;
+  if(msg.targetLang!==targetLang){msg.targetLang=targetLang;changed=true;}
+  var nextInfo=getMsgTranslatedText(msg,targetLang,targetText||'');
+  var next=nextInfo.text;
+  if((msg.targetText||'')!==next){msg.targetText=next;changed=true;}
+  if(targetLang===msg.sourceLang&&msg.sourceText&&!(msg.translations||{})[targetLang]){setMsgTranslation(msg,targetLang,msg.sourceText);}
+  var activeSess=getSession(state.activeConvId)||{};
+  if(msg.from==='them'&&targetLang===resolveEffectiveLang(activeSess,'owner'))msg.text=msg.targetText||msg.sourceText;
+  if(msg.from==='me'&&targetLang===resolveEffectiveLang(activeSess,'partner'))msg.translated=msg.targetText||'';
+  // Invalidate back-translate if target text changed
+  if(changed&&msg.backtranslate){
+    var newHash=btContentHash(msg.sourceText,msg.targetText);
+    if(msg.backtranslate.contentHash&&msg.backtranslate.contentHash!==newHash&&msg.backtranslate.resultText){
+      msg.backtranslate.stale=true;
+    }
+    msg.backtranslate.contentHash=newHash;
+  }
+  return changed;
+}
+function normalizeTag(s){return s.toLowerCase().replace(/\s+/g,'-').replace(/[^a-z0-9\-]/g,'').slice(0,24);}
+function detectLang(text,fb){var t=(text||'').trim();if(!t)return fb||'en';if(/[฀-๿]/.test(t))return'th';if(/[぀-ヿ]/.test(t))return'ja';if(/[一-鿿]/.test(t))return'zh';if(/[가-힯]/.test(t))return'ko';if(/[؀-ۿ]/.test(t))return'ar';return fb||'en';}
+function fallbackCopy(t){var ta=document.createElement('textarea');ta.value=t;ta.style.cssText='position:fixed;left:-9999px;';document.body.appendChild(ta);ta.select();try{document.execCommand('copy');toast('Copied');}catch(e){}document.body.removeChild(ta);}
+function scrollBottom(){var c=document.getElementById('messages');if(c)c.scrollTop=c.scrollHeight;}
+function populateLangSelect(id,def){var sel=document.getElementById(id);if(!sel)return;sel.innerHTML='';LANGS.forEach(function(l){var o=document.createElement('option');o.value=l.code;o.textContent=l.label;if(l.code===def)o.selected=true;sel.appendChild(o);});}
+function populateLangSelectCompact(id,def){var sel=document.getElementById(id);if(!sel)return;sel.innerHTML='';LANGS.forEach(function(l){var o=document.createElement('option');o.value=l.code;o.textContent=l.flag+' '+l.code;if(l.code===def)o.selected=true;sel.appendChild(o);});}
+function sanitizeTagList(tags){var out=[];(tags||[]).forEach(function(t){var n=normalizeTag(t||'');if(n&&out.indexOf(n)<0)out.push(n);});return out;}
+function clonePlain(obj){return JSON.parse(JSON.stringify(obj||{}));}
+function ncVerdictLabel(val){if(val==='good')return'Sounds right';if(val==='partial')return'Needs review';if(val==='flag')return'Flagged';return'None';}
+function ncVerdictClass(val){if(val==='good')return'good';if(val==='flag')return'bad';return'good';}
+function setNcBacktranslate(next){
+  state.ncBacktranslate=normalizeBacktranslatePayload(next,{
+    sourceLang:(document.getElementById('nc-tgt-lang')||{}).value||'en',
+    targetLang:(document.getElementById('nc-src-lang')||{}).value||'en',
+    inputText:(document.getElementById('nc-target')||{}).textContent||'',
+    resultText:'',
+    verdict:'',
+    contentHash:btContentHash((document.getElementById('nc-source')||{}).textContent||'',(document.getElementById('nc-target')||{}).textContent||''),
+    updatedAt:Date.now()
+  });
+  updateNcVerdictUI();
+}
+function updateNcVerdictUI(){
+  var btn=document.getElementById('nc-verdict-btn');
+  if(!btn)return;
+  var verdict=(state.ncBacktranslate&&state.ncBacktranslate.verdict)||'';
+  btn.textContent='Verdict: '+ncVerdictLabel(verdict);
+  btn.className='bbl-vbtn '+ncVerdictClass(verdict);
+}
+function cycleNcVerdict(){
+  if(!state.ncBacktranslate)setNcBacktranslate({});
+  var order=['','good','partial','flag'];
+  var current=(state.ncBacktranslate&&state.ncBacktranslate.verdict)||'';
+  var idx=order.indexOf(current);
+  state.ncBacktranslate.verdict=order[(idx+1)%order.length];
+  state.ncBacktranslate.updatedAt=Date.now();
+  updateNcVerdictUI();
+}
+function safeTranslateText(text,from,to){
+  var value=String(text||'').trim();
+  if(!value)return Promise.resolve('');
+  if(!from||!to||from===to)return Promise.resolve(value);
+  return translate(value,from,to).then(function(out){return(out||value).trim()||value;}).catch(function(){return value;});
+}
+function cloneCatalogForSwap(cat){
+  var copy=Object.assign({},clonePlain(cat),{
+    id:'swap-'+uid(),
+    name:(cat&&cat.name?cat.name:'Phrasebook')+' ↔',
+    desc:(cat&&cat.desc?cat.desc+' · ':'')+'Swapped source/target copy',
+    createdAt:Date.now()
+  });
+  return copy;
+}
+async function buildSwappedPhrasebook(cards){
+  var normalized=(cards||[]).map(normalizeCard);
+  var allCatalogs=getCatalogs();
+  var catalogMap={};
+  var swappedTags=[];
+  var swappedCards=await Promise.all(normalized.map(async function(card){
+    var srcLang=card.sourceLang||'en';
+    var tgtLang=card.targetLang||srcLang||'en';
+    var nextCatalogIds=(card.catalogIds||[]).map(function(catId){
+      if(!catId)return '';
+      if(!catalogMap[catId]){
+        var found=allCatalogs.find(function(cat){return cat&&cat.id===catId;});
+        catalogMap[catId]=cloneCatalogForSwap(found||{name:'Phrasebook'});
+      }
+      return catalogMap[catId].id;
+    }).filter(Boolean);
+    var translatedTags=await Promise.all((card.tags||[]).map(function(tag){return safeTranslateText(tag,srcLang,tgtLang).then(function(out){return normalizeTag(out)||normalizeTag(tag);});}));
+    translatedTags=translatedTags.filter(Boolean);
+    translatedTags.forEach(function(tag){if(swappedTags.indexOf(tag)<0)swappedTags.push(tag);});
+    var clarifyChain=await Promise.all((card.clarifyChain||[]).map(async function(item){
+      return {
+        text:await safeTranslateText(item&&item.text||'',srcLang,tgtLang),
+        author:item&&item.author||'Partner',
+        timestamp:item&&item.timestamp||Date.now()
+      };
+    }));
+    var notes=await safeTranslateText(card.notes||'',srcLang,tgtLang);
+    var backResult=card.target||await safeTranslateText(card.source||'',srcLang,tgtLang);
+    return normalizeCard({
+      id:'swap-'+uid(),
+      catalogIds:nextCatalogIds,
+      sourceLang:tgtLang,
+      targetLang:srcLang,
+      source:card.target||card.source||'',
+      target:card.source||'',
+      notes:notes,
+      tags:translatedTags,
+      backtranslate:{
+        sourceLang:srcLang,
+        targetLang:tgtLang,
+        inputText:card.source||'',
+        resultText:backResult,
+        verdict:(card.backtranslate&&card.backtranslate.verdict)||'',
+        contentHash:btContentHash(card.target||card.source||'',card.source||''),
+        updatedAt:Date.now()
+      },
+      clarifyChain:clarifyChain,
+      savedBy:(getPrefs().userName||'Me')+' · swapped export',
+      createdAt:Date.now(),
+      updatedAt:Date.now()
+    });
+  }));
+  return {
+    type:'phrasebook',
+    mode:'swapped',
+    cards:swappedCards,
+    catalogs:Object.keys(catalogMap).map(function(id){return catalogMap[id];}),
+    tags:swappedTags,
+    exportedAt:Date.now()
+  };
+}
+
+
+// ════════════════════════════════════════════════════════
+// TRANSPORT — talk-signal relay (hibernation-based)
+// Single responsibility: connect, send, receive, reconnect.
+// hello is sent as transient=true so relay never stores it.
+// Heartbeat runs even when page is hidden to keep DO alive.
+// On visibility return after >20s, force-reconnect instead
+// of trusting a potentially dead socket.
+// ════════════════════════════════════════════════════════
+
+var RELAY_BASE    = 'talk-signal.myacctfortracking.workers.dev/signal';
+var RELAY_WS_URL  = 'wss://'  + RELAY_BASE;
+var RELAY_HTTP_URL= 'https://' + RELAY_BASE;
+var RELAY_APP     = 'talk-say-v1';
+
+var ws              = null;
+var connectedConvId = null;
+var socketState     = 'closed';
+var intentionalClose= false;
+var rcTimer         = null;
+var rcAttempts      = 0;
+var hbTimer         = null;
+var lastPongAt      = 0;
+var lastRxAt        = 0;
+var _hiddenAt       = 0;
+
+var outQ            = [];
+var pendingAcks     = {};
+var lastRelaySeq    = 0;
+var msgSeq          = 0;
+var inboundSeen     = {};
+
+var roomRuntimeByConv  = {};
+var transportHandlers  = [];
+
+var HEARTBEAT_MS      = 30000;
+var PING_TIMEOUT_MS   = 120000;
+var RECONNECT_BASE_MS = 1200;
+var RECONNECT_MAX_MS  = 180000;
+var RECONNECT_JITTER  = 0.3;
+var DEDUP_TTL_MS      = 12000;
+var MSG_TTL_MS        = 120000;
+var MAX_QUEUE         = 40;
+var MAX_RETRY         = 8;
+
+// ── Room runtime ──────────────────────────────────────────
+function getRoomRuntime(convId) {
+  if (!convId) return null;
+  if (!roomRuntimeByConv[convId]) roomRuntimeByConv[convId] = {
+    selfPresent:false,peerPresent:false,peerEverSeen:false,
+    peerLastSeenAt:0,localJoinNoted:false,peerJoinNoted:false,
+    peerLeftNoted:false,connectedOnce:false,lastHistorySyncSentAt:0,joinEventKeys:{}
+  };
+  return roomRuntimeByConv[convId];
+}
+function noteRuntimeJoin(convId,key,text,ts,dedupeKey){
+  var rt=getRoomRuntime(convId);if(!rt||!text)return;
+  if(key==='localJoin'){if(rt.localJoinNoted)return;rt.localJoinNoted=true;}
+  else if(key==='peerJoin'){if(rt.peerJoinNoted)return;rt.peerJoinNoted=true;rt.peerLeftNoted=false;}
+  else if(key==='peerLeft'){if(rt.peerLeftNoted)return;rt.peerLeftNoted=true;}
+  var now=ts||Date.now();
+  var stableKey=String(dedupeKey||key||'join');
+  if(rt.joinEventKeys&&rt.joinEventKeys[stableKey])return;
+  rt.joinEventKeys[stableKey]=now;
+  addSystemNote(convId,text,now);
+}
+function markPeerSeen(convId,ts,opts){
+  var rt=getRoomRuntime(convId);opts=opts||{};
+  if(!rt||opts.fromBackfill)return;
+  var stamp=ts||Date.now();var wasPresent=rt.peerPresent;
+  rt.peerLastSeenAt=stamp;rt.peerEverSeen=true;rt.peerPresent=true;
+  var sess=getSession(convId);
+  if(sess){
+    sess.peerLastSeenAt=stamp;
+    putSession(sess);
+  }
+  if(!wasPresent&&!opts.suppressJoinNote){
+    var partnerName=firstRealName(sess&&sess.partnerHandle,sess&&sess.peerName);
+    if(partnerName)noteRuntimeJoin(convId,'peerJoin',partnerName+' has joined · '+fmtDateTime(stamp),stamp,'peerJoin:'+String(sess&&sess.partnerIdentityId||partnerName));
+  }
+  updateDot();
+  renderMediaShareUI();
+}
+function markPeerLeft(convId,ts){
+  var rt=getRoomRuntime(convId);if(!rt||!rt.peerPresent)return;
+  rt.peerPresent=false;
+  rt.peerJoinNoted=false;
+  Object.keys(rt.joinEventKeys||{}).forEach(function(k){if(k.indexOf('peerJoin:')===0)delete rt.joinEventKeys[k];});
+  noteRuntimeJoin(convId,'peerLeft','Partner left',ts||Date.now());
+  updateDot();
+}
+function peerIsFresh(){
+  var rt=getRoomRuntime(state.activeConvId||connectedConvId);
+  return !!(rt&&rt.peerPresent&&rt.peerLastSeenAt&&(Date.now()-rt.peerLastSeenAt)<30000);
+}
+function resetActivePresence(convId){
+  var rt=getRoomRuntime(convId);
+  if(rt&&convId){
+    var sess=getSession(convId);
+    var initiator=firstRealName(sess&&sess.myHandle,sess&&sess.myName,getPreferredOwnerName())||'yournamehere';
+    if(!rt.selfPresent)noteRuntimeJoin(convId,'localJoin',initiator+' has joined · '+fmtDateTime(Date.now()),Date.now(),'localJoin:'+String(sess&&sess.ownerIdentityId||initiator));
+    rt.selfPresent=true;
+  }else if(rt){rt.selfPresent=false;}
+  updateDot();
+}
+function fmtPresenceTime(ts){return ts?fmtDateTime(ts):'Not seen yet';}
+function refreshInviteStatus(convId){
+  var cid=convId||state.activeConvId;
+  var el=cid&&document.getElementById('invite-status-'+cid);
+  var rt=getRoomRuntime(cid);var sess=cid&&getSession(cid);
+  if(!el||!rt)return;
+  el.style.color='var(--ink-dim)';
+  if(!rt.peerEverSeen){el.textContent='Waiting for partner';return;}
+  if(rt.peerPresent){el.textContent=getSessionLabel(sess)+' connected \u2713';el.style.color='var(--green)';return;}
+  el.textContent='Partner last seen '+fmtPresenceTime(rt.peerLastSeenAt);
+}
+function updatePresenceIndicators(){
+  var cid=state.activeConvId||connectedConvId;
+  var rt=getRoomRuntime(cid);var sess=cid?getSession(cid):null;
+  var selfEl=document.getElementById('shell-self-name');
+  var selfLbl=selfEl&&selfEl.querySelector('.shell-participant-label');
+  var peerEl=document.getElementById('shell-peer-name');
+  var peerLbl=peerEl&&peerEl.querySelector('.shell-participant-label');
+  var arrowEl=document.getElementById('shell-partner-arrow');
+  var s=sess?normalizeSession(sess):normalizeSession({});
+  var myName=firstRealName(s.myHandle,s.myName);var peerName=firstRealName(s.partnerHandle,s.peerName);
+  if(selfEl){selfEl.classList.toggle('online',!!(rt&&rt.selfPresent));selfEl.title=(rt&&rt.selfPresent)?'You are attached':'Not attached';}
+  if(peerEl){peerEl.classList.toggle('online',!!(rt&&rt.peerPresent));peerEl.title=(rt&&rt.peerPresent)?'Present now':((rt&&rt.peerEverSeen)?('Last seen '+fmtPresenceTime(rt.peerLastSeenAt)):'Not seen yet');}
+  if(selfLbl&&document.activeElement!==selfEl)selfLbl.textContent=myName||(!peerName?'new chat':'');
+  if(peerLbl)peerLbl.textContent=peerName||'?';
+  if(arrowEl)arrowEl.hidden=!(myName&&peerEl&&!peerEl.hidden);
+  refreshInviteStatus(cid);
+}
+function refreshActiveSessionChrome(convId){
+  var cid=convId||state.activeConvId;var sess=cid?getSession(cid):null;
+  updatePartnerHeader(sess);updateDot();refreshInviteStatus(cid);
+}
+function setSocketState(s){
+  socketState=s;var rt=getRoomRuntime(state.activeConvId||connectedConvId);
+  if(rt)rt.selfPresent=(s==='open');updateDot();
+}
+
+// ── Dedup ─────────────────────────────────────────────────
+function shouldDrop(d){
+  if(!d||!d.id)return false;
+  if(['msg','tr','clarify-note'].indexOf(d.type)<0)return false;
+  var now=Date.now();var key=d.type+'::'+d.id+'::'+String(d.from||'')+'::'+String(d.identityId||d.participant||'');
+  if(inboundSeen[key]&&inboundSeen[key]>now)return true;
+  inboundSeen[key]=now+DEDUP_TTL_MS;
+  if(Math.random()<0.05){Object.keys(inboundSeen).forEach(function(k){if(inboundSeen[k]<=now)delete inboundSeen[k];});}
+  return false;
+}
+
+// ── Queue ─────────────────────────────────────────────────
+function pruneOutQueue(){
+  var now=Date.now();
+  outQ=outQ.filter(function(e){return e&&e.ts&&(now-e.ts)<MSG_TTL_MS;});
+  if(outQ.length>MAX_QUEUE)outQ=outQ.slice(-MAX_QUEUE);
+}
+function queueOutMsg(msg){
+  if(msg&&msg.id){for(var i=0;i<outQ.length;i++){if(outQ[i]&&outQ[i].msg&&outQ[i].msg.id===msg.id)return;}}
+  outQ.push({msg:msg,ts:Date.now()});pruneOutQueue();
+}
+function flushOutQueue(){
+  if(!ws||ws.readyState!==1)return;
+  pruneOutQueue();var q=outQ.slice();outQ=[];
+  q.forEach(function(e){try{ws.send(JSON.stringify(e.msg));if(e.msg.id)pendingAcks[e.msg.id]=e.msg;}catch(_){outQ.push(e);}});
+}
+function resendUnacked(){
+  if(!ws||ws.readyState!==1)return;
+  var unacked=Object.keys(pendingAcks).map(function(id){return pendingAcks[id];}).filter(Boolean);
+  if(!unacked.length)return;
+  addDiagLog('RESEND unacked: '+unacked.length);
+  unacked.slice(0,MAX_RETRY).forEach(function(msg){try{ws.send(JSON.stringify(msg));}catch(_){}});
+}
+function clearAck(id){delete pendingAcks[id];}
+
+// ── Heartbeat ─────────────────────────────────────────────
+function startHeartbeatLoop(){
+  if(hbTimer)clearInterval(hbTimer);
+  lastRxAt=lastPongAt=Date.now();
+  hbTimer=setInterval(function(){
+    if(!ws||ws.readyState!==1)return;
+    var now=Date.now();
+    var lastAct=Math.max(lastPongAt||0,lastRxAt||0);
+    if(lastAct&&(now-lastAct)>PING_TIMEOUT_MS){
+      addDiagLog('HEARTBEAT timeout — reconnecting');
+      ws.close(4002,'ping-timeout');return;
+    }
+    try{ws.send(JSON.stringify({type:'ping',session:connectedConvId,from:DEVICE_ID,ts:now,transient:true}));}catch(_){}
+  },HEARTBEAT_MS);
+}
+function stopHeartbeatLoop(){if(hbTimer){clearInterval(hbTimer);hbTimer=null;}}
+
+// ── Backfill ──────────────────────────────────────────────
+function fetchBackfill(){
+  if(!connectedConvId)return;
+  var since=lastRelaySeq;
+  var url=RELAY_HTTP_URL
+    +'?app='+encodeURIComponent(RELAY_APP)
+    +'&session='+encodeURIComponent(connectedConvId)
+    +'&client='+encodeURIComponent(DEVICE_ID)
+    +'&since='+since;
+  fetch(url).then(function(r){return r.json();}).then(function(msgs){
+    if(!Array.isArray(msgs)||!msgs.length)return;
+    var existing={};state.messages.forEach(function(m){if(m.id)existing[m.id]=true;});
+    var fresh=msgs.filter(function(m){return!m.id||!existing[m.id];});
+    addDiagLog('BACKFILL: '+fresh.length+' new of '+msgs.length+' fetched since seq='+since);
+    fresh.forEach(function(m){
+      var seq=Number(m.seq);if(Number.isFinite(seq)&&seq>lastRelaySeq)lastRelaySeq=seq;
+      transportHandlers.forEach(function(h){h(Object.assign({_fromBackfill:true},m));});
+    });
+  }).catch(function(e){addDiagLog('BACKFILL failed: '+String(e),'warn');});
+}
+
+// ── Connect ───────────────────────────────────────────────
+function transportConnect(convId,opts){
+  opts=opts||{};
+  if(connectedConvId===convId&&ws&&ws.readyState<=1)return;
+  if(ws){intentionalClose=true;try{ws.close();}catch(_){}ws=null;}
+  if(rcTimer){clearTimeout(rcTimer);rcTimer=null;}
+  stopHeartbeatLoop();
+  if(!opts.preserveQueue){outQ=[];pendingAcks={};}
+  if(connectedConvId!==convId)lastRelaySeq=0;connectedConvId=convId;intentionalClose=false;rcAttempts=0;
+  var url=RELAY_WS_URL
+    +'?app='+encodeURIComponent(RELAY_APP)
+    +'&session='+encodeURIComponent(convId)
+    +'&client='+encodeURIComponent(DEVICE_ID);
+  setSocketState('connecting');
+  addDiagLog('CONNECTED session='+convId.slice(0,8));
+  try{ws=new WebSocket(url);}catch(e){scheduleReconnect();return;}
+  var ref=ws;
+  var ct=setTimeout(function(){if(ws===ref&&ws.readyState===0)ws.close(4001,'connect-timeout');},8000);
+  ws.onopen=function(){
+    if(ws!==ref)return;clearTimeout(ct);
+    if(rcTimer){clearTimeout(rcTimer);rcTimer=null;}
+    setSocketState('open');lastRxAt=lastPongAt=Date.now();
+    var rt=getRoomRuntime(connectedConvId);
+    if(rt){rt.selfPresent=true;if(rt.connectedOnce)addDiagLog('RECONNECTED (silent)');rt.connectedOnce=true;}
+    startHeartbeatLoop();
+    var sess=getSession(connectedConvId);
+    var hello={type:'hello',transient:true,session:connectedConvId,from:DEVICE_ID,participant:PART_ID,
+      name:firstRealName(sess&&sess.myHandle,sess&&sess.myName,getPreferredOwnerName())||'yournamehere',
+      myHandle:firstRealName(sess&&sess.myHandle,sess&&sess.myName,getPreferredOwnerName())||'yournamehere',
+      lang:effectiveLangFromSession(sess),effectiveTargetLang:getEffectiveTargetLang(sess),side:'owner',identityId:sess&&sess.ownerIdentityId,ts:Date.now(),seq:++msgSeq};
+    addDiagLog('TX hello name='+hello.name+' lang='+hello.lang);
+    try{ws.send(JSON.stringify(hello));}catch(_){}
+    fetchBackfill();
+    flushOutQueue();
+    resendUnacked();
+  };
+  ws.onmessage=function(e){
+    if(ws!==ref)return;lastRxAt=Date.now();
+    try{
+      var m=JSON.parse(e.data);
+      if(m.type==='ping'){
+        lastPongAt=Date.now();markPeerSeen(connectedConvId,Date.now(),{suppressJoinNote:true});
+        try{ws.send(JSON.stringify({type:'pong',session:connectedConvId,from:DEVICE_ID,ts:Date.now(),transient:true}));}catch(_){}
+        return;
+      }
+      if(m.type==='pong'){lastPongAt=Date.now();markPeerSeen(connectedConvId,Date.now(),{suppressJoinNote:true});return;}
+      var seq=Number(m.seq);if(Number.isFinite(seq)&&seq>lastRelaySeq)lastRelaySeq=seq;
+      transportHandlers.forEach(function(h){h(m);});
+    }catch(_){}
+  };
+  ws.onclose=function(ev){
+    if(ws!==ref)return;ws=null;stopHeartbeatLoop();clearTimeout(ct);
+    addDiagLog('DISCONNECTED code='+ev.code+(intentionalClose?' (intentional)':''));
+    if(intentionalClose){setSocketState('closed');return;}
+    var rt=getRoomRuntime(connectedConvId);if(rt)rt.selfPresent=false;
+    setSocketState('reconnecting');scheduleReconnect();
+  };
+  ws.onerror=function(){if(ws===ref&&ws)ws.close();};
+}
+
+function scheduleReconnect(){
+  if(rcTimer||!connectedConvId)return;
+  rcAttempts++;
+  var jitter=1+(Math.random()*2-1)*RECONNECT_JITTER;
+  var delay=Math.round(Math.min(RECONNECT_MAX_MS,RECONNECT_BASE_MS*Math.pow(2,rcAttempts-1))*jitter);
+  if(rcAttempts===1)delay=Math.round(Math.random()*300);
+  addDiagLog('RECONNECT in '+delay+'ms attempt='+rcAttempts);
+  var target=connectedConvId;
+  rcTimer=setTimeout(function(){
+    rcTimer=null;if(state.activeConvId!==target)return;
+    intentionalClose=false;transportConnect(target,{preserveQueue:true});
+  },delay);
+}
+
+function transportDisconnect(opts){
+  opts=opts||{};intentionalClose=true;
+  if(ws){try{ws.close();}catch(_){}ws=null;}
+  if(rcTimer){clearTimeout(rcTimer);rcTimer=null;}
+  stopHeartbeatLoop();
+  if(!opts.preserveQueue){outQ=[];pendingAcks={};}
+  var prev=connectedConvId;connectedConvId=null;
+  var rt=getRoomRuntime(prev);if(rt)rt.selfPresent=false;
+  setSocketState('closed');
+}
+
+function transportSend(ev){
+  if(!connectedConvId)return false;
+  var isEphemeral=['ping','pong','typing','reattach','hello','ack'].indexOf(ev.type)>=0||ev.transient===true;
+  var sess=getSession(connectedConvId)||{};
+  var m=Object.assign({},ev,{session:connectedConvId,from:DEVICE_ID,participant:PART_ID,side:(ev&&ev.side)||'owner',identityId:(ev&&ev.identityId)||sess.ownerIdentityId||PART_ID,ts:Date.now(),seq:++msgSeq});
+  if(ws&&ws.readyState===1){try{ws.send(JSON.stringify(m));return true;}catch(_){}}
+  if(!isEphemeral)queueOutMsg(m);
+  return false;
+}
+
+function sendReliable(ev){
+  var sess=getSession(connectedConvId)||{};
+  var m=Object.assign({},ev,{session:connectedConvId,from:DEVICE_ID,participant:PART_ID,side:(ev&&ev.side)||'owner',identityId:(ev&&ev.identityId)||sess.ownerIdentityId||PART_ID,ts:Date.now(),seq:++msgSeq});
+  if(ws&&ws.readyState===1){try{ws.send(JSON.stringify(m));if(m.id)pendingAcks[m.id]=m;return true;}catch(_){}}
+  queueOutMsg(m);return false;
+}
+
+function markMessageDeliveryState(convId,msgId,status,stamp){
+  if(!convId||!msgId)return;
+  var msgs=(convId===state.activeConvId)?state.messages:getMsgs(convId);
+  var changed=false;
+  var at=stamp||Date.now();
+  for(var i=0;i<msgs.length;i++){
+    if(msgs[i]&&msgs[i].id===msgId){
+      msgs[i].status=status;
+      if(status==='delivered')msgs[i].deliveredAt=at;
+      if(status==='translated')msgs[i].readAt=at;
+      changed=true;break;
+    }
+  }
+  if(!changed)return;
+  saveMsgs(convId,msgs);
+  if(convId===state.activeConvId){
+    var live=findMsg(msgId);
+    if(live)updateMessageStatusUI(live);
+  }
+}
+
+// ── Visibility / focus ────────────────────────────────────
+document.addEventListener('visibilitychange',function(){
+  if(document.hidden){_hiddenAt=Date.now();/* heartbeat keeps running */return;}
+  var hiddenMs=Date.now()-(_hiddenAt||0);
+  if(state.activeConvId){
+    if(hiddenMs>20000||!ws||ws.readyState!==1){
+      addDiagLog('VISIBILITY return after '+Math.round(hiddenMs/1000)+'s — reconnecting');
+      rcAttempts=0;transportConnect(state.activeConvId,{preserveQueue:true});
+    }else{fetchBackfill();}
+  }
+});
+window.addEventListener('focus',function(){
+  var hiddenMs=_hiddenAt?Date.now()-_hiddenAt:0;
+  if(state.activeConvId){
+    if(hiddenMs>20000||!ws||ws.readyState!==1){addDiagLog('FOCUS return — reconnecting');rcAttempts=0;transportConnect(state.activeConvId,{preserveQueue:true});}
+    else{fetchBackfill();}
+  }
+});
+window.addEventListener('online',function(){if(state.activeConvId&&(!ws||ws.readyState!==1)){rcAttempts=0;transportConnect(state.activeConvId,{preserveQueue:true});}});
+window.addEventListener('offline',function(){transportDisconnect({preserveQueue:true});});
+
+// ── Force reconnect (dot click) ───────────────────────────
+function forceReconnect(){
+  if(!state.activeConvId){toast('No active session');return;}
+  addDiagLog('forceReconnect: '+state.activeConvId.slice(0,8));
+  rcAttempts=0;transportDisconnect({preserveQueue:true});
+  transportConnect(state.activeConvId,{preserveQueue:true});toast('Reconnecting\u2026');
+}
+
+// ── Dot indicator (element removed; keep function for call sites) ──────────
+function updateDot(){updatePresenceIndicators();}
+
+function onTransportEvent(h){transportHandlers.push(h);}
+
+// updateDot defined in transport block above
+
+// ════════════════════════════════════════════════════════
+// NAVIGATION
+// ════════════════════════════════════════════════════════
+function showScreen(id){document.querySelectorAll('.screen').forEach(function(s){s.classList.remove('active');});var el=document.getElementById(id);if(el)el.classList.add('active');}
+
+// ════════════════════════════════════════════════════════
+// LEFT PANEL
+// ════════════════════════════════════════════════════════
+function openLeftPanel(){document.getElementById('left-panel').classList.add('open');document.getElementById('left-scrim').classList.add('show');renderSessionList();}
+function closeLeftPanel(){document.getElementById('left-panel').classList.remove('open');document.getElementById('left-scrim').classList.remove('show');closeSettings();}
+function openControlPanel(){openLeftPanel();toggleSettingsDrawer();}
+function closeControlPanel(){closeSettings();}
+function saveLocalName(el){
+  var prev=getPrefs().userName||'yournamehere';
+  var v=(el.textContent||'').trim();
+  if(!v){el.textContent=prev;return;}
+  var p=getPrefs();p.userName=v;savePrefs(p);
+  el.textContent=v;
+  // Propagate to all sessions
+  var sess=state.activeConvId&&getSession(state.activeConvId);
+  if(sess){sess.myHandle=v;sess.myName=v;putSession(sess);}
+  // Resend hello if connected so partner sees the new name immediately
+  if(connectedConvId&&ws&&ws.readyState===1){
+    var sess=getSession(connectedConvId);
+    var helloMsg={type:'hello',transient:true,session:connectedConvId,from:DEVICE_ID,participant:PART_ID,side:'owner',identityId:sess&&sess.ownerIdentityId,
+      name:v,myHandle:v,lang:effectiveLangFromSession(sess),effectiveTargetLang:getEffectiveTargetLang(sess),ts:Date.now(),seq:++msgSeq};
+    try{ws.send(JSON.stringify(helloMsg));}catch(_){}
+  }
+  toast('Name saved');
+}
+
+// ── Language picker ────────────────────────────────────────
+function detectBrowserLang(){
+  var raw=(navigator.language||'').toLowerCase();
+  var code=raw.split('-')[0];
+  var known=LANGS.find(function(l){return l.code===code;});
+  return known?known.code:null;
+}
+function getLangEntry(code){
+  return LANGS.find(function(l){return l.code===code;})||LANGS[0];
+}
+function getLangLabel(code){
+  if(!code)return'Auto';
+  return getLangEntry(code).label;
+}
+function updateLangPill(){
+  var myLang=getPrefs().myLang||'';
+  var ribbonBtn=document.getElementById('ribbon-lang-btn');
+  if(ribbonBtn)ribbonBtn.textContent=myLang?(getLangEntry(myLang).flag||'🌐'):'🌐';
+}
+function renderLanguageSheet(){
+  var host=document.getElementById('language-sheet-options');if(!host)return;
+  var cur=getPrefs().myLang||'';
+  var rows=['<button class="lsd-row lsd-row-link" style="width:100%;border:none;background:none;text-align:left;" onclick="setMyLang(\'\')"><span class="lsd-label">🌐 Auto-detect</span><span class="lsd-ctrl">'+(cur===''?'✓':'')+'</span></button>'];
+  LANGS.forEach(function(l){rows.push('<button class="lsd-row lsd-row-link" style="width:100%;border:none;background:none;text-align:left;" onclick="setMyLang(\''+l.code+'\')"><span class="lsd-label">'+l.flag+' '+escHtml(l.label)+'</span><span class="lsd-ctrl">'+(l.code===cur?'✓':'')+'</span></button>');});
+  host.innerHTML=rows.join('');
+}
+function toggleLangPicker(e){
+  if(e)e.stopPropagation();
+  openLanguagePanel();
+}
+function openLanguagePanel(){
+  renderLanguageSheet();
+  var ov=document.getElementById('language-overlay');
+  if(ov)ov.hidden=false;
+}
+function setMyLang(code){
+  var p=getPrefs();p.myLang=code;p._langDetected=true;savePrefs(p);
+  var actor=getPreferredOwnerName()||'User';
+  var all=getAllSessions();
+  all.forEach(function(s){
+    var prev=resolveEffectiveLang(s,'owner');
+    if(prev!==code){
+      s.ownerLangMode=code?'fixed':'auto';
+      s.ownerFixedLang=code||'';
+      if(code)setEffectiveReplyLang(s,'owner',code);
+      putSession(s);
+      addSystemNote(s.convId,actor+' switched from '+getLangLabel(prev)+' to '+getLangLabel(code),Date.now());
+    }
+  });
+  updateLangPill();
+  renderLanguageSheet();
+  var ov=document.getElementById('language-overlay');if(ov)ov.hidden=true;
+  var effectiveLang=code||detectBrowserLang()||'en';
+  if(connectedConvId&&ws&&ws.readyState===1){
+    var sess=getSession(connectedConvId);
+    var hello={type:'hello',transient:true,session:connectedConvId,from:DEVICE_ID,participant:PART_ID,
+      name:firstRealName(sess&&sess.myHandle,sess&&sess.myName,getPreferredOwnerName())||'yournamehere',
+      myHandle:firstRealName(sess&&sess.myHandle,sess&&sess.myName,getPreferredOwnerName())||'yournamehere',
+      lang:effectiveLang,effectiveTargetLang:getEffectiveTargetLang(sess),side:'owner',identityId:sess&&sess.ownerIdentityId,ts:Date.now(),seq:++msgSeq};
+    try{ws.send(JSON.stringify(hello));}catch(_){}
+  }
+  if(!code){toast('🌐 Language set to Auto-detect');}
+  else{toast(getLangEntry(code).flag+' Language set to '+getLangEntry(code).label);}
+}
+
+function openOnboardingModal(onDone){
+  pendingOnboardingFlow=onDone||null;
+  var p=getPrefs();
+  var modal=document.getElementById('onboarding-modal');
+  var input=document.getElementById('onboarding-name');
+  var err=document.getElementById('onboarding-error');
+  if(err)err.textContent='';
+  if(input)input.value=firstRealName(p.globalName,p.userName)||'';
+  if(modal)modal.hidden=false;
+  setTimeout(function(){if(input)input.focus();},30);
+}
+function submitOnboardingName(){
+  var input=document.getElementById('onboarding-name');
+  var err=document.getElementById('onboarding-error');
+  var name=(input&&input.value||'').trim();
+  if(!name){if(err)err.textContent='Please enter your name to continue.';return;}
+  var p=getPrefs();p.globalName=name;p.userName=name;savePrefs(p);
+  var modal=document.getElementById('onboarding-modal');
+  if(modal)modal.hidden=true;
+  if(err)err.textContent='';
+  var resume=pendingOnboardingFlow;pendingOnboardingFlow=null;
+  if(typeof resume==='function')resume(name);
+}
+function ensureUserName(callback){
+  var p=getPrefs();
+  var existing=firstRealName(p.globalName,p.userName);
+  if(existing){if(callback)callback(existing);return true;}
+  openOnboardingModal(function(name){if(callback)callback(name);});
+  return false;
+}
+function createNewSession(silent){
+  ensureUserName(function(name){
+    var cid=uid();var p=getPrefs();var now=Date.now();
+    var sess=normalizeSession({convId:cid,myHandle:name,myName:name,partnerHandle:'',peerName:'',ownerLangMode:(p.myLang?'fixed':'auto'),ownerFixedLang:p.myLang||'',createdAt:now,lastActivity:now,lastViewedAt:now});
+    putSession(sess);
+    var order=getSessionOrder();order.unshift(cid);saveSessionOrder(normalizeSessionOrder(order));
+    closeLeftPanel();
+    openInviteScreen(cid);
+  });
+}
+
+function openInviteScreen(cid){
+  var sess=getSession(cid);if(!sess)return;
+  state.pendingInviteId=cid;
+  if(connectedConvId&&connectedConvId!==cid){
+    addDiagLog('openInviteScreen: disconnecting from '+connectedConvId.slice(0,8));
+    transportDisconnect({preserveQueue:false});
+  }
+  state.activeConvId=cid;
+  state.messages=getMsgs(cid);
+  setActiveConvId(cid);markViewed(cid);
+  // Add invite system message if not already present
+  addInviteMessage(cid);
+  document.getElementById('shell-empty').style.display='none';
+  document.getElementById('messages').style.display='flex';
+  document.getElementById('composer').style.display='flex';
+  updatePartnerHeader(sess);
+  updateAutoReadBtn();
+  resetActivePresence(cid);
+  transportConnect(cid);
+  renderAllMessages();
+  scrollBottom();
+  showScreen('chat-screen');
+  refreshActiveSessionChrome(cid);
+  renderSessionList();
+  addDiagLog('Session created: '+cid.slice(0,8));
+}
+
+function addInviteMessage(cid){
+  var sess=getSession(cid)||{};
+  var url=buildInviteUrl(sess,getPrefs(),'partner-invite');
+  var existing=state.messages.find(function(m){return m.from==='invite'&&m.convId===cid;});
+  if(existing){
+    if(existing.inviteUrl!==url){
+      existing.inviteUrl=url;
+      saveMsgs(cid,state.messages);
+    }
+    return;
+  }
+  var msg={id:'inv-'+cid,from:'invite',convId:cid,inviteUrl:url,text:'Session created',timestamp:Date.now()};
+  state.messages.push(msg);
+  saveMsgs(cid,state.messages);
+}
+
+function injectInviteCard(cid){/* Now handled by addInviteMessage + renderInviteCard */}
+function copyTextToClipboard(text){
+  if(navigator.clipboard&&navigator.clipboard.writeText)navigator.clipboard.writeText(text).then(function(){toast('Link copied');});
+  else{fallbackCopy(text);}
+}
+
+// drawQR replaced by injectInviteCard
+
+function closeInviteScreen(){
+  // No longer a separate screen — nothing to close
+  state.pendingInviteId=null;
+  showScreen('chat-screen');
+}
+// copyInviteLink / nativeShareInvite removed (invite card uses DOM event listeners)
+function resendInvite(){
+  if(state.pendingInviteId&&connectedConvId){var sess=getSession(state.pendingInviteId);if(sess)transportSend({type:'hello',transient:true,name:firstRealName(sess.myHandle,sess.myName,getPreferredOwnerName())||'yournamehere',myHandle:firstRealName(sess.myHandle,sess.myName,getPreferredOwnerName())||'yournamehere',lang:effectiveLangFromSession(sess),effectiveTargetLang:getEffectiveTargetLang(sess),side:'owner',identityId:sess.ownerIdentityId});}
+  toast('Invite resent');
+}
+
+function openSession(cid){
+  var sess=getSession(cid);if(!sess){toast('Not found');return;}
+  if(state.mediaRuntime.stream&&state.mediaRuntime.activeSessionId&&state.mediaRuntime.activeSessionId!==cid){stopSessionMediaShare({silent:true});}
+  sess=putSession(sess);
+  if(connectedConvId&&connectedConvId!==cid){
+    addDiagLog('openSession: disconnecting from '+connectedConvId.slice(0,8)+' to switch to '+cid.slice(0,8));
+    transportDisconnect({preserveQueue:false});
+  }
+  if(state.pendingInviteId&&state.pendingInviteId!==cid){
+    var oldCard=document.getElementById('invite-card-'+state.pendingInviteId);
+    if(oldCard)oldCard.remove();
+    state.pendingInviteId=null;
+  }
+  state.activeConvId=cid;state.messages=getMsgs(cid);
+  if(stampExistingMessageNames(state.messages,sess))saveMsgs(cid,state.messages);
+  setActiveConvId(cid);markViewed(cid);
+  document.getElementById('shell-empty').style.display='none';
+  document.getElementById('messages').style.display='flex';
+  document.getElementById('composer').style.display='flex';
+  updatePartnerHeader(sess);
+  updateAutoReadBtn();
+  resetActivePresence(cid);
+  transportConnect(cid);
+  state.pendingInviteId=cid;
+  addInviteMessage(cid);
+  renderAllMessages();
+  scrollBottom();
+  showScreen('chat-screen');
+  refreshActiveSessionChrome(cid);
+  renderMediaShareUI();
+}
+
+function updatePartnerHeader(sess){
+  var root=document.getElementById('shell-partner-name');if(!root)return;
+  var selfEl=document.getElementById('shell-self-name');
+  var selfLabel=selfEl&&selfEl.querySelector('.shell-participant-label');
+  if(selfEl&&selfEl.dataset&&selfEl.dataset.editing==='1'){updatePresenceIndicators();return;}
+  if(selfLabel&&document.activeElement===selfEl){updatePresenceIndicators();return;}
+  var peerEl=document.getElementById('shell-peer-name');
+  var peerLabel=peerEl&&peerEl.querySelector('.shell-participant-label');
+  var arrowEl=document.getElementById('shell-partner-arrow');
+  var s=sess?normalizeSession(sess):normalizeSession({});
+  var myName=firstRealName(s.myHandle,s.myName);
+  var peerName=firstRealName(s.partnerHandle,s.peerName);
+  if(selfLabel)selfLabel.textContent=myName||(!peerName?'new chat':'');
+  if(peerLabel)peerLabel.textContent=peerName||'?';
+  if(selfEl)selfEl.hidden=!!peerName&&!myName;
+  if(peerEl)peerEl.hidden=!myName&&!peerName;
+  if(arrowEl)arrowEl.hidden=!(myName&&peerEl&&!peerEl.hidden);
+  updatePresenceIndicators();
+}
+
+function showEmptyShell(){
+  state.activeConvId=null;
+  document.getElementById('shell-empty').style.display='flex';
+  document.getElementById('messages').style.display='none';
+  document.getElementById('composer').style.display='none';
+  updatePartnerHeader(null);
+  updateDot();
+}
+
+function findSessionByLabel(label,excludeConvId){var want=(label||'').trim().toLowerCase();if(!want)return null;return getAllSessions().find(function(s){if(!s||s.convId===excludeConvId)return false;return getSessionLabel(s).trim().toLowerCase()===want;})||null;}
+function findSessionByComputedLabel(myName,peerName,excludeConvId){var computed=String((myName||'').trim()+' / '+((peerName||'').trim()||'Invite Pending')).trim().toLowerCase();if(!computed)return null;return getAllSessions().find(function(s){if(!s||s.convId===excludeConvId)return false;var sn=normalizeSession(s);var lbl=(firstRealName(sn.myHandle,sn.myName)||'')+' / '+(firstRealName(sn.partnerHandle,sn.peerName)||'Invite Pending');return lbl.trim().toLowerCase()===computed;})||null;}
+function saveOwnerName(el){
+  if(!state.activeConvId)return;
+  var sess=getSession(state.activeConvId);if(!sess)return;
+  var oldName=firstRealName(sess.myHandle,sess.myName,getPreferredOwnerName())||'yournamehere';
+  var v=(el.textContent||'').trim();
+  if(!v){el.textContent=oldName;return;}
+  if(v===oldName){updatePartnerHeader(sess);return;}
+  var nextPeer=firstRealName(sess.partnerHandle,sess.peerName);
+  var collisionLabel=nextPeer?(v+' / '+nextPeer):(v+' / Invite Pending');
+  if(findSessionByLabel(collisionLabel,sess.convId)||findSessionByComputedLabel(v,nextPeer,sess.convId)){toast('Rename blocked: another session already uses this label.');el.textContent=oldName;updatePartnerHeader(sess);return;}
+  sess.myHandle=v;sess.myName=v;putSession(sess);
+  updatePartnerHeader(sess);
+  renderSessionList();
+  addSystemNote(sess.convId,'You are now '+v,Date.now());
+  transportSend({type:'hello',transient:true,name:v,myHandle:v,lang:effectiveLangFromSession(sess),effectiveTargetLang:getEffectiveTargetLang(sess),side:'owner',identityId:sess.ownerIdentityId,timestamp:Date.now()});
+}
+
+var HISTORY_SYNC_MAX=1500;
+var HISTORY_SYNC_CHUNK=80;
+
+function sanitizeHistoryMsgForWire(m){
+  if(!m||typeof m!=='object')return null;
+  return {
+    id:m.id||uid(),
+    from:m.from||'system',
+    sourceText:m.sourceText||m.orig||m.text||'',
+    sourceLang:m.sourceLang||m.lang||'',
+    targetText:m.targetText||m.translated||'',
+    targetLang:m.targetLang||'',
+    text:m.text||'',
+    orig:m.orig||m.sourceText||m.text||'',
+    lang:m.lang||m.sourceLang||'',
+    status:m.status||'received',
+    timestamp:m.timestamp||Date.now(),
+    displayFromName:m.displayFromName||'',
+    displayToName:m.displayToName||'',
+    clarify:m.clarify||{status:'none',text:'',thread:[]},
+    backtranslate:m.backtranslate||null,
+    translations:(m.translations&&typeof m.translations==='object')?m.translations:{},
+    ownerRole:m.ownerRole||(m.from==='me'?'owner':(m.from==='them'?'partner':''))
+  };
+}
+
+function sendHistorySync(convId){
+  if(!convId||!ws||ws.readyState!==1)return;
+  var rt=getRoomRuntime(convId);var now=Date.now();
+  if(rt&&rt.lastHistorySyncSentAt&&(now-rt.lastHistorySyncSentAt)<10000)return;
+  var msgs=(getMsgs(convId)||[]).slice(-HISTORY_SYNC_MAX).map(sanitizeHistoryMsgForWire).filter(Boolean);
+  if(!msgs.length)return;
+  for(var i=0;i<msgs.length;i+=HISTORY_SYNC_CHUNK){
+    transportSend({type:'history-sync',transient:true,chunk:msgs.slice(i,i+HISTORY_SYNC_CHUNK),done:(i+HISTORY_SYNC_CHUNK)>=msgs.length,timestamp:Date.now()});
+  }
+  if(rt)rt.lastHistorySyncSentAt=now;
+  addDiagLog('TX history-sync count='+msgs.length);
+}
+
+function mergeHistorySyncChunk(sess,d){
+  if(!sess||!d||!Array.isArray(d.chunk)||!d.chunk.length)return;
+  var existing=getMsgs(sess.convId)||[];
+  var byId={};existing.forEach(function(m){if(m&&m.id)byId[m.id]=m;});
+  var changed=false;
+  d.chunk.forEach(function(raw){
+    var wireFrom=raw&&raw.from;
+    var role=(raw&&raw.ownerRole)||'';
+    var localFrom=role==='owner'?'me':(role==='partner'?'them':((wireFrom==='me')?'them':(wireFrom==='them'?'me':wireFrom)));
+    var msg=normalizeMsgSchema(Object.assign({},raw,{from:localFrom,ownerRole:role||(localFrom==='me'?'owner':'partner')}),{sourceLang:raw.sourceLang||raw.lang||'en',targetLang:raw.targetLang||''});
+    if(byId[msg.id])return;
+    stampMsgNames(msg,sess);
+    existing.push(msg);byId[msg.id]=msg;changed=true;
+  });
+  if(!changed)return;
+  existing.sort(function(a,b){var dt=(a.timestamp||0)-(b.timestamp||0);if(dt)return dt;return String(a.id||'').localeCompare(String(b.id||''));});
+  saveMsgs(sess.convId,existing);
+  if(sess.convId===state.activeConvId){state.messages=existing;renderAllMessages();scrollBottom();}
+  addDiagLog('RX history-sync merged='+d.chunk.length+(d.done?' done':''));
+}
+
+function savePartnerName(){return;}
+
+// Session list with drag-sort
+var dragSrcId=null;
+function renderSessionList(){
+  var c=document.getElementById('session-list');if(!c)return;
+  var ss=getAllSessions();var order=getSessionOrder();
+  var recycled=getRecycled().map(function(r){return r.convId;});
+  ss=ss.filter(function(s){return recycled.indexOf(s.convId)<0;});
+  ss.sort(function(a,b){var ai=order.indexOf(a.convId);var bi=order.indexOf(b.convId);if(ai>=0&&bi>=0)return ai-bi;if(ai>=0)return-1;if(bi>=0)return 1;return(b.lastActivity||0)-(a.lastActivity||0);});
+  if(!ss.length){c.innerHTML='<div style="text-align:center;padding:20px;font-size:13px;color:var(--ink-dim);">No conversations yet.</div>';renderRecycleBin();return;}
+  var ICON_DIAG='<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>';
+  c.innerHTML=ss.map(function(s){
+    var isActive=state.activeConvId===s.convId;
+    var statusBadge='';
+    return '<div class="sess-card'+(isActive?' active':'')+'" draggable="true" data-conv="'+s.convId+'" ondragstart="dragStart(event)" ondragover="event.preventDefault()" ondrop="dragDrop(event)" ondragend="dragEnd(event)" onclick="onSessCardClick(event,\''+s.convId+'\')">'
+      +'<div class="sess-card-info"><div class="sess-card-title">'+escHtml(getSessionLabel(s))+'</div><div class="sess-card-sub">'+timeAgo(s.lastActivity||s.createdAt)+'</div></div>'
+      +statusBadge
+      +'<div style="display:flex;gap:2px;flex-shrink:0;">'
+      +'<button class="sess-card-act" onclick="event.stopPropagation();shareSession(\''+s.convId+'\')" title="Share">'+ICON_SHARE+'</button>'
+      +'<button class="sess-card-act" onclick="event.stopPropagation();exportSessionChat(\''+s.convId+'\')" title="Export chat">⇩</button>'
+      +'<button class="sess-card-act" onclick="event.stopPropagation();openDiagModal(\''+s.convId+'\')" title="Diagnostics">'+ICON_DIAG+'</button>'
+      +'<button class="sess-card-act del" onclick="event.stopPropagation();softDelete(\''+s.convId+'\')" title="Delete">'+ICON_DELETE+'</button>'
+      +'</div></div>';
+  }).join('');
+  renderRecycleBin();
+}
+function onSessCardClick(e,cid){
+  var sess=getSession(cid);if(!sess)return;
+  closeLeftPanel();
+  openSession(cid);
+}
+function dragStart(e){dragSrcId=e.currentTarget.dataset.conv;e.currentTarget.classList.add('dragging');if(e.dataTransfer){e.dataTransfer.effectAllowed='move';try{e.dataTransfer.setData('text/plain',dragSrcId);}catch(_){}}}
+function dragDrop(e){e.preventDefault();var tgt=e.currentTarget.dataset.conv;if(!tgt||tgt===dragSrcId)return;var order=normalizeSessionOrder(getSessionOrder());var fi=order.indexOf(dragSrcId);var ti=order.indexOf(tgt);if(fi<0||ti<0)return;order.splice(fi,1);order.splice(ti,0,dragSrcId);saveSessionOrder(normalizeSessionOrder(order,false));renderSessionList();}
+function dragEnd(e){e.currentTarget.classList.remove('dragging');dragSrcId=null;}
+
+function softDelete(cid){var r=getRecycled();var sess=getSession(cid);if(!sess)return;r.push({convId:cid,title:getSessionLabel(sess),deletedAt:Date.now()});saveRecycled(r);if(state.activeConvId===cid){transportDisconnect();showEmptyShell();}renderSessionList();toast('Deleted — see Recently Deleted to undo');}
+function restoreSession(cid){saveRecycled(getRecycled().filter(function(r){return r.convId!==cid;}));saveSessionOrder(normalizeSessionOrder(getSessionOrder()));renderSessionList();toast('Restored');}
+function permDelete(cid){saveRecycled(getRecycled().filter(function(r){return r.convId!==cid;}));saveSessions(getAllSessions().filter(function(s){return s.convId!==cid;}));deleteSessData(cid);saveSessionOrder(normalizeSessionOrder(getSessionOrder().filter(function(id){return id!==cid;}),false));renderSessionList();toast('Permanently deleted');}
+function renderRecycleBin(){var bin=document.getElementById('recycle-bin');if(!bin)return;var r=getRecycled();var now=Date.now();r=r.filter(function(x){return(now-x.deletedAt)<30*86400000;});saveRecycled(r);if(!r.length){bin.innerHTML='';return;}bin.innerHTML='<div class="recycle-header" onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display===\'none\'?\'block\':\'none\'">▸ Recently Deleted ('+r.length+')</div><div class="recycle-list" style="display:none;">'+r.map(function(x){return '<div class="recycle-item"><span style="flex:1;">'+escHtml(x.title||x.convId||'new chat')+'</span><button class="restore" onclick="restoreSession(\''+x.convId+'\')">Restore</button><button class="purge" onclick="permDelete(\''+x.convId+'\')">Delete</button></div>';}).join('')+'</div>';}
+
+// Share / invite
+function shareCurrentSession(){if(!state.activeConvId){toast('No active session');return;}shareSession(state.activeConvId);}
+var INVITE_SCHEMA_VERSION=2;
+function encodeInvitePayload(payload){
+  try{
+    return btoa(unescape(encodeURIComponent(JSON.stringify(payload))))
+      .replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+  }catch(_){return '';}
+}
+function decodeInvitePayload(encoded){
+  if(!encoded)return null;
+  try{
+    var safe=String(encoded).replace(/-/g,'+').replace(/_/g,'/');
+    while(safe.length%4)safe+='=';
+    return JSON.parse(decodeURIComponent(escape(atob(safe))));
+  }catch(_){return null;}
+}
+function isLegacyInviteUrl(url){
+  if(!url)return true;
+  try{
+    var parsed=new URL(url,location.href);
+    var s=parsed.searchParams;
+    var h=new URLSearchParams((parsed.hash||'').replace(/^#/,''));
+    if(h.get('i'))return false;
+    if(s.get('j'))return true;
+    if(s.get('invite'))return true;
+    if(s.get('join'))return true;
+    return false;
+  }catch(_){return true;}
+}
+function parseInviteFromSearch(searchParams,hashParams){
+  var hashInvite=hashParams&&hashParams.get('i');
+  if(hashInvite){
+    var hashPayload=validateInvitePayload(decodeInvitePayload(hashInvite));
+    if(!hashPayload)return {rejected:true,reason:'invalid-payload'};
+    return hashPayload;
+  }
+  if(searchParams.get('j'))return {rejected:true,reason:'legacy-raw-url'};
+  var rawInvite=searchParams.get('invite');
+  if(!rawInvite)return null;
+  var payload=validateInvitePayload(decodeInvitePayload(rawInvite));
+  if(!payload)return {rejected:true,reason:'invalid-payload'};
+  if(searchParams.get('join')!=='share')return {rejected:true,reason:'missing-share-origin'};
+  if(payload.joinOrigin!=='share-partner'&&payload.joinOrigin!=='share-owner-handoff')return {rejected:true,reason:'missing-share-origin'};
+  return payload;
+}
+function validateInvitePayload(payload){
+  if(!payload||typeof payload!=='object')return null;
+  if(payload.schemaVersion===INVITE_SCHEMA_VERSION){
+    if(typeof payload.s!=='string'||!payload.s.trim())return null;
+    if(typeof payload.d!=='string')return null;
+    if(payload.o!=='p'&&payload.o!=='o')return null;
+    var mapped={
+      schemaVersion:INVITE_SCHEMA_VERSION,
+      sessionId:payload.s,
+      initiatorDeviceId:payload.d,
+      initiatorGlobalName:payload.n||'',
+      initiatorLang:payload.l||'',
+      initiatorAnnouncedAt:payload.a,
+      createdAt:payload.c,
+      joinOrigin:payload.o==='o'?'share-owner-handoff':'share-partner',
+      side:payload.o==='o'?'owner':'partner'
+    };
+    if(payload.pm!==undefined)mapped.partnerLangMode=payload.pm;
+    if(payload.pf!==undefined)mapped.partnerFixedLang=payload.pf;
+    if(payload.pl!==undefined)mapped.partnerLastSentLang=payload.pl;
+    if(payload.pe!==undefined)mapped.partnerEffectiveReplyLang=payload.pe;
+    if(payload.o==='o'){
+      if(payload.oi!==undefined)mapped.ownerIdentityId=payload.oi;
+      if(payload.om!==undefined)mapped.ownerLangMode=payload.om;
+      if(payload.of!==undefined)mapped.ownerFixedLang=payload.of;
+      if(payload.ol!==undefined)mapped.ownerLastSentLang=payload.ol;
+      if(payload.oe!==undefined)mapped.ownerEffectiveReplyLang=payload.oe;
+    }
+    return mapped;
+  }
+  if(payload.schemaVersion===1){
+    if(typeof payload.sessionId!=='string'||!payload.sessionId.trim())return null;
+    if(typeof payload.initiatorDeviceId!=='string')return null;
+    if(payload.joinOrigin!=='share-partner'&&payload.joinOrigin!=='share-owner-handoff')return null;
+    if(payload.joinOrigin==='share-owner-handoff'&&payload.side!=='owner')return null;
+    if(payload.joinOrigin==='share-partner'&&payload.side!=='partner')return null;
+    return payload;
+  }
+  return null;
+}
+function pruneInvitePayload(payload){
+  var out={};
+  Object.keys(payload||{}).forEach(function(k){
+    var v=payload[k];
+    if(v!==undefined&&v!==null&&v!=='')out[k]=v;
+  });
+  return out;
+}
+
+function buildInvitePayload(sess,prefs,intent){
+  sess=normalizeSession(sess||{});
+  var mode=(intent==='owner-handoff')?'owner-handoff':'partner-invite'; // Keep partner-invite and owner-handoff payloads distinct.
+  var base={schemaVersion:INVITE_SCHEMA_VERSION,s:sess.convId,d:PART_ID,n:sess.myName||prefs.userName||'yournamehere',
+    l:getEffectiveReplyLang(sess,'owner','en'),a:Date.now(),c:Date.now(),o:(mode==='owner-handoff'?'o':'p')};
+  if(mode==='partner-invite'){
+    base.pm=sess.partnerLangMode;base.pf=sess.partnerFixedLang;base.pl=sess.partnerLastSentLang;base.pe=sess.partnerEffectiveReplyLang;
+  }
+  if(mode==='owner-handoff'){
+    // Preserve full owner/partner language-routing invariants during handoff hydration.
+    base.oi=sess.ownerIdentityId;base.om=sess.ownerLangMode;base.of=sess.ownerFixedLang;base.ol=sess.ownerLastSentLang;base.oe=sess.ownerEffectiveReplyLang;
+    base.pm=sess.partnerLangMode;base.pf=sess.partnerFixedLang;base.pl=sess.partnerLastSentLang;base.pe=sess.partnerEffectiveReplyLang;
+  }
+  return pruneInvitePayload(base);
+}
+function buildInviteUrl(sess,prefs,intent){
+  var payload=buildInvitePayload(sess,prefs,intent);
+  var encoded=encodeInvitePayload(payload);
+  if(encoded)return location.href.split('?')[0].split('#')[0]+'#i='+encoded;
+  return '';
+}
+
+function hydrateSessionFromInvite(sess,invite){
+  if(!sess||!invite)return sess;
+  var inviteName=firstRealName(invite.initiatorGlobalName);
+  if(inviteName){sess.partnerHandle=inviteName;sess.peerName=inviteName;}
+  if(invite.side==='owner'){
+    // Preserve owner language-routing state across owner handoff device switches.
+    if(invite.ownerIdentityId)sess.ownerIdentityId=invite.ownerIdentityId;
+    if(invite.ownerLangMode==='fixed'||invite.ownerLangMode==='auto')sess.ownerLangMode=invite.ownerLangMode;
+    if(invite.ownerFixedLang!==undefined)sess.ownerFixedLang=normalizeLangSetting(invite.ownerFixedLang)||'';
+    if(invite.ownerLastSentLang!==undefined)sess.ownerLastSentLang=normalizeLangSetting(invite.ownerLastSentLang)||'';
+    if(invite.ownerEffectiveReplyLang!==undefined)sess.ownerEffectiveReplyLang=normalizeLangSetting(invite.ownerEffectiveReplyLang)||'';
+  }
+  if(invite.partnerLangMode==='fixed'||invite.partnerLangMode==='auto')sess.partnerLangMode=invite.partnerLangMode;
+  if(invite.partnerFixedLang!==undefined)sess.partnerFixedLang=normalizeLangSetting(invite.partnerFixedLang)||'';
+  if(invite.partnerLastSentLang!==undefined)sess.partnerLastSentLang=normalizeLangSetting(invite.partnerLastSentLang)||'';
+  if(invite.partnerEffectiveReplyLang!==undefined)sess.partnerEffectiveReplyLang=normalizeLangSetting(invite.partnerEffectiveReplyLang)||'';
+  sess.inviterDeviceId=sess.inviterDeviceId||invite.initiatorDeviceId;
+  sess.inviteCreatedAt=sess.inviteCreatedAt||invite.createdAt;
+  addDiagLog('handoff apply side='+(invite.side||'?')+' ownerIdentityId='+(sess.ownerIdentityId||'?')+' eff='+resolveEffectiveLang(sess,'owner'));
+  return normalizeSession(sess);
+}
+function shareSession(cid){
+  var sess=getSession(cid);if(!sess){toast('Not found');return;}
+  var p=getPrefs();
+  var url=buildInviteUrl(sess,p,'partner-invite');
+  var handoffUrl=buildInviteUrl(sess,p,'owner-handoff');
+  if(!url||!handoffUrl){toast('Unable to generate share link');return;}
+  addDiagLog('share link generated side=owner mode='+sess.ownerLangMode+' conv='+String(cid||'').slice(0,8));
+  var el=document.getElementById('share-link-text');if(el){el.href=url;el.textContent=url;}
+  var h=document.getElementById('share-handoff-link-text');if(h){h.href=handoffUrl;h.textContent=handoffUrl;}
+  ['share-partner-qr','share-owner-qr'].forEach(function(id){var node=document.getElementById(id);if(node)node.innerHTML='';});
+  if(window.QRCode){
+    try{new QRCode(document.getElementById('share-partner-qr'),{text:url,width:220,height:220,colorDark:'#1A1714',colorLight:'#fff',correctLevel:QRCode.CorrectLevel.H});}catch(_){}
+    try{new QRCode(document.getElementById('share-owner-qr'),{text:handoffUrl,width:220,height:220,colorDark:'#1A1714',colorLight:'#fff',correctLevel:QRCode.CorrectLevel.H});}catch(_){}
+  }
+  document.getElementById('share-overlay').hidden=false;
+  if(navigator.share){navigator.share({url:url}).catch(function(){});}
+}
+function copyShareLink(){var el=document.getElementById('share-link-text');var url=el?el.href:'';if(navigator.clipboard&&navigator.clipboard.writeText)navigator.clipboard.writeText(url).then(function(){toast('Copied');document.getElementById('share-overlay').hidden=true;});else{fallbackCopy(url);document.getElementById('share-overlay').hidden=true;}}
+
+
+// ════════════════════════════════════════════════════════
+// DIAGNOSTIC LOG
+// ════════════════════════════════════════════════════════
+var diagLog=[];var diagCurrentSess=null;
+var MAX_DIAG=400;
+function addDiagLog(msg,level){
+  var ts=new Date().toISOString().slice(11,23);
+  var prefix=level==='err'?'ERR':level==='warn'?'WRN':'---';
+  var entry=ts+' '+prefix+' '+String(msg||'');
+  diagLog.push(entry);
+  if(diagLog.length>MAX_DIAG)diagLog=diagLog.slice(-MAX_DIAG);
+  // Live update if modal open
+  var body=document.getElementById('diag-log-body');
+  if(body&&!document.getElementById('diag-overlay').hidden){
+    body.textContent=diagLog.join('\n');
+    body.scrollTop=body.scrollHeight;
+  }
+}
+function openDiagModal(cid){
+  diagCurrentSess=cid||state.activeConvId;
+  var label=document.getElementById('diag-sess-label');
+  var sess=diagCurrentSess?getSession(diagCurrentSess):null;
+  if(label)label.textContent='Session: '+(sess?getSessionLabel(sess):(diagCurrentSess||'global'));
+  var body=document.getElementById('diag-log-body');
+  if(body){body.textContent=diagLog.length?diagLog.join('\n'):'No log entries yet.';body.scrollTop=body.scrollHeight;}
+  document.getElementById('diag-overlay').hidden=false;
+}
+function copyDiagLog(){
+  var text=diagLog.join('\n');
+  if(navigator.clipboard&&navigator.clipboard.writeText)navigator.clipboard.writeText(text).then(function(){toast('Log copied');});
+  else{fallbackCopy(text);}
+}
+function clearDiagLog(){
+  diagLog=[];
+  var body=document.getElementById('diag-log-body');
+  if(body)body.textContent='(cleared)';
+}
+// ════════════════════════════════════════════════════════
+// TRANSLATION
+// ════════════════════════════════════════════════════════
+var trCache=new Map();
+function translate(text,from,to){
+  var t=(text||'').trim();
+  if(!t)return Promise.resolve(text);
+  // Same language — return source unchanged, no cloud call
+  if(!from||!to||from===to){addDiagLog('TRANSLATE skip same-lang '+from);return Promise.resolve(text);}
+  var key=from+'|'+to+'|'+t;
+  if(trCache.has(key)){addDiagLog('TRANSLATE cache-hit '+from+'>'+to);return Promise.resolve(trCache.get(key));}
+  addDiagLog('TRANSLATE call '+from+'>'+to+' "'+t.slice(0,20)+'"');
+  // Try on-device Chrome translator first
+  var p=Promise.resolve(null);
+  if(window.translation&&window.translation.createTranslator){
+    if(!window._tr)window._tr={};
+    var ck=from+'-'+to;
+    p=Promise.resolve().then(function(){
+      if(window._tr[ck])return window._tr[ck].translate(t);
+      return window.translation.createTranslator({sourceLanguage:from,targetLanguage:to}).then(function(tr){window._tr[ck]=tr;return tr.translate(t);});
+    }).then(function(r){if(r)tEngine='on-device';return r||null;}).catch(function(){return null;});
+  }
+  return p.then(function(result){
+    if(result){trCache.set(key,result);return result;}
+    // Cloud via MyMemory — always allowed (consent='always' default), with 8s timeout
+    return new Promise(function(resolve){
+      var done=false;
+      var timer=setTimeout(function(){if(!done){done=true;resolve(null);}},8000);
+      fetch('https://api.mymemory.translated.net/get?q='+encodeURIComponent(t)+'&langpair='+from+'|'+to)
+        .then(function(r){return r.json();})
+        .then(function(data){
+          if(done)return;done=true;clearTimeout(timer);
+          if(data&&data.responseStatus===200&&data.responseData&&data.responseData.translatedText){
+            var tr=data.responseData.translatedText;
+            if(tr.indexOf('MYMEMORY')>=0){resolve(null);return;}
+            tEngine='cloud';trCache.set(key,tr);addDiagLog('MYMEMORY ok '+from+'>'+to+' "'+tr.slice(0,20)+'"');resolve(tr);
+          }else{resolve(null);}
+        })
+        .catch(function(e){addDiagLog('MYMEMORY fail: '+String(e||''),'err');if(!done){done=true;clearTimeout(timer);resolve(null);}});
+    });
+  });
+}
+
+// ════════════════════════════════════════════════════════
+// TTS
+// ════════════════════════════════════════════════════════
+var synth=window.speechSynthesis;var canSpeak='speechSynthesis' in window;
+var _voicesReady=false;var _voicesList=[];
+function ensureVoices(cb){
+  if(_voicesReady&&_voicesList.length){cb(_voicesList);return;}
+  var voices=synth.getVoices();
+  if(voices&&voices.length){_voicesReady=true;_voicesList=voices;cb(voices);return;}
+  // Voices not yet loaded — wait for event
+  var waited=false;
+  var onReady=function(){
+    if(waited)return;waited=true;
+    _voicesList=synth.getVoices();_voicesReady=true;
+    cb(_voicesList);
+  };
+  if(synth.onvoiceschanged!==undefined)synth.addEventListener('voiceschanged',onReady,{once:true});
+  // Fallback timeout — some browsers never fire the event
+  setTimeout(function(){if(!waited){_voicesList=synth.getVoices()||[];_voicesReady=true;cb(_voicesList);}},500);
+}
+function speak(text,lang,btn){
+  if(!canSpeak||!text)return;
+  if(btn&&ttsActive===btn){synth.cancel();setTTSBtn(btn,false);ttsActive=null;return;}
+  if(ttsActive){synth.cancel();setTTSBtn(ttsActive,false);ttsActive=null;}
+  // Chrome bug: cancel() then speak() in same tick sometimes fails
+  synth.cancel();
+  ensureVoices(function(voices){
+    var utt=new SpeechSynthesisUtterance(text);
+    var locale=TTS_LOCALE[lang]||lang;
+    var base=(locale||lang||'').split('-')[0].toLowerCase();
+    var voice=
+      voices.find(function(v){return (v.lang||'').toLowerCase()===(locale||'').toLowerCase();}) ||
+      voices.find(function(v){return (v.lang||'').toLowerCase().indexOf(base+'-')===0;}) ||
+      voices.find(function(v){return ((v.lang||'').split('-')[0]||'').toLowerCase()===base;}) ||
+      voices.find(function(v){return !!v.default;}) ||
+      null;
+    utt.lang=locale||lang||'en';
+    if(voice)utt.voice=voice;
+    console.log('[TTS] attempt len=%d lang=%s voice=%s',String(text||'').length,utt.lang,(voice&&voice.name)||'browser-default');
+    setTTSBtn(btn,true);ttsActive=btn;
+    utt.onend=function(){setTTSBtn(btn,false);if(ttsActive===btn)ttsActive=null;clearInterval(utt._keepAlive);};
+    utt.onerror=function(){setTTSBtn(btn,false);if(ttsActive===btn)ttsActive=null;clearInterval(utt._keepAlive);};
+    try{
+      synth.cancel(); // Chrome desktop: clear any stuck synth state before speaking
+      synth.speak(utt);
+      // Chrome workaround: pause/resume keeps utterance alive past 15s (Android + desktop)
+      utt._keepAlive=setInterval(function(){if(!synth.speaking){clearInterval(utt._keepAlive);return;}synth.pause();synth.resume();},10000);
+    }catch(e){setTTSBtn(btn,false);ttsActive=null;}
+  });
+}
+function setTTSBtn(btn,on){if(!btn)return;btn.classList.toggle('playing',on);}
+function toggleAutoRead(){state.autoSpeakIncoming=!state.autoSpeakIncoming;var p=getPrefs();p.autoSpeakIncoming=state.autoSpeakIncoming;savePrefs(p);updateAutoReadBtn();if(state.autoSpeakIncoming&&!canSpeak)toast('Auto-read enabled but speech unavailable');else toast('Auto-read '+(state.autoSpeakIncoming?'on':'off'));}
+function updateAutoReadBtn(){syncAutoReadState();}
+function syncAutoReadState(){
+  var cb=document.getElementById('set-autoread');
+  if(cb)cb.checked=!!state.autoSpeakIncoming;
+  var rib=document.getElementById('ribbon-autoread');
+  if(rib)rib.checked=!!state.autoSpeakIncoming;
+}
+function setAutoReadFromSettings(checked){
+  if(!!checked!==!!state.autoSpeakIncoming)toggleAutoRead();
+}
+function setAutoReadFromRibbon(checked){
+  if(!!checked!==!!state.autoSpeakIncoming)toggleAutoRead();
+}
+function muteAutoRead(){if(canSpeak)synth.cancel();}
+function dismissAutoRead(){if(canSpeak)synth.cancel();if(state.autoSpeakIncoming)toggleAutoRead();}
+
+// ════════════════════════════════════════════════════════
+// STT
+// ════════════════════════════════════════════════════════
+function toggleSTT(){
+  if(!SpeechRec){toast('Voice not available');return;}
+  if(sttActive){if(recognition)recognition.stop();return;}
+  var sess=getSession(state.activeConvId);
+  recognition=new SpeechRec();
+  recognition.lang=TTS_LOCALE[resolveEffectiveLang(sess,'owner')||getPrefs().myLang||'en']||'en';
+  recognition.interimResults=true;recognition.continuous=false;
+  var btn=document.getElementById('stt-btn');
+  recognition.onstart=function(){sttActive=true;if(btn)btn.classList.add('active');};
+  recognition.onresult=function(e){var f='',i='';for(var r of e.results){if(r.isFinal)f+=r[0].transcript;else i+=r[0].transcript;}var ta=document.getElementById('msg-input');ta.value=f||i;autoResize();updateSendBtn();};
+  recognition.onend=function(){sttActive=false;if(btn)btn.classList.remove('active');};
+  recognition.onerror=function(e){if(e.error==='not-allowed')toast('Mic permission needed');sttActive=false;if(btn)btn.classList.remove('active');};
+  try{recognition.start();}catch(e){}
+}
+
+// ════════════════════════════════════════════════════════
+// RELAY EVENT HANDLER
+// ════════════════════════════════════════════════════════
+function upsertPartnerFromEnvelope(sess,d,opts){
+  if(!sess||!d)return;
+  var prevName=firstRealName(sess.partnerHandle,sess.peerName);
+  var partnerName=firstRealName(d.name,sess.partnerHandle,sess.peerName);
+  if(partnerName){sess.partnerHandle=partnerName;sess.peerName=partnerName;}
+  if(d.identityId)sess.partnerIdentityId=d.identityId;
+  putSession(sess);
+  if(state.activeConvId===sess.convId)updatePartnerHeader(sess);
+  return {prevName:prevName,nextName:partnerName};
+}
+
+
+function applyPeerRoutingHints(sess,d){
+  if(!sess||!d)return false;
+  var changed=false;
+  if(d.lang){var l=normalizeLangSetting(d.lang)||'';if(l&&sess.partnerLastSentLang!==l){sess.partnerLastSentLang=l;changed=true;}}
+  if(d.partnerLangMode==='fixed'||d.partnerLangMode==='auto'){if(sess.partnerLangMode!==d.partnerLangMode){sess.partnerLangMode=d.partnerLangMode;changed=true;}}
+  if(d.partnerFixedLang!==undefined){var pf=normalizeLangSetting(d.partnerFixedLang)||'';if(sess.partnerFixedLang!==pf){sess.partnerFixedLang=pf;changed=true;}}
+  if(d.effectiveTargetLang){var et=normalizeLangSetting(d.effectiveTargetLang)||'';if(et&&sess.partnerEffectiveReplyLang!==et){sess.partnerEffectiveReplyLang=et;changed=true;}}
+  if(d.partnerEffectiveReplyLang!==undefined){var pe=normalizeLangSetting(d.partnerEffectiveReplyLang)||'';if(sess.partnerEffectiveReplyLang!==pe){sess.partnerEffectiveReplyLang=pe;changed=true;}}
+  return changed;
+}
+function handleRelayEvent(d){
+  if(!d||!d.type)return;
+  addDiagLog('RX type='+d.type+(d.id?' id='+String(d.id||'').slice(0,8):'')+(d.from?' from='+String(d.from||'').slice(0,8):'')+(d.name?' name='+d.name:''));
+  // Skip own messages
+  if(d.from===DEVICE_ID){return;}
+  // Find session: prefer d.session (set by relay), fall back to activeConvId
+  var sessId=d.session||state.activeConvId;
+  var sess=sessId?getSession(sessId):null;
+  if(!sess){addDiagLog('RX ignored: no session for '+String(sessId||'').slice(0,8),'warn');return;}
+
+  // ACK for durable events only
+  if((d.type==='msg'||d.type==='tr')&&d.id)transportSend({type:'ack',ackType:d.type,id:d.id,timestamp:Date.now()});
+  if(shouldDrop(d)){addDiagLog('RX dedupe-dropped: '+d.type,'warn');return;}
+
+  if(d.type==='hello'){
+    var rt=getRoomRuntime(sess.convId);
+    applyPeerRoutingHints(sess,d);
+    var wasEverSeen=rt&&rt.peerEverSeen;
+    var lastSeen=rt&&rt.peerLastSeenAt||0;
+    var nameUpdate=upsertPartnerFromEnvelope(sess,d,{});
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill});
+    addDiagLog('HELLO from '+(d.name||'?')+' side='+(d.side||'?')+' identity='+(d.identityId||'?'));
+    updatePartnerHeader(sess);
+    renderSessionList();
+    if(!d._fromBackfill){
+      resendUnacked();
+      sendHistorySync(sess.convId);
+      renderAllMessages();scrollBottom();
+      if(nameUpdate&&nameUpdate.prevName&&nameUpdate.nextName&&nameUpdate.prevName!==nameUpdate.nextName){
+        addSystemNote(sess.convId,nameUpdate.prevName+' is now '+nameUpdate.nextName,Date.now());
+      }
+    }
+    return;
+  }
+
+  if(d.type==='history-sync'){
+    mergeHistorySyncChunk(sess,d);
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    return;
+  }
+  if(d.type==='presence'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    if(applyPeerRoutingHints(sess,d))putSession(sess);
+    return;
+  }
+  if(d.type==='media-share'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    applyRemoteMediaShareState(d,sess);
+    return;
+  }
+  if(d.type==='media-cc'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    applyRemoteCc(d,sess);
+    return;
+  }
+
+  if(d.type==='msg'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill});
+    applyPeerRoutingHints(sess,d);
+    var srcTxt=d.sourceText||d.orig||d.text||'';
+    var srcLang=d.sourceLang||d.lang||detectLang(srcTxt,resolveEffectiveLang(sess,'partner'))||resolveEffectiveLang(sess,'partner');
+    var partnerMode=sess.partnerLangMode==='fixed'?'fixed':'auto';
+    var partnerFixed=normalizeLangSetting(sess.partnerFixedLang)||'';
+    var partnerOutLang=(partnerMode==='fixed'&&partnerFixed)?partnerFixed:srcLang;
+    sess.partnerLastSentLang=partnerOutLang;
+    setEffectiveReplyLang(sess,'partner',partnerOutLang);
+    // Receiver always wants translation in local effective reply language.
+    var myLang=getEffectiveReplyLang(sess,'owner','en');
+    var incomingTargetLang=normalizeLangSetting(d.targetLang||'');
+    var incomingForcedText=(incomingTargetLang===myLang)?(d.targetText||d.text||''):'';
+    // Record partner's detected language in tally (partner messages only)
+    var partnerId=(d.identityId||sess.partnerIdentityId||sess.inviterDeviceId||d.from||'partner');
+    recordLangTally(partnerId,srcLang);
+    var ps=ensureParticipantState(partnerId);
+    sess.partnerIdentityId=sess.partnerIdentityId||partnerId;
+    putSession(sess);
+    addDiagLog('partnerLang tally: '+(ps?getLangTallySummary(partnerId):'n/a'));
+    addDiagLog('RX msg id='+String(d.id||'').slice(0,8)+' srcLang='+srcLang+' myLang='+myLang+' text='+(srcTxt||'').slice(0,30));
+
+    if(d.id&&findMsg(d.id)){
+      var existing=findMsg(d.id);
+      normalizeMsgSchema(existing,{sourceLang:srcLang,targetLang:myLang});
+      var changed=mergeMsgTranslations(existing,d.translations||{});
+      if(srcTxt&&existing.sourceText!==srcTxt){existing.sourceText=srcTxt;existing.orig=srcTxt;changed=true;}
+      if(srcLang&&existing.sourceLang!==srcLang){existing.sourceLang=srcLang;existing.lang=srcLang;changed=true;}
+      if(incomingForcedText)changed=applyMsgTarget(existing,myLang,incomingForcedText)||changed;
+      if(!existing.deliveredAt){existing.deliveredAt=d.timestamp||d.ts||Date.now();changed=true;}
+      if(!existing.readAt){existing.readAt=Date.now();changed=true;}
+      if(changed){updateTransDOM(existing);saveMsgs(state.activeConvId,state.messages);}
+      return;
+    }
+
+    upsertPartnerFromEnvelope(sess,d,{allowLangUpdate:false});
+    updatePartnerHeader(sess);
+    if(state.pendingInviteId===sess.convId){
+      state.pendingInviteId=null;
+    }
+    var rxTs=d.timestamp||d.ts||Date.now();
+    var msg=normalizeMsgSchema({id:d.id,from:'them',sourceText:srcTxt,sourceLang:srcLang,targetLang:myLang,targetText:incomingForcedText,orig:srcTxt,text:null,lang:srcLang,status:'received',deliveredAt:rxTs,readAt:Date.now(),timestamp:rxTs,clarify:{status:'none',text:'',thread:[]},translations:{}},{sourceLang:srcLang,targetLang:myLang});
+    // Use wire name for display, not stale session name
+    msg.displayFromName=firstRealName(d.name,sess.partnerHandle,sess.peerName)||'Partner';
+    mergeMsgTranslations(msg,d.translations||{});
+    stampMsgNames(msg,sess);
+    state.messages.push(msg);renderMsg(msg);scrollBottom();
+    sess.lastActivity=msg.timestamp;putSession(sess);saveMsgs(sess.convId,state.messages);
+
+    // Same language — no translation needed
+    if(srcLang===myLang){
+      applyMsgTarget(msg,myLang,srcTxt);
+      updateTransDOM(msg);saveMsgs(sess.convId,state.messages);
+      sendReliable({type:'tr',id:d.id,sourceText:msg.sourceText,sourceLang:msg.sourceLang,targetText:msg.targetText,targetLang:myLang,translations:msg.translations});
+      if(state.autoSpeakIncoming&&msg.targetText)speak(msg.targetText,myLang,null);
+      return;
+    }
+    translate(msg.sourceText,srcLang,myLang).then(function(tr){
+      var translated=tr||msg.sourceText;
+      addDiagLog(tr?('TRANSLATE ok '+srcLang+'>'+myLang+' "'+tr.slice(0,25)+'"'):('TRANSLATE null '+srcLang+'>'+myLang+' fallback=source'));
+      applyMsgTarget(msg,myLang,translated);
+      updateTransDOM(msg);saveMsgs(sess.convId,state.messages);
+      sendReliable({type:'tr',id:d.id,sourceText:msg.sourceText,sourceLang:msg.sourceLang,targetText:msg.targetText,targetLang:myLang,translations:msg.translations});
+      if(state.autoSpeakIncoming&&msg.targetText)speak(msg.targetText,myLang,null);
+    });
+    return;
+  }
+
+  if(d.type==='tr'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    var m2=findMsg(d.id);
+    if(m2){
+      normalizeMsgSchema(m2,{sourceLang:m2.sourceLang||'en',targetLang:d.targetLang||(m2.from==='me'?resolveEffectiveLang(sess,'partner'):resolveEffectiveLang(sess,'owner'))});
+      applyMsgTarget(m2,d.targetLang||m2.targetLang,d.targetText||d.text||'');
+      markMessageDeliveryState(state.activeConvId,m2.id,'translated',Date.now());
+      updateTransDOM(m2);saveMsgs(state.activeConvId,state.messages);
+    }
+    return;
+  }
+
+  if(d.type==='ack'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    if(d.ackType==='msg'){
+      clearAck(d.id);
+      markMessageDeliveryState(state.activeConvId,d.id,'delivered',Date.now());
+    }
+    else if(d.ackType==='tr'){clearAck(d.id);}
+    return;
+  }
+
+  if(d.type==='typing'){markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});var hintChanged=applyPeerRoutingHints(sess,d);showTyping(d.name||sess.partnerHandle||sess.peerName,d.typing);if(hintChanged)putSession(sess);return;}
+
+  if(d.type==='clarify-note'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    var m5=findMsg(d.id);
+    if(m5){appendClarifyNote(m5,d.text||'',firstRealName(d.name,sess.partnerHandle,sess.peerName)||'Partner',d.timestamp||Date.now());saveMsgs(state.activeConvId,state.messages);updateBblClarify(m5);}
+    return;
+  }
+  if(d.type==='card'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    if(d.card&&d.card.source){
+      upsertCardLastWins(d.card,false);
+      addDiagLog('RX card source='+String(d.card.source||'').slice(0,20));
+      if(document.getElementById('catalog-screen').classList.contains('active'))renderCatalogCards();
+    }
+    return;
+  }
+  if(d.type==='msg-meta'){
+    markPeerSeen(sess.convId,d.timestamp||d.ts||Date.now(),{fromBackfill:!!d._fromBackfill,suppressJoinNote:true});
+    // Peer updated tags or verdict on a shared message
+    var mm=findMsg(d.id);
+    if(mm){
+      var changed=false;
+      if(d.tags){mm.tags=sanitizeTagList(d.tags);changed=true;}
+      if(d.verdict!==undefined&&mm.backtranslate){
+        mm.backtranslate=normalizeBacktranslatePayload(mm.backtranslate,{});
+        mm.backtranslate.verdict=d.verdict;changed=true;
+      }
+      if(changed){
+        saveMsgs(state.activeConvId,state.messages);
+        renderMsgAssignedTags(mm.id);
+        if(d.verdict!==undefined)renderBubbleBacktranslateFooter(mm.id,'chat');
+        addDiagLog('RX msg-meta id='+String(d.id||'').slice(0,8));
+      }
+    }
+    return;
+  }
+}
+
+// ════════════════════════════════════════════════════════
+// UNIFIED BUBBLE RENDERER
+// Contract: used for both chat messages and phrasebook cards.
+// ctx: 'chat' | 'phrasebook'
+// Config object controls allowed differences:
+//   headerLeft: string (sender name / saved-by)
+//   headerRight: {time, prov} 
+//   footerMode: 'save' | 'delete'
+//   theme: 'mine' | 'theirs' | 'pb'
+// ════════════════════════════════════════════════════════
+function buildBubbleCard(cfg){
+  // cfg: {id, srcTxt, srcLang, tgtTxt, tgtLang, srcTtsLang, tgtTtsLang, headerLeft, time, prov, footerMode, isMine, ctx}
+  var id=cfg.id;
+  var srcTxt=cfg.srcTxt||'';
+  var tgtTxt=cfg.tgtTxt||'';
+  var srcLang=cfg.srcLang||'en';
+  var tgtLang=cfg.tgtLang||'en';
+  var srcTtsLang=cfg.srcTtsLang||srcLang;
+  var tgtTtsLang=cfg.tgtTtsLang||tgtLang;
+  var isMine=!!cfg.isMine;
+  var ctx=cfg.ctx||'chat';
+
+  // Header row
+  var statusDot='';
+  if(ctx==='chat'){
+    var deliveredOn=!!cfg.deliveredAt||cfg.status==='delivered'||cfg.status==='translated';
+    var readOn=!!cfg.readAt||cfg.status==='translated';
+    var dotClass=readOn?'on-read':(deliveredOn?'on-delivered':'off');
+    statusDot='<span class="msg-status-dots">'
+      +'<button class="msg-status-dot '+dotClass+'" type="button" onclick="openStatusPopup(\''+id+'\',this)">\u25CF</button>'
+      +'</span>';
+  }
+  var header='<div class="bbl-hdr">'
+    +'<span class="bbl-sender">'+escHtml(cfg.headerLeft||'')+'</span>'
+    +'<div class="bbl-hdr-right">'
+    +statusDot
+    +'<span class="bbl-time">'+escHtml(cfg.time||'')+'</span>'
+    +'</div></div>';
+
+  // Body row 1+2: two equal columns with Use + TTS per side
+  var aS=attrSafe(srcTxt);var aSL=attrSafe(srcTtsLang);
+  var aT=attrSafe(tgtTxt);var aTL=attrSafe(tgtTtsLang);
+  var srcClass='bbl-txt'+(srcTxt?'':' loading');
+  var tgtClass='bbl-txt'+(tgtTxt?'':' loading');
+
+  var body='<div class="bbl-body">'
+    +'<div class="bbl-side">'
+    +'<div class="'+srcClass+'" id="bsrc-'+id+'">'+renderMd(srcTxt)+'</div>'
+    +'<div class="bbl-side-acts">'
+    +'<button class="bbl-use" data-use-src="'+id+'">Use</button>'
+    +'<button class="bbl-tts" onclick="speak('+aS+','+aSL+',this)" title="Listen">'+ICON_TTS+'</button>'
+    +'</div></div>'
+    +'<div class="bbl-divider"></div>'
+    +'<div class="bbl-side">'
+    +'<div class="'+tgtClass+'" id="btgt-'+id+'">'+renderMd(tgtTxt)+'</div>'
+    +'<div class="bbl-side-acts">'
+    +'<button class="bbl-use" data-use-tgt="'+id+'">Use</button>'
+    +'<button class="bbl-tts" onclick="speak('+aT+','+aTL+',this)" title="Listen">'+ICON_TTS+'</button>'
+    +'</div></div>'
+    +'</div>';
+
+  // Footer row: Save/Delete | Tags | Clarify | Back-translate — plain icons, no state
+  var saveBtn=ctx==='phrasebook'
+    ?'<button class="bbl-act" onclick="confirmDeleteCard(\''+id+'\')" title="Delete">'+ICON_DELETE+'</button>'
+    :'<button class="bbl-act" onclick="bblSave(\''+id+'\')" title="Save">'+ICON_SAVE+'</button>';
+
+  var footer='<div class="bbl-foot">'
+    +'<div class="bbl-foot-bar">'
+    +saveBtn
+    +'<button class="bbl-act" data-role="tags" onclick="toggleMsgTagDrawer(\''+id+'\')" title="Tags">#</button>'
+    +'<button class="bbl-act" data-role="clarify" id="bact-c-'+id+'" onclick="bblClarifyClick(\''+id+'\',\''+ctx+'\')" title="Clarify">'+ICON_CLARIFY+'</button>'
+    +'<button class="bbl-act" data-role="bt" onclick="toggleBubbleBacktranslate(\''+id+'\',\''+ctx+'\')" title="Back-translate">'+ICON_BACK+'</button>'
+    +'</div>'
+    // Tag drawer
+    +'<div class="tag-drawer" id="msg-tag-drawer-'+id+'">'
+    +'<div class="pb-tags-row" id="msg-tag-assigned-'+id+'"></div>'
+    +'<input class="tag-drawer-input" id="msg-tag-input-'+id+'" placeholder="Find or add tag…" oninput="renderMsgTagResults(\''+id+'\')" onkeydown="if(event.key===\'Enter\'){event.preventDefault();submitMsgTagInput(\''+id+'\');}">'
+    +'<div class="tag-search-results" id="msg-tag-results-'+id+'"></div>'
+    +'</div>'
+    // Clarify panel
+    +'<div class="clarify-block" id="bclarify-'+id+'">'
+    +'<div class="clarify-thread" id="bclarify-thread-'+id+'"></div>'
+    +'<div class="clarify-compose">'
+    +'<input class="clarify-input" id="bclarify-input-'+id+'" placeholder="Add clarify note…" onkeydown="if(event.key===\'Enter\'){event.preventDefault();sendClarifyNote(\''+id+'\',\''+ctx+'\');}">'
+    +'<button class="clarify-send" onclick="sendClarifyNote(\''+id+'\',\''+ctx+'\')">Send</button>'
+    +'</div></div>'
+    // Back-translate panel
+    +'<div class="bbl-backtrans" id="bbt-'+id+'">'
+    +'<div class="bbl-back-row"><button class="retranslate-btn" onclick="rerunBubbleBacktranslate(\''+id+'\',\''+ctx+'\')">Back translate</button></div>'
+    +'<div class="bbl-back-row"><div id="bbt-t-'+id+'" class="bbl-back-text"></div><button class="bbl-tts" onclick="bblBtTTS(\''+id+'\',\''+ctx+'\',this)" title="Listen">'+ICON_TTS+'</button></div>'
+    +'<div class="bbl-back-row" id="bbt-v-'+id+'"></div>'
+    +'</div>'
+    // Inline save confirm (chat only)
+    +(ctx==='chat'?'<div class="save-confirm" id="save-confirm-'+id+'"></div>':'')
+    +'</div>';
+
+  return header+body+footer;
+}
+
+// ════════════════════════════════════════════════════════
+// CHAT MESSAGE RENDERING
+// ════════════════════════════════════════════════════════
+function getSides(msg){
+  var sess=getSession(state.activeConvId)||{};
+  var myLang=getEffectiveReplyLang(sess,'owner','en');
+  var partnerLang=getEffectiveReplyLang(sess,'partner','en');
+
+  if(msg.from==='me'){
+    // Left: what I typed (my lang). Right: translation into partner's lang.
+    var srcTxt=msg.sourceText||'';
+    var srcLang=msg.sourceLang||myLang;
+    var targetKey=msg.targetLang||partnerLang;
+    var tgtInfo=getMsgTranslatedText(msg,targetKey,msg.targetText||'');
+    var tgtTxt=tgtInfo.text;
+    var tgtLang=targetKey;
+    return {srcLang:srcLang,srcTxt:srcTxt,srcTtsLang:srcLang,tgtLang:tgtLang,tgtTxt:tgtTxt,tgtTtsLang:tgtInfo.langUsed||tgtLang};
+  }else{
+    // Received message: left=translation (my lang), right=original (partner's lang).
+    // This way the reader sees the meaning first, source second.
+    var origTxt=msg.sourceText||'';
+    var origLang=msg.sourceLang||partnerLang;
+    var targetKey=msg.targetLang||myLang;
+    var transInfo=getMsgTranslatedText(msg,targetKey,msg.targetText||'');
+    var transTxt=transInfo.text;
+    var transLang=targetKey;
+    // srcTxt/srcLang = LEFT column, tgtTxt/tgtLang = RIGHT column
+    return {srcLang:transLang,srcTxt:transTxt,srcTtsLang:transInfo.langUsed||transLang,tgtLang:origLang,tgtTxt:origTxt,tgtTtsLang:msg.sourceLang||origLang};
+  }
+}
+
+// Back-translate always operates on the original source text → back to that lang
+// For 'mine': source is what I typed (srcLang), translate target back to srcLang
+// For 'theirs': source is what partner typed (tgtLang after swap), translate translation back to that lang
+function getBacktranslateContextFromMsg(msg){
+  var sess=getSession(state.activeConvId)||{};
+  var myLang=getEffectiveReplyLang(sess,'owner','en');
+  var partnerLang=getEffectiveReplyLang(sess,'partner','en');
+  if(msg.from==='me'){
+    // Back-translate: take partner-lang translation, translate back to my lang
+    var tgtTxt=getMsgTranslatedText(msg,msg.targetLang||partnerLang,msg.targetText||'').text;
+    return {inputText:tgtTxt,fromLang:partnerLang,toLang:msg.sourceLang||myLang};
+  }else{
+    // Back-translate: take my-lang translation, translate back to partner's lang (= source)
+    var transTxt=getMsgTranslatedText(msg,msg.targetLang||myLang,msg.targetText||'').text;
+    return {inputText:transTxt,fromLang:myLang,toLang:msg.sourceLang||partnerLang};
+  }
+}
+
+function renderMsg(msg){
+  if(msg.from==='system'){addSysMsg(msg.text||'');return;}
+  if(msg.from==='invite'){renderInviteCard(msg);return;}
+  var isMine=msg.from==='me';
+  var sides=getSides(msg);
+  var sess=getSession(state.activeConvId);
+  var name=msg.displayFromName||(isMine?((sess&&sess.myName)||'Me'):((sess&&sess.peerName)||'Partner'));
+  var bt=getMsgBacktranslate(msg);
+  var thread=ensureClarifyThread(msg);
+
+  var inner=buildBubbleCard({
+    id:msg.id,
+    srcTxt:sides.srcTxt,srcLang:sides.srcLang,srcTtsLang:sides.srcTtsLang,
+    tgtTxt:sides.tgtTxt,tgtLang:sides.tgtLang,tgtTtsLang:sides.tgtTtsLang,
+    headerLeft:name,
+    time:fmtTime(msg.timestamp||Date.now()),
+    status:msg.status||'sent',
+    deliveredAt:msg.deliveredAt||0,
+    readAt:msg.readAt||0,
+    isMine:isMine,
+    ctx:'chat',
+    thread:thread,
+    hasVerdict:!!(bt&&bt.verdict),
+    backResult:!!(bt&&bt.resultText)
+  });
+
+  var el=document.createElement('div');
+  el.className='msg-row'+(isMine?' mine':' theirs');
+  el.id='row-'+msg.id;
+  el.innerHTML='<div class="bubble-card">'+inner+'</div>';
+  document.getElementById('messages').appendChild(el);
+
+  // Restore open state for clarify/backtrans panels
+  if(thread.length){updateBblClarify(msg,'chat');}
+  if(bt&&bt.resultText){renderBubbleBacktranslateFooter(msg.id,'chat');}
+}
+
+function updateMessageStatusUI(msg){
+  if(!msg||!msg.id)return;
+  var row=document.getElementById('row-'+msg.id);
+  if(!row)return;
+  var dot=row.querySelector('.msg-status-dot');
+  if(!dot)return;
+  var deliveredOn=!!msg.deliveredAt||msg.status==='delivered'||msg.status==='translated';
+  var readOn=!!msg.readAt||msg.status==='translated';
+  dot.className='msg-status-dot '+(readOn?'on-read':(deliveredOn?'on-delivered':'off'));
+}
+
+function renderAllMessages(){
+  var c=document.getElementById('messages');c.innerHTML='';
+  state.messages.forEach(function(m){
+    renderMsg(m);
+  });
+  // Re-hydrate open panels from state and sync footer buttons
+  state.messages.forEach(function(m){
+    if(!m.id||m.from==='system')return;
+    if(state.chatTagOpen[m.id]){var td=document.getElementById('msg-tag-drawer-'+m.id);if(td){td.classList.add('open');renderMsgAssignedTags(m.id);}}
+    if(state.chatClarifyOpen[m.id]){var cb=document.getElementById('bclarify-'+m.id);if(cb){cb.classList.add('open');updateBblClarify(m,'chat');}}
+    if(state.chatBtOpen[m.id]){var bt=document.getElementById('bbt-'+m.id);if(bt){bt.classList.add('open');renderBubbleBacktranslateFooter(m.id,'chat');}}
+    syncFooterButtonState(m.id);
+  });
+  scrollBottom();
+}
+
+function updateTransDOM(msg){
+  var sides=getSides(msg);
+  if(msg.from==='me'){
+    // Right column = translation
+    var el=document.getElementById('btgt-'+msg.id);
+    if(el&&sides.tgtTxt){el.innerHTML=renderMd(sides.tgtTxt);el.classList.remove('loading');}
+  }else{
+    // Left column = translation (swapped for received)
+    var el=document.getElementById('bsrc-'+msg.id);
+    if(el&&sides.srcTxt){el.innerHTML=renderMd(sides.srcTxt);el.classList.remove('loading');}
+    // Right column = original (may already be set from wire)
+    var el2=document.getElementById('btgt-'+msg.id);
+    if(el2&&sides.tgtTxt){el2.innerHTML=renderMd(sides.tgtTxt);el2.classList.remove('loading');}
+  }
+}
+
+// ════════════════════════════════════════════════════════
+// BUBBLE ACTIONS (shared chat + phrasebook)
+// ════════════════════════════════════════════════════════
+
+// Back-translate with stale detection
+function getMsgBacktranslate(msg){
+  if(!msg||typeof msg!=='object')return normalizeBacktranslatePayload(null,{});
+  msg.backtranslate=normalizeBacktranslatePayload(msg.backtranslate,{});
+  return msg.backtranslate;
+}
+
+function getBacktranslateSource(id,ctx){
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(!card)return null;
+    // Back-translate: take target text, translate back to source lang
+    return {inputText:card.target||'',fromLang:card.targetLang||'en',toLang:card.sourceLang||'en',bt:normalizeBacktranslatePayload(card.backtranslate,{})};
+  }
+  var msg=findMsg(id);if(!msg)return null;
+  var bt=getMsgBacktranslate(msg);
+  var btCtx=getBacktranslateContextFromMsg(msg);
+  return {inputText:btCtx.inputText,fromLang:btCtx.fromLang,toLang:btCtx.toLang,bt:bt};
+}
+
+function renderBubbleBacktranslateFooter(id,ctx){
+  var src=getBacktranslateSource(id,ctx);if(!src)return;
+  var bt=src.bt;
+  var tEl=document.getElementById('bbt-t-'+id);
+  var vEl=document.getElementById('bbt-v-'+id);
+  if(tEl){
+    if(bt.stale){tEl.innerHTML='<span class="bbl-stale-prompt" onclick="rerunBubbleBacktranslate(\''+id+'\',\''+ctx+'\')">Verification out of date \u2014 tap to re-check.</span>';}
+    else{tEl.textContent=bt.resultText||'No back-translation yet.';}
+  }
+  if(vEl){
+    var html='';
+    // Auto quality suggestion (non-interactive label)
+    if(bt.resultText&&bt.autoQuality){
+      var qCls=bt.autoQuality==='good'?'good':bt.autoQuality==='partial'?'partial':'bad';
+      var qLabel=bt.autoQuality==='good'?'Good match':bt.autoQuality==='partial'?'Partial match':'Poor match';
+      html+='<div class="bbl-verdict-pill '+qCls+'" style="margin-right:6px;">'+qLabel+'</div>';
+    }
+    // Manual verdict state
+    if(bt.verdict==='good')html+='<div class="bbl-verdict-pill good">Sounds right \u2713</div>';
+    else if(bt.verdict==='flag')html+='<div class="bbl-verdict-pill bad">Flagged</div>';
+    else if(bt.resultText)html+='<button class="bbl-vbtn good" onclick="bblSetVerdict(\''+id+'\',\'good\',\''+ctx+'\')">Sounds right</button> <button class="bbl-vbtn bad" onclick="bblSetVerdict(\''+id+'\',\'flag\',\''+ctx+'\')">Flag</button>';
+    vEl.innerHTML=html;
+  }
+}
+
+function toggleBubbleBacktranslate(id,ctx){
+  var panel=document.getElementById('bbt-'+id);if(!panel)return;
+  var isOpen=panel.classList.contains('open');
+  panel.classList.toggle('open');
+  if(ctx==='phrasebook')state.pbBackOpen[id]=!isOpen;
+  else state.chatBtOpen[id]=!isOpen;
+  syncFooterButtonState(id);
+  if(!isOpen){
+    rerunBubbleBacktranslate(id,ctx||'chat');
+  }
+}
+
+// Clear previous back-translate result and verdict so it runs fresh
+function resetBacktranslateState(id,ctx){
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(!card)return;
+    card.backtranslate=normalizeBacktranslatePayload(card.backtranslate,{});
+    card.backtranslate.verdict='';card.backtranslate.autoQuality='';card.backtranslate.resultText='';
+    card.backtranslate.stale=false;
+    saveUpdatedCard(card);
+  }else{
+    var msg=findMsg(id);if(!msg)return;
+    var bt=getMsgBacktranslate(msg);
+    bt.verdict='';bt.autoQuality='';bt.resultText='';bt.stale=false;
+    saveMsgs(state.activeConvId,state.messages);
+  }
+}
+
+function rerunBubbleBacktranslate(id,ctx){
+  resetBacktranslateState(id,ctx||'chat');
+  var src=getBacktranslateSource(id,ctx||'chat');if(!src)return;
+  var txt=src.inputText;var from=src.fromLang;var to=src.toLang;
+  var tEl=document.getElementById('bbt-t-'+id);
+  var vEl=document.getElementById('bbt-v-'+id);
+  if(!txt){if(tEl)tEl.textContent='No text to verify';return;}
+  if(from===to){if(tEl)tEl.textContent='Same language \u2014 no back-translation needed';return;}
+  if(tEl){tEl.textContent='Checking\u2026';tEl.style.fontStyle='normal';}
+  if(vEl)vEl.innerHTML='';
+  translate(txt,from,to).then(function(back){
+    if(ctx==='phrasebook'){
+      var card=getCardById(id);if(!card)return;
+      card.backtranslate=normalizeBacktranslatePayload(card.backtranslate,{sourceLang:from,targetLang:to,inputText:txt,resultText:back||'',contentHash:btContentHash(card.source,card.target),updatedAt:Date.now()});
+      card.backtranslate.stale=false;
+      saveUpdatedCard(card);
+    }else{
+      var msg=findMsg(id);if(!msg)return;
+      msg.backtranslate=normalizeBacktranslatePayload(msg.backtranslate,{sourceLang:from,targetLang:to,inputText:txt,resultText:back||'',contentHash:btContentHash(msg.sourceText,msg.targetText),updatedAt:Date.now()});
+      msg.backtranslate.stale=false;
+      saveMsgs(state.activeConvId,state.messages);
+    }
+    renderBubbleBacktranslateFooter(id,ctx||'chat');
+    autoSetMatchQuality(id,ctx||'chat');
+  });
+}
+
+// Fix 3: Compare back-translation to original and set quality label
+function autoSetMatchQuality(id,ctx){
+  var src=getBacktranslateSource(id,ctx);if(!src||!src.bt||!src.bt.resultText)return;
+  var originalText='';
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(card)originalText=card.source||'';
+  }else{
+    var msg=findMsg(id);if(!msg)return;
+    originalText=msg.sourceText||'';
+  }
+  if(!originalText)return;
+  var quality=computeMatchQuality(originalText,src.bt.resultText);
+  // Store as suggestion label (autoQuality), never overwrite manual verdict
+  src.bt.autoQuality=quality;
+  if(ctx==='phrasebook'){var card2=getCardById(id);if(card2){card2.backtranslate=src.bt;saveUpdatedCard(card2);}}
+  else{saveMsgs(state.activeConvId,state.messages);}
+  renderBubbleBacktranslateFooter(id,ctx);
+}
+function computeMatchQuality(original,backTranslated){
+  if(!original||!backTranslated)return '';
+  var a=original.toLowerCase().trim().replace(/[.,!?;:'"]/g,'');
+  var b=backTranslated.toLowerCase().trim().replace(/[.,!?;:'"]/g,'');
+  if(a===b)return 'good';
+  var wordsA=a.split(/\s+/).filter(Boolean);
+  var wordsB=b.split(/\s+/).filter(Boolean);
+  if(!wordsA.length||!wordsB.length)return 'partial';
+  var setB=new Set(wordsB);
+  var overlap=wordsA.filter(function(w){return setB.has(w);}).length;
+  var ratio=overlap/Math.max(wordsA.length,wordsB.length);
+  if(ratio>=0.7)return 'good';
+  if(ratio>=0.3)return 'partial';
+  return 'poor';
+}
+
+function bblSetVerdict(id,val,ctx){
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(!card)return;
+    var bt=normalizeBacktranslatePayload(card.backtranslate,{});
+    bt.verdict=bt.verdict===val?'':val;bt.updatedAt=Date.now();
+    card.backtranslate=bt;saveUpdatedCard(card);
+  }else{
+    var msg=findMsg(id);if(!msg)return;
+    var bt2=getMsgBacktranslate(msg);
+    bt2.verdict=bt2.verdict===val?'':val;bt2.updatedAt=Date.now();
+    msg.backtranslate=bt2;saveMsgs(state.activeConvId,state.messages);
+    // broadcast verdict to peer
+    transportSend({type:'msg-meta',id:id,verdict:bt2.verdict,timestamp:Date.now()});
+  }
+  renderBubbleBacktranslateFooter(id,ctx||'chat');
+  toast(val==='good'?'Verified \u2713':'Flagged');
+}
+
+function bblBtTTS(id,ctx,btn){
+  var src=getBacktranslateSource(id,ctx||'chat');if(!src||!src.bt.resultText)return;
+  speak(src.bt.resultText,src.toLang,btn);
+}
+
+// Clarify (shared)
+function bblClarifyClick(id,ctx){
+  var blk=document.getElementById('bclarify-'+id);if(!blk)return;
+  var isOpen=blk.classList.contains('open');
+  blk.classList.toggle('open');
+  if(ctx==='phrasebook')state.pbClarifyOpen[id]=!isOpen;
+  else state.chatClarifyOpen[id]=!isOpen;
+  syncFooterButtonState(id);
+  if(!isOpen){
+    var msg=ctx==='phrasebook'?null:findMsg(id);
+    if(msg)updateBblClarify(msg,ctx);
+    else updateBblClarifyFromCard(id);
+  }
+}
+
+function ensureClarifyThread(msg){if(!msg.clarify||typeof msg.clarify!=='object')msg.clarify={status:'none',text:''};if(!Array.isArray(msg.clarify.thread))msg.clarify.thread=[];return msg.clarify.thread;}
+function appendClarifyNote(msg,text,author,ts){var body=(text||'').trim();if(!body)return;var thread=ensureClarifyThread(msg);thread.push({text:body,author:author||'Partner',timestamp:ts||Date.now()});msg.clarify.status='thread';msg.clarify.text=body;}
+
+function buildClarifyThreadHtml(thread,id,ctx){
+  if(!thread.length)return '<div class="clarify-empty">No clarify notes yet.</div>';
+  return thread.map(function(item,idx){
+    return '<div class="clarify-item">'
+      +'<div class="clarify-item-hdr"><span class="clarify-author">'+escHtml(item.author||'Partner')+'</span><span class="clarify-ts">'+fmtDateTime(item.timestamp||Date.now())+'</span>'
+      +'<button class="clarify-remove" onclick="removeClarifyItem(\''+id+'\','+idx+',\''+ctx+'\')" title="Remove">×</button></div>'
+      +'<div class="clarify-body">'+renderMd(item.text||'')+'</div>'
+      +'</div>';
+  }).join('');
+}
+
+function updateBblClarify(msg,ctx){
+  var threadEl=document.getElementById('bclarify-thread-'+msg.id);
+  var thread=ensureClarifyThread(msg);
+  if(threadEl)threadEl.innerHTML=buildClarifyThreadHtml(thread,msg.id,ctx||'chat');
+}
+
+function updateBblClarifyFromCard(id){
+  var card=getCardById(id);if(!card)return;
+  var threadEl=document.getElementById('bclarify-thread-'+id);
+  var thread=card.clarifyChain||[];
+  if(threadEl)threadEl.innerHTML=buildClarifyThreadHtml(thread,id,'phrasebook');
+}
+
+function removeClarifyItem(id,idx,ctx){
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(!card)return;
+    var chain=card.clarifyChain||[];if(idx<0||idx>=chain.length)return;
+    chain.splice(idx,1);card.clarifyChain=chain;saveUpdatedCard(card);updateBblClarifyFromCard(id);
+  }else{
+    var msg=findMsg(id);if(!msg)return;
+    var thread=ensureClarifyThread(msg);if(idx<0||idx>=thread.length)return;
+    thread.splice(idx,1);saveMsgs(state.activeConvId,state.messages);updateBblClarify(msg,ctx);
+  }
+}
+
+function sendClarifyNote(id,ctx){
+  var input=document.getElementById('bclarify-input-'+id);if(!input)return;
+  var note=(input.value||'').trim();if(!note)return;
+  var sess=getSession(state.activeConvId);
+  var myName=(sess&&sess.myName)||'Me';
+
+  if(ctx==='phrasebook'){
+    var card=getCardById(id);if(!card)return;
+    card.clarifyChain=(card.clarifyChain||[]).concat([{text:note,author:myName,timestamp:Date.now()}]);
+    saveUpdatedCard(card);input.value='';updateBblClarifyFromCard(id);
+  }else{
+    var msg=findMsg(id);if(!msg)return;
+    appendClarifyNote(msg,note,myName,Date.now());
+    input.value='';saveMsgs(state.activeConvId,state.messages);
+    transportSend({type:'clarify-note',id:id,text:note,name:myName,timestamp:Date.now()});
+    updateBblClarify(msg,ctx||'chat');
+    upsertClarifiedPhrase(msg);
+  }
+  // Panel stays open — per plan §1.2D
+}
+
+// One-tap save with inline confirm
+function bblSave(id){
+  var msg=findMsg(id);if(!msg)return;
+  var sess=getSession(state.activeConvId)||{};
+  var myLang=getEffectiveReplyLang(sess,'owner','en');
+  var partnerLang=getEffectiveReplyLang(sess,'partner','en');
+
+  // Card always stores: source = what was originally typed, target = translation
+  var sourceText, sourceLang, targetText, targetLang;
+  if(msg.from==='me'){
+    sourceText=msg.sourceText||'';sourceLang=msg.sourceLang||myLang;
+    targetLang=msg.targetLang||partnerLang;
+    targetText=getMsgTranslatedText(msg,targetLang,msg.targetText||'').text;
+  }else{
+    sourceText=msg.sourceText||'';sourceLang=msg.sourceLang||partnerLang;
+    targetLang=msg.targetLang||myLang;
+    targetText=getMsgTranslatedText(msg,targetLang,msg.targetText||'').text;
+  }
+  if(!sourceText){toast('Nothing to save');return;}
+  if(!targetText){toast('Wait for translation before saving');return;}
+
+  msg._saved=true;saveMsgs(state.activeConvId,state.messages);
+  var bt=getMsgBacktranslate(msg);var thread=ensureClarifyThread(msg);
+  var card=normalizeCard({
+    id:uid(),catalogIds:[],
+    sourceLang:sourceLang,targetLang:targetLang,
+    source:sourceText,target:targetText,
+    notes:'',tags:sanitizeTagList(msg.tags||[]),
+    backtranslate:normalizeBacktranslatePayload(bt,{sourceLang:targetLang,targetLang:sourceLang,inputText:targetText,resultText:'',verdict:'',contentHash:btContentHash(sourceText,targetText),updatedAt:Date.now()}),
+    clarifyChain:thread.map(function(item){return{text:item.text||'',author:item.author||'Partner',timestamp:item.timestamp||Date.now()};}),
+    savedBy:getPrefs().userName||'Me',
+    createdAt:Date.now(),updatedAt:Date.now()
+  });
+  upsertCardLastWins(card);  // overwrites by (source+sourceLang+target+targetLang) key
+  var conf=document.getElementById('save-confirm-'+id);
+  if(conf){
+    conf.innerHTML='Saved ✓ <a onclick="openPhrasebookModal()">Edit</a>';
+    conf.classList.add('show');
+    clearTimeout(conf._t);
+    conf._t=setTimeout(function(){conf.classList.remove('show');},4000);
+  }
+  toast('Saved to phrasebook');
+}
+
+function upsertClarifiedPhrase(msg){
+  if(!msg||!msg.clarify)return;
+  var s=getSides(msg);var src=(s.srcTxt||'').trim();if(!src)return;
+  var tgt=(s.tgtTxt||'').trim();
+  var cards=getCards();var thread=ensureClarifyThread(msg);
+  var chain=thread.map(function(item){return{text:item.text||'',author:item.author||'Partner',timestamp:item.timestamp||Date.now()};});
+  var notes=chain.map(function(item){return(item.author||'Partner')+': '+(item.text||'');}).join('\n');
+  var card=cards.find(function(c){return(c.source||'').trim()===src&&(c.sourceLang||'en')===s.srcLang&&(c.target||'').trim()===tgt&&(c.targetLang||'en')===s.tgtLang;});
+  if(card){card.notes=notes||card.notes||'';card.clarifyChain=chain.slice();card.updatedAt=Date.now();}
+  else{cards.unshift(normalizeCard({id:uid(),catalogIds:[],sourceLang:s.srcLang||'en',targetLang:s.tgtLang||'en',source:src,target:tgt,notes:notes||'',tags:[],backtranslate:{sourceLang:'',targetLang:'',inputText:'',resultText:'',verdict:'',updatedAt:Date.now()},clarifyChain:chain.slice(),createdAt:Date.now(),updatedAt:Date.now()}));}
+  saveCards(cards);
+}
+
+// Tags (shared)
+function toggleMsgTagDrawer(id){
+  var el=document.getElementById('msg-tag-drawer-'+id);if(!el)return;
+  el.classList.toggle('open');
+  state.chatTagOpen[id]=el.classList.contains('open');
+  syncFooterButtonState(id);
+  if(el.classList.contains('open')){renderMsgAssignedTags(id);renderMsgTagResults(id);}
+}
+// Fix 5: Sync all footer button active states for a bubble
+function syncFooterButtonState(id){
+  var row=document.getElementById('row-'+id);if(!row)return;
+  // Read actual DOM state of each drawer
+  var tagDrawer=document.getElementById('msg-tag-drawer-'+id);
+  var clarifyDrawer=document.getElementById('bclarify-'+id);
+  var btDrawer=document.getElementById('bbt-'+id);
+  var tagIsOpen=tagDrawer&&tagDrawer.classList.contains('open');
+  var clarifyIsOpen=clarifyDrawer&&clarifyDrawer.classList.contains('open');
+  var btIsOpen=btDrawer&&btDrawer.classList.contains('open');
+  // Find buttons and set/clear active state explicitly
+  var btns=row.querySelectorAll('.bbl-act[data-role]');
+  for(var i=0;i<btns.length;i++){
+    var role=btns[i].getAttribute('data-role');
+    var active=false;
+    if(role==='tags')active=!!tagIsOpen;
+    else if(role==='clarify')active=!!clarifyIsOpen;
+    else if(role==='bt')active=!!btIsOpen;
+    if(active){btns[i].classList.add('active-chip');}
+    else{btns[i].classList.remove('active-chip');}
+  }
+}
+function ensureMsgTags(msg){if(!msg)return[];if(!Array.isArray(msg.tags))msg.tags=[];msg.tags=sanitizeTagList(msg.tags);return msg.tags;}
+function renderMsgAssignedTags(id){
+  var msg=findMsg(id)||getCardById(id);
+  var el=document.getElementById('msg-tag-assigned-'+id);if(!msg||!el)return;
+  var tags=msg.tags?sanitizeTagList(msg.tags):[];
+  el.innerHTML=tags.map(function(t){return '<span class="pb-tag-pill">#'+escHtml(t)+'<button onclick="removeMsgTag(\''+id+'\',\''+t+'\')">×</button></span>';}).join('');
+}
+function renderMsgTagResults(id){
+  var input=document.getElementById('msg-tag-input-'+id);
+  var out=document.getElementById('msg-tag-results-'+id);if(!out)return;
+  out.innerHTML=renderTagSearchChips(input&&input.value||'','assignMsgTag',id);
+}
+function submitMsgTagInput(id){var input=document.getElementById('msg-tag-input-'+id);if(!input)return;assignMsgTag(id,input.value||'');input.value='';renderMsgTagResults(id);}
+function assignMsgTag(id,tag){
+  var n=normalizeTag(tag||'');if(!n)return;
+  var msg=findMsg(id);
+  if(msg){
+    var tags=ensureMsgTags(msg);if(tags.indexOf(n)<0)tags.push(n);
+    addTagToRegistry(n);saveMsgs(state.activeConvId,state.messages);
+    // broadcast tag update to peer
+    transportSend({type:'msg-meta',id:id,tags:tags,timestamp:Date.now()});
+  }else{
+    var card=getCardById(id);
+    if(card){card.tags=sanitizeTagList((card.tags||[]).concat([n]));addTagToRegistry(n);saveUpdatedCard(card);}
+  }
+  renderMsgAssignedTags(id);renderMsgTagResults(id);
+}
+function removeMsgTag(id,tag){
+  var n=normalizeTag(tag||'');
+  var msg=findMsg(id);
+  if(msg){
+    msg.tags=ensureMsgTags(msg).filter(function(t){return t!==n;});
+    saveMsgs(state.activeConvId,state.messages);
+    transportSend({type:'msg-meta',id:id,tags:msg.tags,timestamp:Date.now()});
+  }else{
+    var card=getCardById(id);
+    if(card){card.tags=sanitizeTagList((card.tags||[]).filter(function(t){return t!==n;}));saveUpdatedCard(card);}
+  }
+  renderMsgAssignedTags(id);renderMsgTagResults(id);
+}
+
+// Sys msg
+function addSysMsg(t){var c=document.getElementById('messages');if(!c)return;var d=document.createElement('div');d.className='sys-msg';d.textContent=t;c.appendChild(d);scrollBottom();}
+
+function renderInviteCard(msg){
+  var c=document.getElementById('messages');if(!c)return;
+  var cid=msg.convId||state.activeConvId;
+  var sess=cid?getSession(cid):null;
+  var currentUrl=sess?buildInviteUrl(sess,getPrefs(),'partner-invite'):'';
+  var needsMigration=!msg.inviteUrl||isLegacyInviteUrl(msg.inviteUrl)||!decodeInvitePayload(new URLSearchParams(String(msg.inviteUrl).split('#')[1]||'').get('i'));
+  if(currentUrl&&needsMigration&&msg.inviteUrl!==currentUrl){
+    msg.inviteUrl=currentUrl;
+    if(cid&&state.messages&&state.messages.indexOf(msg)>=0)saveMsgs(cid,state.messages);
+  }
+  var url=msg.inviteUrl||currentUrl||'';
+  var card=document.createElement('div');
+  card.id='invite-card-'+msg.id;
+  card.style.cssText='background:#fff;border:1.5px solid var(--border);border-radius:14px;padding:16px;margin:8px 0;display:flex;flex-direction:column;align-items:center;gap:10px;';
+  // Timestamp
+  var ts=document.createElement('div');
+  ts.style.cssText='font-size:10px;color:var(--ink-dim);';
+  ts.textContent='Session created \u00b7 '+fmtDateTime(msg.timestamp);
+  card.appendChild(ts);
+  // QR code
+  var qrWrap=document.createElement('div');
+  qrWrap.style.cssText='width:180px;height:180px;background:#fff;border:1px solid var(--border);border-radius:8px;display:flex;align-items:center;justify-content:center;overflow:hidden;';
+  card.appendChild(qrWrap);
+  var qrLabel=document.createElement('div');
+  qrLabel.style.cssText='font-size:11px;color:var(--ink-dim);font-weight:600;';
+  qrLabel.textContent='Partner invite QR/link';
+  card.appendChild(qrLabel);
+  // Link
+  var linkDiv=document.createElement('div');
+  linkDiv.style.cssText='width:100%;background:var(--paper);border:1px solid var(--border);border-radius:8px;padding:6px 8px;word-break:break-all;font-size:10px;color:var(--teal);font-weight:600;';
+  linkDiv.textContent=url;
+  card.appendChild(linkDiv);
+  // Buttons
+  var btnRow=document.createElement('div');
+  btnRow.style.cssText='display:flex;gap:6px;width:100%;';
+  var copyBtn=document.createElement('button');
+  copyBtn.textContent='Copy';
+  copyBtn.style.cssText='flex:1;background:var(--teal);color:#fff;border:none;border-radius:8px;padding:8px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;';
+  copyBtn.addEventListener('click',function(){copyTextToClipboard(url);});
+  btnRow.appendChild(copyBtn);
+  if(navigator.share){
+    var shareBtn=document.createElement('button');
+    shareBtn.textContent='Share';
+    shareBtn.style.cssText='flex:1;background:var(--paper);color:var(--ink-mid);border:1.5px solid var(--border);border-radius:8px;padding:8px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;';
+    shareBtn.addEventListener('click',function(){navigator.share({url:url}).catch(function(){});});
+    btnRow.appendChild(shareBtn);
+  }
+  card.appendChild(btnRow);
+  // Status line
+  var statusDiv=document.createElement('div');
+  statusDiv.id='invite-status-'+msg.convId;
+  statusDiv.style.cssText='font-size:11px;color:var(--ink-dim);';
+  card.appendChild(statusDiv);
+  c.appendChild(card);
+  // Draw QR
+  if(url&&window.QRCode){
+    try{new QRCode(qrWrap,{text:url,width:180,height:180,colorDark:'#1A1714',colorLight:'#ffffff',correctLevel:QRCode.CorrectLevel.H});}catch(e){}
+  }
+  refreshInviteStatus(msg.convId);
+}
+
+// Composer
+function autoResize(){var el=document.getElementById('msg-input');if(!el)return;el.style.height='auto';el.style.height=Math.min(el.scrollHeight,110)+'px';}
+function updateSendBtn(){var el=document.getElementById('msg-input');var sb=document.getElementById('send-btn');if(sb)sb.disabled=!(el&&el.value.trim());}
+function composerInput(){
+  autoResize();updateSendBtn();
+  if(!localTypingActive){localTypingActive=true;sendTyping('start');}
+  if(typingStopTimer)clearTimeout(typingStopTimer);
+  typingStopTimer=setTimeout(function(){if(localTypingActive){localTypingActive=false;sendTyping('stop');}},1800);
+}
+function composerKeydown(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendMessage();}}
+function sendTyping(kind){
+  var sess=getSession(state.activeConvId);var n=normalizeSession(sess||{});
+  transportSend({type:'typing',typing:kind||'start',name:firstRealName(n.myHandle,n.myName,getPreferredOwnerName())||'yournamehere',myHandle:firstRealName(n.myHandle,n.myName,getPreferredOwnerName())||'yournamehere',effectiveTargetLang:getEffectiveTargetLang(n),lang:effectiveLangFromSession(n),side:'owner',identityId:n.ownerIdentityId,timestamp:Date.now()});
+}
+function showTyping(n,kind){
+  var el=document.getElementById('typing-bar');var sess=getSession(state.activeConvId);
+  if(!el)return;
+  if(kind==='stop'){el.textContent='';if(typingTimer)clearTimeout(typingTimer);return;}
+  el.textContent=(firstRealName(n,sess&&sess.partnerHandle,sess&&sess.peerName)||'Partner')+' is typing…';
+  clearTimeout(typingTimer);typingTimer=setTimeout(function(){if(el)el.textContent='';},3200);
+}
+
+async function sendMessage(){
+  var ta=document.getElementById('msg-input');var text=ta.value.trim();if(!text)return;
+  if(localTypingActive){localTypingActive=false;sendTyping('stop');}
+  if(typingStopTimer){clearTimeout(typingStopTimer);typingStopTimer=null;}
+  var sess=getSession(state.activeConvId);if(!sess)return;
+  var p=getPrefs();
+
+  var ownerEffective=getEffectiveReplyLang(sess,'owner','en');
+  var explicitLang=(sess.ownerLangMode==='fixed')?normalizeLangSetting(sess.ownerFixedLang||''):'';
+  var detectedLang=detectLang(text,detectBrowserLang()||'en');
+  // Case A/B language rules:
+  // A) auto => semantic source and expected replies follow detected typed language.
+  // B) fixed => semantic source normalizes to fixed language and expected replies stay fixed.
+  var outLang=explicitLang||(detectedLang||ownerEffective||'en');
+  var outboundText=text;
+  if(explicitLang&&detectedLang&&detectedLang!==explicitLang){
+    try{
+      outboundText=(await translate(text,detectedLang,explicitLang))||text;
+    }catch(_){outboundText=text;}
+  }
+  var partnerTargetLang=getEffectiveReplyLang(sess,'partner','en');
+  sess.ownerLastSentLang=outLang;
+  setEffectiveReplyLang(sess,'owner',outLang);
+  putSession(sess);
+
+  var msg=normalizeMsgSchema({id:uid(),from:'me',ownerRole:'owner',sourceText:outboundText,sourceLang:outLang,targetLang:partnerTargetLang,targetText:'',text:outboundText,lang:outLang,translated:null,status:'sent',timestamp:Date.now(),clarify:{status:'none',text:'',thread:[]},translations:{}},{sourceLang:outLang,targetLang:partnerTargetLang});
+  stampMsgNames(msg,sess);
+  state.messages.push(msg);renderMsg(msg);ta.value='';autoResize();updateSendBtn();scrollBottom();
+  sess.lastActivity=msg.timestamp;putSession(sess);
+
+  var payload={type:'msg',id:msg.id,sourceText:msg.sourceText,sourceLang:msg.sourceLang,targetText:'',targetLang:partnerTargetLang,effectiveTargetLang:getEffectiveTargetLang(sess),translations:msg.translations,orig:msg.sourceText,lang:msg.sourceLang,timestamp:msg.timestamp,name:firstRealName(sess.myHandle,sess.myName,p.globalName,p.userName)||'yournamehere',myHandle:firstRealName(sess.myHandle,sess.myName,p.globalName,p.userName)||'yournamehere',side:'owner',identityId:sess.ownerIdentityId};
+  var ok=sendReliable(payload);
+  if(!ok){msg.status='queued';addDiagLog('TX msg QUEUED id='+msg.id.slice(0,8),'warn');}
+  else{msg.status='sent';addDiagLog('TX msg SENT id='+msg.id.slice(0,8)+' src='+outLang+' tgt='+msg.targetLang);}
+  saveMsgs(sess.convId,state.messages);
+  updateMessageStatusUI(msg);
+
+  // Translate locally so sender sees target column filled in their own bubble
+  if(outLang===msg.targetLang){
+    applyMsgTarget(msg,msg.targetLang,outboundText);
+    updateTransDOM(msg);
+    saveMsgs(sess.convId,state.messages);
+  }else{
+    translate(outboundText,outLang,msg.targetLang).then(function(tr){
+      applyMsgTarget(msg,msg.targetLang,tr||outboundText);
+      updateTransDOM(msg);
+      saveMsgs(sess.convId,state.messages);
+    });
+  }
+}
+
+function insertPhrase(src){
+  var ta=document.getElementById('msg-input');
+  if(ta){ta.value=src||'';autoResize();updateSendBtn();setTimeout(function(){ta.focus();},50);}
+  if(document.getElementById('catalog-screen').classList.contains('active'))closePhrasebookView();
+}
+// Event delegation for Use buttons — reads text from sibling .bbl-txt element
+document.addEventListener('click',function(e){
+  var btn=e.target.closest('.bbl-use[data-use-src],.bbl-use[data-use-tgt]');
+  if(!btn)return;
+  var id=btn.getAttribute('data-use-src')||btn.getAttribute('data-use-tgt');
+  if(!id)return;
+  var isSrc=btn.hasAttribute('data-use-src');
+  var textEl=document.getElementById(isSrc?'bsrc-'+id:'btgt-'+id);
+  if(textEl){insertPhrase(textEl.textContent.trim());}
+});
+
+// ════════════════════════════════════════════════════════
+// PHRASEBOOK CARD RENDERING (unified bubble renderer)
+// ════════════════════════════════════════════════════════
+function renderCatalogCards(){
+  var q=(document.getElementById('cat-search')&&document.getElementById('cat-search').value||'').trim().toLowerCase();
+  var cards=getCards();
+  var activeCatalogId=getActivePhrasebookCatalogId();
+  if(activeCatalogId!=='all')cards=cards.filter(function(c){return(c.catalogIds||[]).indexOf(activeCatalogId)>=0;});
+  if(q)cards=cards.filter(function(c){return(c.source||'').toLowerCase().indexOf(q)>=0||(c.target||'').toLowerCase().indexOf(q)>=0||(c.tags||[]).join(' ').toLowerCase().indexOf(q)>=0;});
+  cards.sort(function(a,b){return(b.updatedAt||0)-(a.updatedAt||0);});
+  var clear=document.getElementById('cat-search-clear');if(clear)clear.classList.toggle('show',!!q);
+
+  // Filter chip
+  renderFilterChip();
+
+  var list=document.getElementById('card-list');if(!list)return;
+  if(!cards.length){list.innerHTML='<div style="text-align:center;padding:24px;color:var(--ink-dim);">No phrases.</div>';return;}
+
+  list.innerHTML=cards.map(function(c){
+    var bt=normalizeBacktranslatePayload(c.backtranslate,{sourceLang:c.targetLang||'en',targetLang:c.sourceLang||'en',inputText:c.target||'',resultText:'',verdict:'',contentHash:btContentHash(c.source,c.target)});
+    var thread=c.clarifyChain||[];
+    var tags=sanitizeTagList(c.tags||[]);
+    var savedBy=c.savedBy?('Saved by '+c.savedBy+' \u00b7 '+fmtDateTime(c.createdAt)):(fmtDateTime(c.createdAt)||'');
+
+    var inner=buildBubbleCard({
+      id:c.id,
+      srcTxt:c.source||'',srcLang:c.sourceLang||'en',
+      tgtTxt:c.target||'',tgtLang:c.targetLang||'en',
+      headerLeft:savedBy,
+      time:timeAgo(c.updatedAt),
+      prov:'',
+      isMine:false,
+      ctx:'phrasebook',
+      thread:thread,
+      hasVerdict:!!(bt&&bt.verdict),
+      backResult:!!(bt&&bt.resultText)
+    });
+
+    return '<div class="pb-row-wrap" id="pbrow-'+c.id+'">'
+      +'<div class="msg-row theirs" id="row-'+c.id+'">'
+      +'<div class="bubble-card">'+inner+'</div>'
+      +'</div>'
+      +'</div>';
+  }).join('');
+
+  // Fix 7: Render phrasebook recycle bin
+  renderPbRecycleBin();
+
+  // Re-hydrate open panels and sync footer buttons
+  cards.forEach(function(c){
+    if(state.pbBackOpen[c.id]){
+      var panel=document.getElementById('bbt-'+c.id);if(panel)panel.classList.add('open');
+      renderBubbleBacktranslateFooter(c.id,'phrasebook');
+    }
+    if(state.pbClarifyOpen[c.id]){
+      var blk=document.getElementById('bclarify-'+c.id);if(blk)blk.classList.add('open');
+      updateBblClarifyFromCard(c.id);
+    }
+    if(state.pbTagDrawer[c.id]){
+      var td=document.getElementById('msg-tag-drawer-'+c.id);if(td){td.classList.add('open');renderMsgAssignedTags(c.id);}
+    }
+    renderMsgAssignedTags(c.id);
+    syncFooterButtonState(c.id);
+  });
+}
+
+function renderFilterChip(){
+  var row=document.getElementById('filter-chip-row');if(!row)return;
+  var active=getActivePhrasebookCatalogId();
+  if(active==='all'){row.innerHTML='';return;}
+  var cats=getCatalogs();var cat=cats.find(function(c){return c.id===active;});
+  if(!cat){row.innerHTML='';return;}
+  var lbl=(cat.emoji?cat.emoji+' ':'')+(cat.name||'Catalog');
+  row.innerHTML='<button class="filter-chip">'+escHtml(lbl)+'<button class="filter-chip-x" onclick="clearCatalogFilter()" title="Clear filter">×</button></button>';
+}
+function clearCatalogFilter(){state.currentCatId='all';renderCatalogCards();document.getElementById('cat-screen-title').textContent='Phrasebook';}
+
+// ════════════════════════════════════════════════════════
+// SETTINGS
+// ════════════════════════════════════════════════════════
+var THEMES=[
+  {id:'default',label:'Ocean',mine:'#2E8B8B',theirs:'#F5F1EC',hdr:'#267878'},
+  {id:'midnight',label:'Midnight',mine:'#1e293b',theirs:'#f8fafc',hdr:'#0f172a'},
+  {id:'rose',label:'Rose',mine:'#be123c',theirs:'#fff1f2',hdr:'#9f1239'},
+  {id:'forest',label:'Forest',mine:'#166534',theirs:'#f0fdf4',hdr:'#14532d'},
+  {id:'amber',label:'Amber',mine:'#b45309',theirs:'#fffbeb',hdr:'#92400e'},
+  {id:'purple',label:'Violet',mine:'#7c3aed',theirs:'#f5f3ff',hdr:'#6d28d9'}
+];
+var BUBBLE_DEFAULTS={sourceTheme:'default',targetTheme:'default',bubbleWidth:75,bubbleFontSize:15,targetBubbleFontSize:15,accentColor:'#2E8B8B',targetAccentColor:'#1A1714'};
+var PRESET_PALETTES={
+  light:[
+    {id:'atomic-tangerine',label:'Atomic Tangerine',hex:'#ff6b35'},
+    {id:'peach-glow',label:'Peach Glow',hex:'#f7c59f'},
+    {id:'beige',label:'Beige',hex:'#efefd0'},
+    {id:'steel-azure',label:'Steel Azure',hex:'#004e89'},
+    {id:'baltic-blue',label:'Baltic Blue',hex:'#1a659e'}
+  ],
+  medium:[
+    {id:'pacific-blue',label:'Pacific Blue',hex:'#46b1c9'},
+    {id:'frosted-blue',label:'Frosted Blue',hex:'#84c0c6'},
+    {id:'ash-grey',label:'Ash Grey',hex:'#9fb7b9'},
+    {id:'ash-grey-2',label:'Ash Grey 2',hex:'#bcc1ba'},
+    {id:'almond-cream',label:'Almond Cream',hex:'#f2e2d2'}
+  ],
+  dark:[
+    {id:'gunmetal',label:'Gunmetal',hex:'#474448'},
+    {id:'shadow-grey',label:'Shadow Grey',hex:'#2d232e'},
+    {id:'bone',label:'Bone',hex:'#e0ddcf'},
+    {id:'taupe-grey',label:'Taupe Grey',hex:'#534b52'},
+    {id:'parchment',label:'Parchment',hex:'#f1f0ea'}
+  ]
+};
+function paletteColorById(preset,id){
+  var colors=PRESET_PALETTES[preset]||PRESET_PALETTES.medium;
+  var hit=colors.find(function(c){return c.id===id;});
+  return hit?hit.hex:colors[0].hex;
+}
+function renderPresetChoices(preset,meChoice,partnerChoice){
+  var meSel=document.getElementById('set-bbl-preset-me');
+  var partnerSel=document.getElementById('set-bbl-preset-partner');
+  if(!meSel||!partnerSel)return;
+  var colors=PRESET_PALETTES[preset]||PRESET_PALETTES.medium;
+  var options=colors.map(function(c){return '<option value="'+c.id+'">'+c.label+'</option>';}).join('');
+  meSel.innerHTML=options;
+  partnerSel.innerHTML=options;
+  meSel.value=colors.some(function(c){return c.id===meChoice;})?meChoice:colors[0].id;
+  partnerSel.value=colors.some(function(c){return c.id===partnerChoice;})?partnerChoice:colors[Math.min(4,colors.length-1)].id;
+}
+
+function toggleSettingsDrawer(){
+  var d=document.getElementById('left-settings-drawer');
+  var gb=document.getElementById('left-gear-btn');
+  var panel=document.getElementById('left-panel');
+  if(!d)return;
+  var opening=!d.classList.contains('open');
+  d.classList.toggle('open',opening);
+  if(gb)gb.classList.toggle('active',opening);
+  if(panel)panel.classList.toggle('settings-open',opening);
+  if(opening)openSettings();
+}
+function openSettings(){
+  var p=getPrefs();
+  updateLangPill();
+  var mineBg=p.srcBgColor||'#2E8B8B';
+  var theirsBg=p.tgtBgColor||'#F5F1EC';
+  var srcBg=document.getElementById('set-src-bg');if(srcBg)srcBg.value=mineBg;
+  var tgtBg=document.getElementById('set-tgt-bg');if(tgtBg)tgtBg.value=theirsBg;
+  var srcFont=document.getElementById('set-src-font');if(srcFont)srcFont.value=effectiveBubbleTextColor(mineBg,p.srcFontColor);
+  var tgtFont=document.getElementById('set-tgt-font');if(tgtFont)tgtFont.value=effectiveBubbleTextColor(theirsBg,p.tgtFontColor);
+  var preset=document.getElementById('set-bbl-preset');if(preset)preset.value=p.bubblePreset||'medium';
+  var bblSz=document.getElementById('set-bbl-size');if(bblSz)bblSz.value=String(p.bubbleFontSize||15);
+  var tgtSz=document.getElementById('set-target-size');if(tgtSz)tgtSz.value=String(p.targetBubbleFontSize||15);
+  var bblW=document.getElementById('set-bbl-width');if(bblW)bblW.value=p.bubbleWidth||75;
+  var tgtW=document.getElementById('set-tgt-width');if(tgtW)tgtW.value=p.tgtBubbleWidth||p.bubbleWidth||75;
+  var arCb=document.getElementById('set-autoread');if(arCb)arCb.checked=!!state.autoSpeakIncoming;
+  renderPresetChoices(p.bubblePreset||'medium',p.bubblePresetMeChoice,p.bubblePresetPartnerChoice);
+}
+function closeSettings(){
+  var d=document.getElementById('left-settings-drawer');
+  if(d)d.classList.remove('open');
+  var gb=document.getElementById('left-gear-btn');
+  var panel=document.getElementById('left-panel');
+  if(gb)gb.classList.remove('active');
+  if(panel)panel.classList.remove('settings-open');
+}
+
+// Direct color controls — source bubble
+function applySrcBg(val){
+  var p=getPrefs();p.srcBgColor=val;p.accentColor=val;
+  savePrefs(p);
+  document.documentElement.style.setProperty('--teal',val);
+  applyBubbleTheme();
+}
+function applySrcText(){}
+function applyBubblePreset(v){
+  var preset=PRESET_PALETTES[v]?v:'medium';
+  var colors=PRESET_PALETTES[preset];
+  var meChoice=colors[0].id;
+  var partnerChoice=colors[Math.min(4,colors.length-1)].id;
+  var srcBg=paletteColorById(preset,meChoice);
+  var tgtBg=paletteColorById(preset,partnerChoice);
+  var p=getPrefs();
+  p.bubblePreset=preset;
+  p.bubblePresetMeChoice=meChoice;
+  p.bubblePresetPartnerChoice=partnerChoice;
+  p.srcBgColor=srcBg;p.srcFontColor='';
+  p.tgtBgColor=tgtBg;p.tgtFontColor='';
+  p.accentColor=srcBg;
+  savePrefs(p);
+  document.documentElement.style.setProperty('--teal',srcBg);
+  openSettings();
+  applyBubbleTheme();
+}
+function applyPresetChoice(side,choiceId){
+  var p=getPrefs();
+  var preset=PRESET_PALETTES[p.bubblePreset]?p.bubblePreset:'medium';
+  var list=PRESET_PALETTES[preset];
+  if(!list.some(function(c){return c.id===choiceId;}))return;
+  if(side==='partner'){
+    p.bubblePresetPartnerChoice=choiceId;
+    p.tgtBgColor=paletteColorById(preset,choiceId);
+    p.tgtFontColor='';
+  }else{
+    p.bubblePresetMeChoice=choiceId;
+    p.srcBgColor=paletteColorById(preset,choiceId);
+    p.srcFontColor='';
+    p.accentColor=p.srcBgColor;
+    document.documentElement.style.setProperty('--teal',p.srcBgColor);
+  }
+  savePrefs(p);
+  openSettings();
+  applyBubbleTheme();
+}
+function applyTgtBg(val){
+  var p=getPrefs();p.tgtBgColor=val;
+  savePrefs(p);applyBubbleTheme();
+}
+function applyTgtText(){}
+function resetAllBubbleDefaults(){
+  var p=getPrefs();
+  p.srcBgColor='#2E8B8B';p.srcTextColor='#ffffff';p.accentColor='#2E8B8B';
+  p.tgtBgColor='#F5F1EC';p.targetAccentColor='#1A1714';
+  p.bubbleWidth=75;p.tgtBubbleWidth=75;p.bubbleFontSize=15;p.targetBubbleFontSize=15;
+  p.srcFontColor='';p.tgtFontColor='';p.bubblePreset='medium';p.bubblePresetMeChoice='pacific-blue';p.bubblePresetPartnerChoice='almond-cream';
+  savePrefs(p);document.documentElement.style.setProperty('--teal','#2E8B8B');
+  openSettings();applyBubbleTheme();toast('Appearance reset to defaults');
+}
+
+function renderThemeGrid(){/* theme grids removed — direct color pickers used */}
+function renameTheme(i,kind,val){if(i<0||i>=THEMES.length)return;THEMES[i].label=(val||'').trim()||THEMES[i].label;var p=getPrefs();p.themeLibrary=THEMES;savePrefs(p);renderThemeGrid(kind);}
+function setThemeColor(i,kind,val){if(i<0||i>=THEMES.length)return;if(kind==='target')THEMES[i].theirs=val;else THEMES[i].mine=val;var p=getPrefs();p.themeLibrary=THEMES;savePrefs(p);applyTheme(kind,THEMES[i].id);}
+function applyTheme(kind,id){var t=THEMES.find(function(x){return x.id===id;});if(!t)return;var p=getPrefs();if(kind==='target'){p.targetTheme=id;
+  // Auto-suggest complementary text color for target bubble
+  var lum=hexLumGlobal(t.theirs||'#F5F1EC');
+  var suggested=lum>0.45?'#1A1714':'#ffffff';
+  p.targetAccentColor=suggested;
+  var picker=document.getElementById('set-target-accent');if(picker)picker.value=suggested;
+}else{p.sourceTheme=id;p.accentColor=t.mine;document.documentElement.style.setProperty('--teal',t.mine);document.documentElement.style.setProperty('--teal-mid',t.hdr);}p.themeLibrary=THEMES;savePrefs(p);renderThemeGrid('source');renderThemeGrid('target');applyBubbleTheme();}
+// Global luminance helper for accent auto-suggest
+function hexLumGlobal(h){h=(h||'#888').replace('#','');var r=parseInt(h.slice(0,2),16)/255,g=parseInt(h.slice(2,4),16)/255,b=parseInt(h.slice(4,6),16)/255;return 0.2126*r+0.7152*g+0.0722*b;}
+function effectiveBubbleTextColor(bgColor,fontColor){
+  if(fontColor)return fontColor;
+  return hexLumGlobal(bgColor)>0.45?'#1A1714':'#ffffff';
+}
+function applyBubbleTheme(){
+  var s=document.getElementById('bubble-theme-tag');if(!s){s=document.createElement('style');s.id='bubble-theme-tag';document.head.appendChild(s);}
+  var p=getPrefs();
+  // "Me/Partner" controls are sender-based (mine/theirs), not left/right column based.
+  var mineWidth=p.bubbleWidth||BUBBLE_DEFAULTS.bubbleWidth;
+  var theirsWidth=p.tgtBubbleWidth||mineWidth;
+  var mineSize=p.bubbleFontSize||BUBBLE_DEFAULTS.bubbleFontSize;
+  var theirsSize=p.targetBubbleFontSize||BUBBLE_DEFAULTS.targetBubbleFontSize;
+  // Source (mine) bubble — text auto-computed; font color overridable
+  var mineBg=p.srcBgColor||'#2E8B8B';
+  var mineLum=hexLumGlobal(mineBg);
+  var mineText=effectiveBubbleTextColor(mineBg,p.srcFontColor);
+  var mineTextDim=mineLum>0.45?'rgba(0,0,0,.55)':'rgba(255,255,255,.75)';
+  var mineTextFaint=mineLum>0.45?'rgba(0,0,0,.4)':'rgba(255,255,255,.5)';
+  var mineBorder=mineLum>0.45?'rgba(0,0,0,.12)':'rgba(255,255,255,.2)';
+  var mineHover=mineLum>0.45?'rgba(0,0,0,.08)':'rgba(255,255,255,.14)';
+  var mineUseBg=mineLum>0.45?'rgba(0,0,0,.1)':'rgba(255,255,255,.22)';
+  // Target (theirs) bubble — text auto-computed; font color overridable
+  var theirsBg=p.tgtBgColor||'#F5F1EC';
+  var theirsLum=hexLumGlobal(theirsBg);
+  var theirsText=effectiveBubbleTextColor(theirsBg,p.tgtFontColor);
+  var theirsTextDim=theirsLum>0.45?'rgba(0,0,0,.55)':'rgba(255,255,255,.75)';
+  var theirsTextFaint=theirsLum>0.45?'rgba(0,0,0,.4)':'rgba(255,255,255,.5)';
+  var theirsBorder=theirsLum>0.45?'rgba(0,0,0,.10)':'rgba(255,255,255,.18)';
+  var theirsHover=theirsLum>0.45?'rgba(0,0,0,.06)':'rgba(255,255,255,.12)';
+  var theirsUseBg=theirsLum>0.45?'rgba(0,0,0,.08)':'rgba(255,255,255,.18)';
+  s.textContent=
+    '.msg-row.mine .bubble-card{background:'+mineBg+';border-color:'+mineBg+';}'
+    +'.msg-row.theirs .bubble-card{background:'+theirsBg+';border-color:'+theirsBg+';}'
+    +'.msg-row.mine{max-width:96%;width:'+mineWidth+'%;}'
+    +'.msg-row.theirs{max-width:96%;width:'+theirsWidth+'%;}'
+    +'.msg-row.mine .bbl-txt{font-size:'+mineSize+'px;}'
+    +'.msg-row.theirs .bbl-txt{font-size:'+theirsSize+'px;}'
+    // Mine text + icons
+    +'.msg-row.mine .bbl-txt{color:'+mineText+';}'
+    +'.msg-row.mine .bbl-sender{color:'+mineTextDim+';}'
+    +'.msg-row.mine .bbl-time{color:'+mineTextFaint+';}'
+    +'.msg-row.mine .bbl-prov{color:'+mineTextFaint+';background:'+mineHover+';}'
+    +'.msg-row.mine .bbl-hdr{border-bottom-color:'+mineBorder+';}'
+    +'.msg-row.mine .bbl-divider{background:'+mineBorder+';}'
+    +'.msg-row.mine .bbl-use{background:'+mineUseBg+';color:'+mineText+';}'
+    +'.msg-row.mine .bbl-use:hover{background:'+mineHover+';}'
+    +'.msg-row.mine .bbl-tts{color:'+mineText+';}'
+    +'.msg-row.mine .msg-status.sent{color:'+mineTextDim+';}'
+    +'.msg-row.mine .msg-status.delivered{color:'+mineText+';}'
+    +'.msg-row.mine .msg-status.read{color:'+mineText+';}'
+    +'.msg-row.mine .bbl-foot{border-top-color:'+mineBorder+';}'
+    +'.msg-row.mine .bbl-act{color:'+mineTextDim+';}'
+    +'.msg-row.mine .bbl-act:hover{background:'+mineHover+';}'
+    +'.msg-row.mine .tag-drawer{border-top-color:'+mineBorder+';}'
+    +'.msg-row.mine .tag-drawer-input{background:'+mineUseBg+';border-color:'+mineBorder+';color:'+mineText+';}'
+    +'.msg-row.mine .pb-tag-pill{background:'+mineUseBg+';color:'+mineText+';}'
+    +'.msg-row.mine .clarify-block{border-top-color:'+mineBorder+';background:'+mineHover+';}'
+    +'.msg-row.mine .clarify-author{color:'+mineText+';}'
+    +'.msg-row.mine .clarify-ts{color:'+mineTextFaint+';}'
+    +'.msg-row.mine .clarify-body{color:'+mineText+';}'
+    +'.msg-row.mine .clarify-remove{color:'+mineTextDim+';}'
+    +'.msg-row.mine .clarify-input{background:'+mineUseBg+';border-color:'+mineBorder+';color:'+mineText+';}'
+    +'.msg-row.mine .clarify-send{background:'+mineUseBg+';color:'+mineText+';}'
+    +'.msg-row.mine .clarify-empty{color:'+mineTextDim+';}'
+    +'.msg-row.mine .bbl-backtrans{border-top-color:'+mineBorder+';}'
+    +'.msg-row.mine .bbl-back-text{color:'+mineTextDim+';}'
+    +'.msg-row.mine .retranslate-btn{background:'+mineUseBg+';color:'+mineText+';}'
+    // Theirs text + icons — complementary with target background
+    +'.msg-row.theirs .bbl-txt{color:'+theirsText+';}'
+    +'.msg-row.theirs .bbl-sender{color:'+theirsTextDim+';}'
+    +'.msg-row.theirs .bbl-time{color:'+theirsTextFaint+';}'
+    +'.msg-row.theirs .bbl-prov{color:'+theirsTextFaint+';background:'+theirsHover+';}'
+    +'.msg-row.theirs .bbl-hdr{border-bottom-color:'+theirsBorder+';}'
+    +'.msg-row.theirs .bbl-divider{background:'+theirsBorder+';}'
+    +'.msg-row.theirs .bbl-use{background:'+theirsUseBg+';color:'+theirsText+';}'
+    +'.msg-row.theirs .bbl-use:hover{background:'+theirsHover+';}'
+    +'.msg-row.theirs .bbl-tts{color:'+theirsText+';}'
+    +'.msg-row.theirs .bbl-foot{border-top-color:'+theirsBorder+';}'
+    +'.msg-row.theirs .bbl-act{color:'+theirsTextDim+';}'
+    +'.msg-row.theirs .bbl-act:hover{background:'+theirsHover+';}'
+    +'.msg-row.theirs .tag-drawer{border-top-color:'+theirsBorder+';}'
+    +'.msg-row.theirs .tag-drawer-input{background:#fff;border-color:'+theirsBorder+';color:'+theirsText+';}'
+    +'.msg-row.theirs .pb-tag-pill{background:'+theirsUseBg+';color:'+theirsText+';}'
+    +'.msg-row.theirs .clarify-block{border-top-color:'+theirsBorder+';}'
+    +'.msg-row.theirs .clarify-author{color:'+theirsText+';}'
+    +'.msg-row.theirs .clarify-ts{color:'+theirsTextFaint+';}'
+    +'.msg-row.theirs .clarify-body{color:'+theirsText+';}'
+    +'.msg-row.theirs .clarify-remove{color:'+theirsTextDim+';}'
+    +'.msg-row.theirs .clarify-input{background:#fff;border-color:'+theirsBorder+';color:'+theirsText+';}'
+    +'.msg-row.theirs .clarify-send{background:'+theirsUseBg+';color:'+theirsText+';}'
+    +'.msg-row.theirs .clarify-empty{color:'+theirsTextDim+';}'
+    +'.msg-row.theirs .bbl-backtrans{border-top-color:'+theirsBorder+';}'
+    +'.msg-row.theirs .bbl-back-text{color:'+theirsTextDim+';}'
+    +'.msg-row.theirs .retranslate-btn{background:'+theirsUseBg+';color:'+theirsText+';}';
+}
+function applyGlobalWidth(v){var p=getPrefs();p.bubbleWidth=parseInt(v);savePrefs(p);applyBubbleTheme();}
+function applyGlobalSize(v){var p=getPrefs();p.bubbleFontSize=parseInt(v);savePrefs(p);applyBubbleTheme();}
+function applyAccent(v){var p=getPrefs();p.accentColor=v;savePrefs(p);document.documentElement.style.setProperty('--teal',v);}
+function applyTargetSize(v){var p=getPrefs();p.targetBubbleFontSize=parseInt(v);savePrefs(p);applyBubbleTheme();}
+function applyTgtWidth(v){var p=getPrefs();p.tgtBubbleWidth=parseInt(v);savePrefs(p);applyBubbleTheme();}
+function applySrcFontColor(v){var p=getPrefs();p.srcFontColor=v;savePrefs(p);applyBubbleTheme();}
+function applyTgtFontColor(v){var p=getPrefs();p.tgtFontColor=v;savePrefs(p);applyBubbleTheme();}
+function clearAppSettings(){if(!confirm('Clear all app settings (appearance, language, preferences)?'))return;var keys=[SK.prefs,'ts3_prefs','joyPrefs','ts3_appearance','ts3_theme','ts3_themeLibrary'];keys.forEach(function(k){if(k)localStorage.removeItem(k);});toast('App settings cleared');openSettings();applyBubbleTheme();}
+function resetAllSettings(){var p=getPrefs();p.srcBgColor='#2E8B8B';p.srcTextColor='#ffffff';p.accentColor='#2E8B8B';p.tgtBgColor='#F5F1EC';p.targetAccentColor='#1A1714';p.bubbleWidth=75;p.tgtBubbleWidth=75;p.bubbleFontSize=15;p.targetBubbleFontSize=15;p.srcFontColor='';p.tgtFontColor='';p.myLang='';p.bubblePreset='medium';p.bubblePresetMeChoice='pacific-blue';p.bubblePresetPartnerChoice='almond-cream';savePrefs(p);document.documentElement.style.setProperty('--teal','#2E8B8B');openSettings();applyBubbleTheme();toast('All settings reset');}
+function applyTargetAccent(v){var p=getPrefs();p.targetAccentColor=v;savePrefs(p);applyBubbleTheme();}
+function toggleNoOpOnSameLanguage(on){var p=getPrefs();p.noOpOnSameLanguage=!!on;savePrefs(p);}
+function toggleForceOppositePartyLanguage(on){var p=getPrefs();p.forceOppositePartyLanguage=!!on;savePrefs(p);}
+function normalizeLangCode(v){return String(v||'').trim().toLowerCase().slice(0,8);}
+function setMyPreferredOutputLang(v){setPreferredOutputLang(PART_ID||DEVICE_ID,normalizeLangCode(v));}
+function setPartnerPreferredOutputLang(v){var sess=getSession(state.activeConvId);setPreferredOutputLang((sess&&sess.inviterDeviceId)||'deviceB',normalizeLangCode(v));}
+function resetSourceBubbleDefaults(){var p=getPrefs();p.sourceTheme=BUBBLE_DEFAULTS.sourceTheme;p.bubbleWidth=BUBBLE_DEFAULTS.bubbleWidth;p.bubbleFontSize=BUBBLE_DEFAULTS.bubbleFontSize;p.accentColor=BUBBLE_DEFAULTS.accentColor;savePrefs(p);document.documentElement.style.setProperty('--teal',BUBBLE_DEFAULTS.accentColor);openSettings();applyBubbleTheme();toast('Source bubble reset');}
+function resetTargetBubbleDefaults(){var p=getPrefs();p.targetTheme=BUBBLE_DEFAULTS.targetTheme;p.targetBubbleFontSize=BUBBLE_DEFAULTS.targetBubbleFontSize;p.targetAccentColor=BUBBLE_DEFAULTS.targetAccentColor;savePrefs(p);openSettings();applyBubbleTheme();toast('Target bubble reset');}
+function applyPhrasebookAccent(v){var p=getPrefs();p.phrasebookAccentColor=v;savePrefs(p);}
+
+function openInfoModal(kind){var title=document.getElementById('info-title');var body=document.getElementById('info-body');if(kind==='privacy'){title.textContent='Privacy';body.innerHTML='<strong>Local-first storage.</strong><br>All session and phrasebook data stays in localStorage unless you export it yourself.';}else{title.textContent='About';body.innerHTML='<strong>Talk + Say · v3.4</strong><br>Shell-first bilingual chat &amp; phrasebook with unified bubble renderer, back-translation, and clarify workflows.';}document.getElementById('info-overlay').hidden=false;}
+function openPrintPhrasebookModal(){document.getElementById('print-overlay').hidden=false;}
+function printPhrasebookSelection(){document.getElementById('print-overlay').hidden=true;renderCatalogCards();setTimeout(function(){window.print();},60);}
+
+// Search
+function openSearch(){document.getElementById('search-overlay').classList.add('open');document.getElementById('omni-search').focus();}
+function closeSearch(){document.getElementById('search-overlay').classList.remove('open');}
+function runOmniSearch(){var q=(document.getElementById('omni-search').value||'').trim().toLowerCase();var r=document.getElementById('search-results');if(!q){r.innerHTML='';return;}var h='';getAllSessions().forEach(function(s){var label=getSessionLabel(s);if(label.toLowerCase().indexOf(q)>=0)h+='<div class="search-result" onclick="closeSearch();openSession(\''+s.convId+'\')"><div class="search-result-type">Session</div>'+escHtml(label)+'</div>';});getCards().forEach(function(c){if((c.source||'').toLowerCase().indexOf(q)>=0||(c.target||'').toLowerCase().indexOf(q)>=0||(c.tags||[]).join(' ').toLowerCase().indexOf(q)>=0)h+='<div class="search-result"><div class="search-result-type">Phrase</div>'+escHtml(c.source)+' → '+escHtml(c.target)+'</div>';});r.innerHTML=h||'<div style="padding:20px;text-align:center;color:var(--ink-dim);">No results</div>';}
+
+// ════════════════════════════════════════════════════════
+// PHRASEBOOK NAVIGATION
+// ════════════════════════════════════════════════════════
+function openPhrasebookModal(){
+  state.currentCatId='all';
+  document.getElementById('cat-screen-title').textContent='Phrasebook';
+  renderCatalogCards();
+  showScreen('catalog-screen');
+}
+function closePhrasebookView(){showScreen('chat-screen');}
+function openCatalogFilterModal(){renderPhrasebookCatalogFilter();document.getElementById('catalog-filter-overlay').hidden=false;}
+
+function getActivePhrasebookCatalogId(){return state.currentCatId||'all';}
+
+function renderPhrasebookCatalogFilter(){
+  var host=document.getElementById('catalog-filter-list');if(!host)return;
+  var cats=getCatalogs().slice().sort(function(a,b){return(a.name||'').localeCompare(b.name||'');});
+  var active=getActivePhrasebookCatalogId();
+  var allCls=active==='all'?' selected':'';
+  host.innerHTML='<button class="tp-tag-chip'+allCls+'" onclick="selectCatalogFilter(\'all\')">All catalogs</button>'
+    +cats.map(function(c){var cls='tp-tag-chip'+(c.id===active?' selected':'');var lbl=(c.emoji?c.emoji+' ':'')+(c.name||'Catalog');return '<button class="'+cls+'" onclick="selectCatalogFilter(\''+c.id+'\')">'+escHtml(lbl)+'<button class="tp-tag-remove" onclick="event.stopPropagation();confirmDeleteCatalog(\''+c.id+'\')">×</button></button>';}).join('');
+}
+
+function selectCatalogFilter(catId){
+  state.currentCatId=catId||'all';
+  document.getElementById('catalog-filter-overlay').hidden=true;
+  var cats=getCatalogs();var cat=cats.find(function(c){return c.id===catId;});
+  document.getElementById('cat-screen-title').textContent=cat?(cat.name||'Catalog'):'Phrasebook';
+  renderCatalogCards();
+}
+
+function clearCatalogSearch(){var el=document.getElementById('cat-search');if(el)el.value='';renderCatalogCards();}
+
+// ════════════════════════════════════════════════════════
+// CARD CRUD
+// ════════════════════════════════════════════════════════
+function getCardById(id){var cards=getCards();for(var i=0;i<cards.length;i++){if(cards[i]&&cards[i].id===id)return cards[i];}return null;}
+function saveUpdatedCard(card){if(!card||!card.id)return;var cards=getCards();var idx=cards.findIndex(function(c){return c&&c.id===card.id;});var next=normalizeCard(Object.assign({},card,{updatedAt:Date.now()}));if(idx>=0)cards[idx]=next;else cards.unshift(next);saveCards(cards);}
+
+function openNewCard(catId,opts){
+  var overlay=document.getElementById('new-card-overlay');
+  var p=getPrefs();var validCat=(catId&&catId!=='all')?catId:'';
+  state.saveContext=opts||null;
+  var ctx=opts||{};
+  // Populate compact language selectors (flag + 2-char code)
+  populateLangSelectCompact('nc-src-lang',ctx.sourceLang||p.phrasebookSourceLang||p.myLang||'en');
+  populateLangSelectCompact('nc-tgt-lang',ctx.targetLang||p.phrasebookTargetLang||p.partnerLang||'en');
+  populateNewCardCatalogs(validCat);
+  // Populate contenteditable fields
+  var srcEl=document.getElementById('nc-source');
+  var tgtEl=document.getElementById('nc-target');
+  srcEl.textContent=ctx.sourceText||'';
+  tgtEl.textContent=ctx.targetText||'';
+  document.getElementById('nc-catalog').value=validCat;
+  state.ncTags=sanitizeTagList(ctx.tags||[]);
+  renderNcTagsInline();ncSourceInput();
+  setNcBacktranslate(ctx.backtranslate||{});
+  var btText=document.getElementById('nc-bt-text');
+  var btPanel=document.getElementById('nc-bt-result');
+  if(btText)btText.textContent=(state.ncBacktranslate&&state.ncBacktranslate.resultText)||'';
+  if(btPanel)btPanel.style.display=(state.ncBacktranslate&&state.ncBacktranslate.resultText)?'block':'none';
+  // Reset drawers
+  document.getElementById('nc-tag-drawer').style.display='none';
+  document.getElementById('nc-catalog-drawer').style.display='none';
+  document.getElementById('nc-lang-mismatch').style.display='none';
+  var title=document.getElementById('nc-title');if(title)title.textContent=opts?'Save phrase':'New phrase';
+  overlay.hidden=false;setTimeout(function(){srcEl.focus();},30);
+}
+
+function populateNewCardCatalogs(selectedId){
+  var sel=document.getElementById('nc-catalog');if(!sel)return;
+  var cats=getCatalogs().slice().sort(function(a,b){return(a.name||'').localeCompare(b.name||'');});
+  sel.innerHTML=['<option value="">All catalogs</option>'].concat(cats.map(function(c){var label=(c.emoji?c.emoji+' ':'')+(c.name||'Catalog');return '<option value="'+escHtml(c.id)+'"'+(selectedId===c.id?' selected':'')+'>'+escHtml(label)+'</option>';})).join('');
+}
+function ncSourceInput(){
+  var source=(document.getElementById('nc-source').textContent||'').trim();
+  var autoBtn=document.getElementById('nc-auto-btn');
+  if(autoBtn)autoBtn.disabled=!source;
+  if(state.ncBacktranslate){
+    state.ncBacktranslate.contentHash=btContentHash(source,(document.getElementById('nc-target').textContent||'').trim());
+  }
+}
+function ncLangChanged(){persistPhrasebookLangSelection();ncCheckLangMismatch();}
+function ncSpeak(kind,btn){
+  var text='',lang='en';
+  if(kind==='source'){
+    text=(document.getElementById('nc-source').textContent||'').trim();
+    lang=(document.getElementById('nc-src-lang').value||'en');
+  }else if(kind==='target'){
+    text=(document.getElementById('nc-target').textContent||'').trim();
+    lang=(document.getElementById('nc-tgt-lang').value||'en');
+  }else{
+    text=(state.ncBacktranslate&&state.ncBacktranslate.resultText)||'';
+    lang=(state.ncBacktranslate&&state.ncBacktranslate.targetLang)||(document.getElementById('nc-src-lang').value||'en');
+  }
+  if(!text){toast('Nothing to play');return;}
+  speak(text,lang,btn||null);
+}
+function ncAutoTranslate(){
+  var src=(document.getElementById('nc-source').textContent||'').trim();if(!src)return;
+  var sl=document.getElementById('nc-src-lang').value||'en';
+  var tl=document.getElementById('nc-tgt-lang').value||'en';
+  var btn=document.getElementById('nc-auto-btn');if(btn)btn.disabled=true;
+  translate(src,sl,tl).then(function(out){
+    document.getElementById('nc-target').textContent=out||'';
+    if(state.ncBacktranslate){
+      state.ncBacktranslate.contentHash=btContentHash(src,out||'');
+    }
+  }).catch(function(){toast('Translation failed');}).finally(function(){ncSourceInput();});
+}
+function ncBackTranslate(){
+  var tgt=(document.getElementById('nc-target').textContent||'').trim();if(!tgt)return;
+  var sl=document.getElementById('nc-src-lang').value||'en';
+  var tl=document.getElementById('nc-tgt-lang').value||'en';
+  var btPanel=document.getElementById('nc-bt-result');
+  var btText=document.getElementById('nc-bt-text');
+  btPanel.style.display='block';
+  btText.textContent='Checking\u2026';
+  translate(tgt,tl,sl).then(function(back){
+    var result=back||'No result';
+    btText.textContent=result;
+    setNcBacktranslate({
+      sourceLang:tl,
+      targetLang:sl,
+      inputText:tgt,
+      resultText:result,
+      verdict:(state.ncBacktranslate&&state.ncBacktranslate.verdict)||'',
+      contentHash:btContentHash((document.getElementById('nc-source').textContent||'').trim(),tgt),
+      updatedAt:Date.now()
+    });
+  });
+}
+// Inline tag drawer for new card
+function toggleNcTagDrawer(){
+  var el=document.getElementById('nc-tag-drawer');
+  var isOpen=el.style.display!=='none';
+  el.style.display=isOpen?'none':'block';
+  if(!isOpen)renderNcTagsInline();
+}
+function renderNcTagsInline(){
+  var el=document.getElementById('nc-tags-assigned');if(!el)return;
+  el.innerHTML=state.ncTags.map(function(t){return '<span class="pb-tag-pill">#'+escHtml(t)+'<button onclick="removeNcTag(\''+t+'\')">×</button></span>';}).join('');
+}
+function renderNcTagResults(){
+  var input=document.getElementById('nc-tag-input');
+  var out=document.getElementById('nc-tag-results');if(!out)return;
+  var q=(input&&input.value||'').trim().toLowerCase();
+  if(!q){out.innerHTML='';return;}
+  out.innerHTML=sanitizeTagList(getTags()).filter(function(t){return t.indexOf(q)>=0;}).slice(0,8).map(function(t){return '<button class="tag-res-chip" onclick="addNcTag(\''+t+'\')">#'+escHtml(t)+'</button>';}).join('');
+}
+function submitNcTagInput(){
+  var input=document.getElementById('nc-tag-input');if(!input)return;
+  addNcTag(input.value||'');input.value='';renderNcTagResults();
+}
+function addNcTag(tag){
+  var n=normalizeTag(tag||'');if(!n)return;
+  if(state.ncTags.indexOf(n)<0)state.ncTags.push(n);
+  addTagToRegistry(n);renderNcTagsInline();
+}
+function removeNcTag(tag){state.ncTags=state.ncTags.filter(function(t){return t!==tag;});renderNcTagsInline();}
+
+// Catalog picker drawer for new card
+function toggleNcCatalogPicker(){
+  var el=document.getElementById('nc-catalog-drawer');
+  el.style.display=el.style.display==='none'?'block':'none';
+  if(el.style.display==='block')ncCheckLangMismatch();
+}
+function ncCheckLangMismatch(){
+  var catId=(document.getElementById('nc-catalog')||{}).value;
+  var warn=document.getElementById('nc-lang-mismatch');if(!warn)return;
+  if(!catId){warn.style.display='none';return;}
+  var cats=getCatalogs();var cat=cats.find(function(c){return c.id===catId;});
+  if(!cat||!cat.lang){warn.style.display='none';return;}
+  var tl=document.getElementById('nc-tgt-lang').value||'';
+  if(tl&&cat.lang&&tl!==cat.lang){
+    warn.style.display='block';
+    warn.textContent='\u26a0 This phrase is '+langLabel(tl)+' but the catalog is '+langLabel(cat.lang);
+  }else{warn.style.display='none';}
+}
+
+function saveNewCard(){
+  var src=(document.getElementById('nc-source').textContent||'').trim();if(!src){toast('Enter a source phrase');return;}
+  var tgt=(document.getElementById('nc-target').textContent||'').trim();
+  var sl=document.getElementById('nc-src-lang').value;
+  var tl=document.getElementById('nc-tgt-lang').value;
+  var catId=(document.getElementById('nc-catalog')||{}).value||'';
+  var cardTags=sanitizeTagList(state.ncTags);
+  persistPhrasebookLangSelection();
+  var bt=normalizeBacktranslatePayload(state.ncBacktranslate,{
+    sourceLang:tl||'en',
+    targetLang:sl||'en',
+    inputText:tgt||src||'',
+    resultText:'',
+    verdict:'',
+    contentHash:btContentHash(src,tgt),
+    updatedAt:Date.now()
+  });
+  var card=normalizeCard({id:uid(),catalogIds:catId?[catId]:[],sourceLang:sl,targetLang:tl,source:src,target:tgt,notes:'',tags:cardTags,backtranslate:bt,clarifyChain:[],savedBy:getPrefs().userName||'Me',createdAt:Date.now(),updatedAt:Date.now()});
+  upsertCardLastWins(card);card.tags.forEach(function(t){addTagToRegistry(t);});
+  document.getElementById('new-card-overlay').hidden=true;
+  toast('Saved');renderCatalogCards();state.saveContext=null;
+}
+
+function confirmDeleteCard(id){softDeleteCard(id);}
+function confirmDeleteCatalog(catId){showConfirm('Delete catalog?','Cards move to All.',function(){saveCatalogs(getCatalogs().filter(function(c){return c.id!==catId;}));var cards=getCards();cards.forEach(function(c){c.catalogIds=(c.catalogIds||[]).filter(function(id){return id!==catId;});});saveCards(cards);renderPhrasebookCatalogFilter();renderCatalogCards();toast('Deleted');});}
+
+// Catalogs
+function buildEmojiGrid(){}
+function openNewCatalog(){
+  var p=getPrefs();
+  populateLangSelect('ncat-lang',p.partnerLang||'en');
+  document.getElementById('ncat-name').value='';
+  document.getElementById('ncat-desc').value='';
+  document.getElementById('ncat-save-btn').disabled=true;
+  ncatLangChanged();
+  document.getElementById('new-cat-overlay').hidden=false;
+}
+function ncatLangChanged(){
+  var sel=document.getElementById('ncat-lang');
+  var code=sel?sel.value:'';
+  var flag=langFlag(code)||'\ud83d\udcdd';
+  var preview=document.getElementById('ncat-icon-preview');
+  if(preview)preview.textContent=flag;
+  state._newCatEmoji=flag;
+}
+function saveNewCatalog(){
+  var name=document.getElementById('ncat-name').value.trim();if(!name)return;
+  var desc=document.getElementById('ncat-desc').value.trim();
+  var langSel=document.getElementById('ncat-lang');
+  var lang=langSel?langSel.value:'';
+  var emoji=state._newCatEmoji||langFlag(lang)||'\ud83d\udcdd';
+  var cats=getCatalogs();
+  cats.push({id:uid(),name:name,desc:desc,emoji:emoji,lang:lang,createdAt:Date.now()});
+  saveCatalogs(cats);
+  document.getElementById('new-cat-overlay').hidden=true;
+  document.getElementById('ncat-name').value='';
+  renderPhrasebookCatalogFilter();renderCatalogCards();toast('Created');
+}
+
+// Tags
+function renderTagSearchChips(query,pickFn,id){var q=(query||'').trim().toLowerCase();if(!q)return '';return sanitizeTagList(getTags()).filter(function(t){return t.indexOf(q)>=0;}).slice(0,8).map(function(t){return '<button class="tag-res-chip" onclick="'+pickFn+'(\''+id+'\',\''+t+'\')">#'+escHtml(t)+'</button>';}).join('');}
+function openTagPicker(ctx,cardId){state.tagPickerCtx=ctx;state.tagPickerCardId=cardId;var card=cardId?getCardById(cardId):null;tagPickerSelectedTags=sanitizeTagList(ctx==='newcard'?state.ncTags.slice():(card&&card.tags?card.tags.slice():[]));document.getElementById('tp-search').value='';renderTagPicker();document.getElementById('tag-picker-overlay').hidden=false;}
+function closeTagPicker(apply){
+  if(apply){
+    tagPickerSelectedTags=sanitizeTagList(tagPickerSelectedTags);
+    if(state.tagPickerCtx==='newcard'){state.ncTags=tagPickerSelectedTags.slice();renderNcTagsInline();}
+    tagPickerSelectedTags.forEach(function(t){addTagToRegistry(t);});
+  }
+  document.getElementById('tag-picker-overlay').hidden=true;
+}
+function renderTagPicker(){var q=(document.getElementById('tp-search')&&document.getElementById('tp-search').value||'').trim().toLowerCase();var all=sanitizeTagList(getTags());var tags=q?all.filter(function(t){return t.indexOf(q)>=0;}):all;document.getElementById('tp-chips').innerHTML=tags.map(function(t){return '<span class="tp-tag-chip'+(tagPickerSelectedTags.indexOf(t)>=0?' selected':'')+'" onclick="toggleTag(\''+t+'\')">#'+escHtml(t)+'<button class="tp-tag-remove" title="Remove globally" onclick="event.stopPropagation();removeTagGlobally(\''+t+'\')">×</button></span>';}).join('');var cb=document.getElementById('tp-create-btn');if(cb)cb.style.display=(q&&all.indexOf(normalizeTag(q))<0)?'block':'none';}
+function toggleTag(t){t=normalizeTag(t);if(!t)return;var i=tagPickerSelectedTags.indexOf(t);if(i>=0)tagPickerSelectedTags.splice(i,1);else tagPickerSelectedTags.push(t);tagPickerSelectedTags=sanitizeTagList(tagPickerSelectedTags);renderTagPicker();}
+function createAndAddTag(){var q=(document.getElementById('tp-search')&&document.getElementById('tp-search').value||'').trim();if(!q)return;var t=normalizeTag(q);if(!t)return;addTagToRegistry(t);if(tagPickerSelectedTags.indexOf(t)<0)tagPickerSelectedTags.push(t);tagPickerSelectedTags=sanitizeTagList(tagPickerSelectedTags);document.getElementById('tp-search').value='';renderTagPicker();}
+function removeTagGlobally(tag){var n=normalizeTag(tag||'');if(!n)return;saveTags(sanitizeTagList(getTags().filter(function(t){return t!==n;})));tagPickerSelectedTags=sanitizeTagList(tagPickerSelectedTags.filter(function(t){return t!==n;}));state.ncTags=sanitizeTagList((state.ncTags||[]).filter(function(t){return t!==n;}));var cards=getCards();var changed=false;cards.forEach(function(c){var next=sanitizeTagList((c.tags||[]).filter(function(t){return t!==n;}));if(next.length!==(c.tags||[]).length){c.tags=next;c.updatedAt=Date.now();changed=true;}});if(changed)saveCards(cards);renderNcTagsInline();renderTagPicker();renderCatalogCards();}
+function initTagPickerInput(){var input=document.getElementById('tp-search');if(!input||input._bound)return;input._bound=true;input.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===','){e.preventDefault();createAndAddTag();}});}
+
+// Confirm
+function showConfirm(title,body,onOk){document.getElementById('confirm-title').textContent=title;document.getElementById('confirm-body').textContent=body;state.confirmCallback=onOk;document.getElementById('confirm-overlay').hidden=false;}
+function confirmOk(){if(state.confirmCallback)state.confirmCallback();document.getElementById('confirm-overlay').hidden=true;}
+function confirmCancel(){document.getElementById('confirm-overlay').hidden=true;}
+
+// Session notes
+function openSessionNote(cid){state.noteSessionId=cid;var notes=getSessionNotes();document.getElementById('session-note-text').value=notes[cid]||'';document.getElementById('session-note-overlay').hidden=false;}
+function closeSessionNote(){document.getElementById('session-note-overlay').hidden=true;}
+function saveSessionNote(){if(!state.noteSessionId)return;var notes=getSessionNotes();notes[state.noteSessionId]=(document.getElementById('session-note-text').value||'').trim();saveSessionNotes(notes);closeSessionNote();toast('Note saved');}
+
+// Import/Export
+function downloadBlob(content,type,fileName,withBom){if(withBom)content='\uFEFF'+content;var blob=new Blob([content],{type:type});var a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=fileName;document.body.appendChild(a);a.click();setTimeout(function(){URL.revokeObjectURL(a.href);a.remove();},0);}
+function formatExportMessageBlock(msg,sess){
+  var ts=fmtDateTime(msg.timestamp||Date.now());
+  if(msg.from==='system')return '['+ts+'] System\n'+String(msg.text||'').trim();
+  if(msg.from==='invite')return '['+ts+'] Invite\n'+String(msg.inviteUrl||msg.text||'').trim();
+  var s=normalizeSession(sess||{});
+  var sender=msg.from==='me'?(msg.displayFromName||s.myName||'Me'):(msg.displayFromName||s.peerName||'Partner');
+  return '['+ts+'] '+sender+'\n'
+    +'Source ('+String(msg.sourceLang||msg.lang||'').toUpperCase()+'): '+String(msg.sourceText||msg.orig||msg.text||'').trim()+'\n'
+    +'Target ('+String(msg.targetLang||'').toUpperCase()+'): '+String(msg.targetText||msg.translated||'').trim()
+    +(msg.status==='failed'?'\nStatus: Not delivered':'');
+}
+function exportSessionChat(cid){
+  var sess=getSession(cid);if(!sess){toast('Session not found');return;}
+  var msgs=getMsgs(cid);
+  var title=(getSessionLabel(sess)||cid||'chat').trim()||'chat';
+  var safeTitle=title.replace(/[^a-z0-9_-]+/gi,'-').replace(/^-+|-+$/g,'').toLowerCase()||'chat';
+  var blocks=['Talk + Say chat export','Session: '+title,'Conversation ID: '+cid,'Exported: '+fmtDateTime(Date.now())];
+  if(msgs.length){blocks.push('','Conversation');msgs.forEach(function(msg){blocks.push('',formatExportMessageBlock(msg,sess));});}
+  else{blocks.push('','Conversation','','(No messages)');}
+  blocks.push('','Diagnostics','',diagLog.length?diagLog.join('\n'):'(No diagnostic entries)');
+  downloadBlob(blocks.join('\n'),'text/plain;charset=utf-8','chat-export-'+safeTitle+'-'+Date.now()+'.txt',true);
+  toast('Chat exported');
+}
+function downloadJSON(payload,filePrefix){downloadBlob(JSON.stringify(payload,null,2),'application/json',filePrefix+'-'+Date.now()+'.json');}
+function downloadCSV(rows,filePrefix){if(!rows.length){toast('Nothing to export');return;}var headers=Object.keys(rows[0]);var csv=[headers.map(csvEscape).join(',')].concat(rows.map(function(row){return headers.map(function(h){return csvEscape(row[h]);}).join(',');})).join('\n');downloadBlob(csv,'text/csv;charset=utf-8',filePrefix+'-'+Date.now()+'.csv',true);}
+function csvEscape(value){var str=value==null?'':String(value);return /[",\n]/.test(str)?'"'+str.replace(/"/g,'""')+'"':str;}
+function parseCsv(text){var rows=[];var row=[];var cell='';var inQuotes=false;for(var i=0;i<text.length;i++){var ch=text[i];var next=text[i+1];if(inQuotes){if(ch==='"'&&next==='"'){cell+='"';i++;}else if(ch==='"'){inQuotes=false;}else{cell+=ch;}}else if(ch==='"'){inQuotes=true;}else if(ch===','){row.push(cell);cell='';}else if(ch==='\n'){row.push(cell);rows.push(row);row=[];cell='';}else if(ch==='\r'){}else{cell+=ch;}}row.push(cell);if(row.length>1||row[0])rows.push(row);if(!rows.length)return[];var headers=rows.shift();return rows.filter(function(cols){return cols.some(function(v){return String(v||'').trim();});}).map(function(cols){var out={};headers.forEach(function(h,idx){out[h]=cols[idx]||'';});return out;});}
+function parseJSONField(value,fallback){if(!value)return fallback;try{return JSON.parse(value);}catch(_){return fallback;}}
+function getPhrasebookExportSelection(){var selected=state.pbExportSelection||{};return getCards().filter(function(card){return selected[card.id]!==false;});}
+function getPhrasebookExportPayload(cards){cards=(cards||[]).map(normalizeCard);var catalogIds={};var selectedTags=[];cards.forEach(function(card){(card.catalogIds||[]).forEach(function(id){if(id)catalogIds[id]=true;});(card.tags||[]).forEach(function(tag){if(selectedTags.indexOf(tag)<0)selectedTags.push(tag);});});var catalogs=getCatalogs().filter(function(cat){return catalogIds[cat.id];});return {type:'phrasebook',cards:cards,catalogs:catalogs,tags:selectedTags,exportedAt:Date.now()};}
+function getPhrasebookCsvRows(cards,catalogsOverride){var catalogs=Array.isArray(catalogsOverride)?catalogsOverride:getCatalogs();return(cards||[]).map(function(card){card=normalizeCard(card);var rowCatalogs=catalogs.filter(function(cat){return(card.catalogIds||[]).indexOf(cat.id)>=0;});return {id:card.id||'',source:card.source||'',sourceLang:card.sourceLang||'',target:card.target||'',targetLang:card.targetLang||'',notes:card.notes||'',tags:JSON.stringify(card.tags||[]),catalogIds:JSON.stringify(card.catalogIds||[]),catalogs:JSON.stringify(rowCatalogs),clarifyChain:JSON.stringify(card.clarifyChain||[]),backtranslate:JSON.stringify(card.backtranslate||{}),backtranslateVerdict:(card.backtranslate&&card.backtranslate.verdict)||'',savedBy:card.savedBy||'',createdAt:card.createdAt||'',updatedAt:card.updatedAt||''};});}
+function getPhrasebookExportViewCards(){return getCards().map(normalizeCard).map(function(card){if(!state.pbExportSwap)return card;return normalizeCard(Object.assign({},card,{source:card.target||card.source||'',sourceLang:card.targetLang||card.sourceLang||'en',target:card.source||'',targetLang:card.sourceLang||card.targetLang||'en'}));});}
+function getPhrasebookExportSelectionFrom(cards){var selected=state.pbExportSelection||{};return(cards||[]).filter(function(card){return selected[card.id]!==false;});}
+function syncPhrasebookExportControls(count){
+  var btn=document.getElementById('phrasebook-export-btn');
+  var saveBtn=document.getElementById('phrasebook-save-btn');
+  var swapBtn=document.getElementById('phrasebook-export-swap-btn');
+  var meta=document.getElementById('phrasebook-export-mode-meta');
+  if(btn)btn.disabled=!count||state.pbExportBusy;
+  if(saveBtn){
+    saveBtn.disabled=!state.pbExportSwap||!count||state.pbExportBusy;
+    saveBtn.textContent='Save swapped copy';
+  }
+  if(swapBtn)swapBtn.classList.toggle('active',!!state.pbExportSwap);
+  if(meta)meta.textContent=state.pbExportSwap?'Source/target are swapped, and tags, clarify notes, notes, and back-translation are rebuilt for the new source language when you save or export.':'Export the selected cards as they are.';
+}
+function openPhrasebookExportModal(){var selection={};getCards().forEach(function(card){selection[card.id]=true;});state.pbExportSelection=selection;state.pbExportSwap=false;state.pbExportBusy=false;renderPhrasebookExportList();document.getElementById('phrasebook-export-overlay').hidden=false;}
+function closePhrasebookExportModal(force){if(state.pbExportBusy&&!force)return;document.getElementById('phrasebook-export-overlay').hidden=true;}
+function togglePhrasebookSwapExport(){if(state.pbExportBusy)return;state.pbExportSwap=!state.pbExportSwap;renderPhrasebookExportList();}
+function setAllPhrasebookExportSelections(on){var next={};getCards().forEach(function(card){next[card.id]=!!on;});state.pbExportSelection=next;renderPhrasebookExportList();}
+function togglePhrasebookExportSelection(id,on){state.pbExportSelection=state.pbExportSelection||{};state.pbExportSelection[id]=!!on;renderPhrasebookExportList();}
+function renderPhrasebookExportList(){var host=document.getElementById('phrasebook-export-list');var summary=document.getElementById('phrasebook-export-summary');if(!host||!summary)return;var cards=getPhrasebookExportViewCards();if(!cards.length){host.innerHTML='<div style="font-size:12px;color:var(--ink-dim);text-align:center;padding:18px 12px;border:1px dashed var(--border);border-radius:12px;">No phrasebook items to export.</div>';summary.textContent='0 selected';syncPhrasebookExportControls(0);return;}host.innerHTML=cards.map(function(card){var checked=(state.pbExportSelection&&state.pbExportSelection[card.id]!==false)?' checked':'';var meta=[(card.sourceLang||'').toUpperCase()+' → '+(card.targetLang||'').toUpperCase(),(card.tags||[]).length?('#'+card.tags.join(' #')):'No tags',(card.backtranslate&&card.backtranslate.verdict)?('Verdict: '+card.backtranslate.verdict):'No verdict'].join(' · ');return '<label class="export-item"><input type="checkbox"'+checked+' onchange="togglePhrasebookExportSelection(\''+card.id+'\',this.checked)"><div style="flex:1;min-width:0;"><div style="font-size:13px;font-weight:600;line-height:1.4;">'+escHtml(card.source||'Untitled')+'</div><div style="font-size:12px;color:var(--ink-mid);line-height:1.4;margin-top:3px;">'+escHtml(card.target||'')+'</div><div class="export-item-meta">'+escHtml(meta)+'</div></div></label>';}).join('');var count=getPhrasebookExportSelectionFrom(cards).length;summary.textContent=count+' selected';syncPhrasebookExportControls(count);}
+function setPhrasebookExportBusy(on,label){
+  state.pbExportBusy=!!on;
+  var btn=document.getElementById('phrasebook-export-btn');
+  var saveBtn=document.getElementById('phrasebook-save-btn');
+  var swapBtn=document.getElementById('phrasebook-export-swap-btn');
+  if(btn)btn.textContent=on?(label||'Working…'):'Export';
+  if(saveBtn)saveBtn.textContent=on?'Preparing…':'Save swapped copy';
+  if(swapBtn)swapBtn.disabled=!!on;
+  syncPhrasebookExportControls(getPhrasebookExportSelectionFrom(getPhrasebookExportViewCards()).length);
+}
+async function resolvePhrasebookExportPayload(cards){
+  if(state.pbExportSwap)return buildSwappedPhrasebook(cards);
+  return getPhrasebookExportPayload(cards);
+}
+async function exportSelectedPhrasebookData(){
+  var cards=getPhrasebookExportSelection();
+  if(!cards.length){toast('Select at least one phrase');return;}
+  var format=(document.getElementById('phrasebook-export-format')||{}).value||'json';
+  setPhrasebookExportBusy(true,state.pbExportSwap?'Swapping…':'Exporting…');
+  try{
+    var payload=await resolvePhrasebookExportPayload(cards);
+    if(format==='csv')downloadCSV(getPhrasebookCsvRows(payload.cards,payload.catalogs),'talk-say-phrasebook-export');
+    else downloadJSON(payload,'talk-say-phrasebook-export');
+    setPhrasebookExportBusy(false);
+    closePhrasebookExportModal(true);
+    toast(state.pbExportSwap?'Swapped phrasebook exported':'Phrasebook exported');
+  }catch(_){
+    toast('Export failed');
+  }finally{
+    setPhrasebookExportBusy(false);
+  }
+}
+async function saveSelectedPhrasebookData(){
+  if(!state.pbExportSwap){toast('Turn on swap mode first');return;}
+  var cards=getPhrasebookExportSelection();
+  if(!cards.length){toast('Select at least one phrase');return;}
+  setPhrasebookExportBusy(true,state.pbExportSwap?'Saving swapped copy…':'Saving selection…');
+  try{
+    var payload=await resolvePhrasebookExportPayload(cards);
+    var mergedCards=getCards().slice();
+    payload.cards.forEach(function(card){mergedCards=mergedCards.filter(function(existing){return cardPairKey(existing.source,existing.sourceLang,existing.target,existing.targetLang)!==cardPairKey(card.source,card.sourceLang,card.target,card.targetLang);});mergedCards.unshift(normalizeCard(card));});
+    saveCards(mergedCards);
+    var mergedCatalogs=getCatalogs().slice();
+    (payload.catalogs||[]).forEach(function(cat){if(!mergedCatalogs.some(function(existing){return existing&&existing.id===cat.id;}))mergedCatalogs.push(cat);});
+    saveCatalogs(mergedCatalogs);
+    saveTags(sanitizeTagList(getTags().concat(payload.tags||[])));
+    renderPhrasebookCatalogFilter();
+    renderCatalogCards();
+    setPhrasebookExportBusy(false);
+    closePhrasebookExportModal(true);
+    toast(state.pbExportSwap?'Swapped phrasebook saved':'Phrase selection saved');
+  }catch(_){
+    toast('Save failed');
+  }finally{
+    setPhrasebookExportBusy(false);
+  }
+}
+function exportSessionsData(){downloadJSON({type:'sessions',sessions:getAllSessions(),order:getSessionOrder(),recycled:getRecycled(),notes:getSessionNotes(),exportedAt:Date.now()},'talk-say-sessions-export');toast('Sessions exported');}
+function exportPhrasebookData(){downloadJSON(getPhrasebookExportPayload(getCards()),'talk-say-phrasebook-export');toast('Phrasebook exported');}
+function exportAppSettings(){downloadJSON({type:'app-settings',prefs:getPrefs(),themes:THEMES,exportedAt:Date.now()},'talk-say-settings-export');toast('Settings exported');}
+function openImportPicker(kind){var input=document.getElementById('settings-import-file');if(!input)return;input.dataset.kind=kind;input.value='';input.click();}
+function importSessionsData(){openImportPicker('sessions');}
+function openPhrasebookImportPicker(){openImportPicker('phrasebook');}
+function importPhrasebookData(){openPhrasebookImportPicker();}
+function importAppSettings(){openImportPicker('settings');}
+function handleImportFile(event){var input=event&&event.target;var file=input&&input.files&&input.files[0];if(!file)return;var kind=(input.dataset&&input.dataset.kind)||'';var reader=new FileReader();reader.onload=function(){var raw=String(reader.result||'');try{if(kind==='phrasebook'){if(/\.csv$/i.test(file.name)||/^text\/csv/i.test(file.type)){applyPhrasebookImport(parsePhrasebookCsv(raw));}else{applyPhrasebookImport(JSON.parse(raw||'{}'));}}else if(kind==='sessions'){applySessionsImport(JSON.parse(raw||'{}'));}else if(kind==='settings'){applySettingsImport(JSON.parse(raw||'{}'));}else toast('Unknown import type');}catch(_){toast(kind==='phrasebook'?'Invalid phrasebook file':'Invalid JSON file');}};reader.onerror=function(){toast('Import failed');};reader.readAsText(file);}
+function parsePhrasebookCsv(text){var rows=parseCsv(text||'');var catalogsById={};var tags=[];var cards=rows.map(function(row){var rowTags=parseJSONField(row.tags,[]);var rowCatalogIds=parseJSONField(row.catalogIds,[]);var rowCatalogs=parseJSONField(row.catalogs,[]);rowCatalogs.forEach(function(cat){if(cat&&cat.id)catalogsById[cat.id]=cat;});rowTags.forEach(function(tag){tag=normalizeTag(tag);if(tag&&tags.indexOf(tag)<0)tags.push(tag);});return normalizeCard({id:row.id||uid(),source:row.source||'',sourceLang:row.sourceLang||'en',target:row.target||'',targetLang:row.targetLang||'en',notes:row.notes||'',tags:rowTags,catalogIds:rowCatalogIds,clarifyChain:parseJSONField(row.clarifyChain,[]),backtranslate:parseJSONField(row.backtranslate,{verdict:row.backtranslateVerdict||''}),savedBy:row.savedBy||'',createdAt:Number(row.createdAt)||Date.now(),updatedAt:Number(row.updatedAt)||Date.now()});});return {type:'phrasebook',cards:cards,catalogs:Object.keys(catalogsById).map(function(id){return catalogsById[id];}),tags:tags};}
+function applySessionsImport(payload){if(!payload||typeof payload!=='object'){toast('Invalid sessions file');return;}saveSessions(Array.isArray(payload.sessions)?payload.sessions:[]);saveSessionOrder(normalizeSessionOrder(Array.isArray(payload.order)?payload.order:[]));saveRecycled(Array.isArray(payload.recycled)?payload.recycled:[]);saveSessionNotes(payload.notes&&typeof payload.notes==='object'?payload.notes:{});state.activeConvId='';state.messages=[];setActiveConvId('');var sessions=getAllSessions();if(sessions.length)openSession(sessions[0].convId);else{transportDisconnect({preserveQueue:true});showEmptyShell();}renderSessionList();toast('Sessions imported');}
+function applyPhrasebookImport(payload){if(!payload||typeof payload!=='object'){toast('Invalid phrasebook file');return;}var imported=Array.isArray(payload.cards)?payload.cards:[];var map=new Map();imported.forEach(function(c){var n=normalizeCard(c||{});map.set(cardPairKey(n.source,n.sourceLang,n.target,n.targetLang),n);});saveCards(Array.from(map.values()));saveCatalogs(Array.isArray(payload.catalogs)?payload.catalogs:[]);saveTags(Array.isArray(payload.tags)?payload.tags:[]);renderCatalogCards();toast('Phrasebook imported');}
+function applySettingsImport(payload){if(!payload||typeof payload!=='object'){toast('Invalid settings file');return;}if(payload.prefs&&typeof payload.prefs==='object')savePrefs(payload.prefs);if(Array.isArray(payload.themes)&&payload.themes.length){THEMES=payload.themes;var p=getPrefs();p.themeLibrary=THEMES;savePrefs(p);}applyBubbleTheme();renderThemeGrid('source');renderThemeGrid('target');toast('Settings imported');}
+function clearDataOnly(){if(!confirm('Clear local sessions only?'))return;var keys=[];for(var i=0;i<localStorage.length;i++)keys.push(localStorage.key(i));keys.forEach(function(k){if(k&&k.indexOf('ts3_')===0)localStorage.removeItem(k);});location.reload();}
+function exportThenClear(){exportSessionsData();setTimeout(clearDataOnly,120);}
+
+// Seed
+function seedStarterData(){
+  if(getCatalogs().length||getCards().length)return;
+  var catId='cat-th';
+  saveCatalogs([{id:catId,name:'Thailand Travel',emoji:'🇹🇭',desc:'Essential phrases',createdAt:Date.now()}]);
+  var starter=[{source:'Hello',target:'สวัสดี'},{source:'Thank you',target:'ขอบคุณ'},{source:'How much?',target:'เท่าไหร่?'},{source:'Where is the bathroom?',target:'ห้องน้ำอยู่ที่ไหน?'},{source:"I don't understand",target:'ฉันไม่เข้าใจ'}];
+  saveCards(starter.map(function(p,i){return normalizeCard({id:'s'+i,catalogIds:[catId],sourceLang:'en',targetLang:'th',source:p.source,target:p.target,notes:'',tags:['essential'],backtranslate:{sourceLang:'th',targetLang:'en',inputText:p.target,resultText:'',verdict:'',contentHash:btContentHash(p.source,p.target),updatedAt:Date.now()},clarifyChain:[],savedBy:'seed',createdAt:Date.now()-i*1000,updatedAt:Date.now()});}));
+}
+
+// add-tag-btn CSS (not in main sheet since it's used in NC overlay only)
+(function(){var s=document.createElement('style');s.textContent='.tags-wrap{display:flex;flex-wrap:wrap;gap:5px;align-items:center;}.tag-pill{background:var(--tag-bg);color:var(--tag-text);border-radius:7px;padding:3px 8px;font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px;}.tag-remove{background:none;border:none;font-size:11px;color:inherit;cursor:pointer;padding:0;line-height:1;opacity:.65;}.tag-remove:hover{opacity:1;}.add-tag-btn{background:none;border:1.5px dashed var(--ink-dim);border-radius:7px;padding:3px 8px;font-size:11px;font-weight:600;color:var(--ink-dim);cursor:pointer;font-family:"DM Sans",sans-serif;}';document.head.appendChild(s);})();
+
+// ════════════════════════════════════════════════════════
+// INIT
+// ════════════════════════════════════════════════════════
+document.addEventListener('DOMContentLoaded',function(){
+  seedStarterData();
+  if(canSpeak){synth.getVoices();if(synth.onvoiceschanged!==undefined)synth.onvoiceschanged=function(){synth.getVoices();};}
+  if(!SpeechRec){var b=document.getElementById('stt-btn');if(b)b.style.display='none';}
+
+  var p=getPrefs();
+  state.autoSpeakIncoming=!!p.autoSpeakIncoming;
+
+  // Default preferred language to auto-detect on first ever load
+  if(!p._langDetected){
+    p.myLang='';
+    p._langDetected=true;savePrefs(p);
+  }
+  updateLangPill();
+
+  if(Array.isArray(p.themeLibrary)&&p.themeLibrary.length)THEMES=p.themeLibrary;
+  // Purge stale text color prefs — colors are always computed from background now
+  delete p.srcTextColor;delete p.targetAccentColor;savePrefs(p);
+  applyBubbleTheme();
+  if(p.phrasebookAccentColor)applyPhrasebookAccent(p.phrasebookAccentColor);
+  updateAutoReadBtn();
+
+  onTransportEvent(handleRelayEvent);
+  // nc-src-lang and nc-tgt-lang are populated in openNewCard()
+  populateLangSelect('ncat-lang',p.partnerLang||'en');
+  ncatLangChanged();
+  initTagPickerInput();
+  hydrateSessionMediaMap();
+  initMediaWindowInteractions();
+  updateDot();
+  renderMediaShareUI();
+
+  function continueStartup(){
+    // Deep link — share-origin invite only
+    var up=new URLSearchParams(location.search);
+    var hp=new URLSearchParams((location.hash||'').replace(/^#/,''));
+    var invite=parseInviteFromSearch(up,hp);
+    if(invite){
+      history.replaceState({},'',location.pathname);
+      if(invite.rejected){
+        addDiagLog('join rejected reason='+invite.reason,'warn');
+        toast('Please join using a Talk + Say share link. Copying the page URL directly is not supported.');
+      }else{
+        addDiagLog('join accepted reason=share-origin session='+String(invite.sessionId||'').slice(0,8));
+        var sess=getSession(invite.sessionId);
+        if(!sess){
+          var now=Date.now();
+          var ownerName=firstRealName(getPrefs().globalName,getPrefs().userName)||'yournamehere';
+          sess=normalizeSession({convId:invite.sessionId,myHandle:ownerName,myName:ownerName,partnerHandle:'',peerName:'',ownerLangMode:(p.myLang?'fixed':'auto'),ownerFixedLang:p.myLang||'',createdAt:now,lastActivity:now,lastViewedAt:now});
+          putSession(sess);
+          var order=getSessionOrder();order.unshift(invite.sessionId);saveSessionOrder(normalizeSessionOrder(order));
+        }else{
+          putSession(sess);
+        }
+        sess=hydrateSessionFromInvite(sess,invite);
+        state.activeConvId=invite.sessionId;
+        state.messages=getMsgs(invite.sessionId);
+        addInviteMessage(invite.sessionId);
+        putSession(sess);
+        openSession(invite.sessionId);
+        return;
+      }
+    }
+
+    var aid=getActiveConvId();
+    if(aid&&getSession(aid)){
+      var savedSess=getSession(aid);
+      if(savedSess){openSession(aid);}
+      else{showEmptyShell();}
+    }else{
+      var allSessions=getAllSessions();
+      if(allSessions.length){openSession(allSessions[0].convId);}
+      else{showEmptyShell();}
+    }
+  }
+  ensureUserName(function(){continueStartup();});
+  var onboardInput=document.getElementById('onboarding-name');
+  if(onboardInput)onboardInput.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();submitOnboardingName();}});
+
+  // Sheet drag-dismiss
+  document.querySelectorAll('.overlay .sheet-handle').forEach(function(h){
+    var sy=0,dy=0;
+    h.addEventListener('pointerdown',function(e){sy=e.clientY;dy=0;h.setPointerCapture(e.pointerId);});
+    h.addEventListener('pointermove',function(e){if(!h.hasPointerCapture(e.pointerId))return;dy=e.clientY-sy;if(dy>0)h.closest('.sheet').style.transform='translateY('+Math.min(dy,120)+'px)';});
+    h.addEventListener('pointerup',function(e){var sh=h.closest('.sheet');if(sh)sh.style.transform='';if(dy>70){var ov=h.closest('.overlay');if(ov)ov.hidden=true;}try{h.releasePointerCapture(e.pointerId);}catch(_){}});
+  });
+
+  // online/offline handlers registered in transport block
+});
+</script>
+<div style="text-align:center;padding:4px 0 max(4px,env(safe-area-inset-bottom));font-size:9px;color:var(--ink-dim);opacity:.5;">Talk + Say v3.4 · Build 2026-03-30 00:58:36 PDT</div></body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file web UI baseline for vSay derived from Talk + Say v3.4 that bundles chat, phrasebook, and media-share capabilities for easy distribution and testing.
- Consolidate storage, transport, translation, and TTS/STT logic into one standalone HTML for local-first workflows and invite/hand-off flows.
- Improve phrasebook workflows with back-translation, clarify threads, tags, and import/export support.

### Description
- Added new file `vsay.html` implementing the full client UI and logic (CSS, HTML, and JavaScript) for a Talk+Say v3.4 build, including chat shell, composer, phrasebook/catalog screens, tag picker, dialogs, and overlays.
- Implemented media-share floating window with local/remote video/audio handling, closed captions (speech recognition), drag/resize behavior, per-session media state persisted to localStorage, and UI controls to toggle video/mic/CC.
- Implemented transport layer using a relay WS/HTTP endpoint with heartbeat, reconnection, backfill, dedupe, out-queue/retry logic, and handlers for message, translation, history-sync, media-share, media-cc, ack, typing, and presence events.
- Added unified bubble renderer shared by chat messages and phrasebook cards with features: two-column source/target layout, TTS playback, back-translation with auto-quality scoring, clarify threads, tag drawers, saving messages to phrasebook, catalog/tag CRUD, phrasebook export/import (JSON/CSV), recycle bins, and appearance settings.

### Testing
- No automated tests were added or executed as part of this change; this PR introduces a new standalone HTML asset intended for manual/browser validation and integration into existing build/test pipelines later.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce0f769848832db995500e2be0a04c)