### PR TITLE
Right-align recent-room metadata and simplify call info chip

### DIFF
--- a/bridge1.html
+++ b/bridge1.html
@@ -43,10 +43,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .lobby-preview video{width:100%;height:100%;object-fit:cover;transform:scaleX(-1);}
 .recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}
 .recent-title{font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.6px;}
-.recent-item{background:var(--surface);border:1px solid var(--surface2);border-radius:10px;padding:10px 12px;}
-.recent-item-top{display:flex;align-items:center;gap:8px;}
-.recent-open{flex:1;min-width:0;background:none;border:none;color:var(--text);text-align:left;cursor:pointer;font:inherit;font-size:14px;font-weight:500;}
-.recent-open small{display:block;color:var(--text-dim);font-size:11px;}
+.recent-item{background:var(--surface);border:1px solid var(--surface2);border-radius:10px;padding:10px 12px;display:flex;flex-direction:column;gap:8px;}
+.recent-item-top{display:flex;align-items:flex-start;gap:8px;min-width:0;}
+.recent-open{flex:1;min-width:0;background:none;border:none;color:var(--text);text-align:left;cursor:pointer;font:inherit;font-size:14px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.recent-item-meta{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex:0 0 auto;max-width:55%;min-width:0;color:var(--text-dim);font-size:11px;line-height:1.2;text-align:right;white-space:nowrap;}
+.recent-item-time,.recent-item-flags{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.recent-item-time{flex:0 1 auto;}
+.recent-item-flags{flex:0 0 auto;}
 .recent-actions{display:flex;gap:6px;margin-top:8px;}
 .recent-act{flex:1;background:rgba(255,255,255,.06);color:var(--text-dim);border:none;border-radius:8px;padding:6px;font-size:11px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
 .recent-act:hover{background:var(--teal);color:#fff;}
@@ -418,10 +421,8 @@ function updateBadges(){
 function renderCallInfoChip(){
   var chip=$('call-info-chip');if(!chip)return;
   var roomName=norm(room.name);
-  var langPair=gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
   var parts=[];
   if(roomName)parts.push('<span class="call-info-chip-part">'+esc(roomName)+'</span>');
-  if(langPair)parts.push('<span class="call-info-chip-part">'+esc(langPair)+'</span>');
   chip.innerHTML=parts.join('<span class="call-info-chip-divider" aria-hidden="true"></span>');
   chip.style.display=parts.length?'':'none';
 }
@@ -493,7 +494,7 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas
 function renderRecent(){
   var w=$('recent-rooms'),l=$('recent-rooms-list'),rows=getRecent();
   w.style.display=rows.length?'':'none';
-  l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class="recent-item"><div class="recent-item-top"><button class="recent-open jr" data-id="'+esc(r.id)+'">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class="recent-actions"><button class="recent-act jr" data-id="'+esc(r.id)+'">▶ Reopen</button>'+(h?'<button class="recent-act jv" data-id="'+esc(r.id)+'">📄 Transcript</button>':'')+'<button class="recent-act danger jd" data-id="'+esc(r.id)+'">✕ Delete</button></div></div>'}).join('');
+  l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var f=gL(r.myLang).flag+' ↔ '+gL(r.theirLang).flag;return '<div class="recent-item"><div class="recent-item-top"><button class="recent-open jr" data-id="'+esc(r.id)+'">'+esc(r.name)+'</button><div class="recent-item-meta"><span class="recent-item-time">'+esc(t)+'</span><span class="recent-item-flags">'+esc(f)+'</span></div></div><div class="recent-actions"><button class="recent-act jr" data-id="'+esc(r.id)+'">▶ Reopen</button>'+(h?'<button class="recent-act jv" data-id="'+esc(r.id)+'">📄 Transcript</button>':'')+'<button class="recent-act danger jd" data-id="'+esc(r.id)+'">✕ Delete</button></div></div>'}).join('');
   l.querySelectorAll('.jr').forEach(function(b){b.onclick=function(){reuseRoom(b.dataset.id)}});
   l.querySelectorAll('.jv').forEach(function(b){b.onclick=function(){viewRoomTr(b.dataset.id)}});
   l.querySelectorAll('.jd').forEach(function(b){b.onclick=function(){delRecent(b.dataset.id)}});


### PR DESCRIPTION
### Motivation
- Prevent language-pair flags from crowding the call overlay and ensure timestamp + flags remain visible on narrow viewports (notably Samsung Chrome) while allowing long room names to truncate cleanly.

### Description
- Removed language-pair flags from `renderCallInfoChip()` so the `#call-info-chip` payload only includes the normalized room name when present.
- Refactored `renderRecent()` to render a dedicated right-aligned metadata block (`.recent-item-meta`) that contains the timestamp and the language-pair flags next to each other, while keeping the action buttons unchanged.
- Added/adjusted CSS for `.recent-item`, `.recent-item-top`, `.recent-open`, `.recent-item-meta`, `.recent-item-time`, and `.recent-item-flags` to enable room-name truncation and preserve a stable, right-justified metadata region on narrow screens.

### Testing
- No automated tests were run for this single-file UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85da72af8832dbac92476f8a7c168)