### PR TITLE
Fix remote video enablement in bridge2.html

### DIFF
--- a/bridge2.html
+++ b/bridge2.html
@@ -505,6 +505,7 @@ function refreshRemoteVideo(){
 function bindRemoteTrackState(track){
   if(!track||track._tbBound)return;
   track._tbBound=true;
+  if(track.kind==='video')track.enabled=true;
   track.onunmute=refreshRemoteVideo;
   track.onmute=refreshRemoteVideo;
   track.onended=refreshRemoteVideo;


### PR DESCRIPTION
## Summary
- ensure inbound remote video tracks are explicitly enabled when bound
- keep existing remote track lifecycle handlers (`onunmute`, `onmute`, `onended`) intact

## Why
Some peers can surface a remote video track in a disabled state, which can prevent the remote feed from rendering. Explicitly enabling incoming video tracks on bind ensures remote video displays reliably.

## Files changed
- `bridge2.html`

## Validation
- Static inspection of the updated WebRTC remote-track handling logic
- Verified diff contains only the intended minimal change

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d79d94ab50832db39e58cae376dd32)