### PR TITLE
Delegate transcript TTS button clicks and use data attributes instead of inline onclick

### DIFF
--- a/bridge1.html
+++ b/bridge1.html
@@ -841,7 +841,7 @@ function trHtml(e){
   var targetLabel=gL(e.tgtLang||room.theirLang||lang).label;
   var sourceText=e.sourceText||'';
   var targetText=e.translatedText||e.sourceText||'';
-  return '<div class="tr-entry"><div class="tr-bubble"><div class="tr-head"><div class="tr-who '+(e.who==='me'?'mine':'')+'">'+esc(label)+'</div><div class="tr-time">'+esc(ts)+'</div></div><div class="tr-body"><div class="tr-col source"><div class="tr-label">'+esc(gL(lang).label)+'</div><div class="tr-text">'+esc(sourceText)+'</div><button class="tr-tts" type="button" title="Play source" aria-label="Play source" onclick="speakText('+JSON.stringify(sourceText)+','+JSON.stringify(lang)+')"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button></div><div class="tr-divider"></div><div class="tr-col"><div class="tr-label">'+esc(targetLabel)+'</div><div class="tr-text">'+esc(targetText)+'</div><button class="tr-tts" type="button" title="Play target" aria-label="Play target" onclick="speakText('+JSON.stringify(targetText)+','+JSON.stringify(e.tgtLang||room.theirLang||lang)+')"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button></div></div></div></div>';
+  return '<div class="tr-entry"><div class="tr-bubble"><div class="tr-head"><div class="tr-who '+(e.who==='me'?'mine':'')+'">'+esc(label)+'</div><div class="tr-time">'+esc(ts)+'</div></div><div class="tr-body"><div class="tr-col source"><div class="tr-label">'+esc(gL(lang).label)+'</div><div class="tr-text">'+esc(sourceText)+'</div><button class="tr-tts" type="button" title="Play source" aria-label="Play source" data-tts-text="'+esc(sourceText)+'" data-tts-lang="'+esc(lang)+'"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button></div><div class="tr-divider"></div><div class="tr-col"><div class="tr-label">'+esc(targetLabel)+'</div><div class="tr-text">'+esc(targetText)+'</div><button class="tr-tts" type="button" title="Play target" aria-label="Play target" data-tts-text="'+esc(targetText)+'" data-tts-lang="'+esc(e.tgtLang||room.theirLang||lang)+'"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button></div></div></div></div>';
 }
 function appendTrDom(entry){
   var b=$('transcript-body'),w=$('call-transcript');if(!b)return;
@@ -989,6 +989,13 @@ function cleanUp(){
 populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();
 loadCcPrefs();syncCcPrefsInputs();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
+$('transcript-body').addEventListener('click',function(ev){
+  var btn=ev.target&&ev.target.closest?ev.target.closest('.tr-tts'):null;
+  if(!btn)return;
+  var text=btn.getAttribute('data-tts-text')||'';
+  var lang=btn.getAttribute('data-tts-lang')||room.myLang||'en';
+  speakText(text,lang);
+});
 $('local-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('loadedmetadata',refreshRemoteVideo);


### PR DESCRIPTION
### Motivation
- Replace inline `onclick` handlers in transcript HTML with a delegated handler to simplify DOM, improve sanitization, and centralize TTS invocation.

### Description
- Updated `trHtml` to emit `data-tts-text` and `data-tts-lang` attributes on `.tr-tts` buttons instead of `onclick` with `speakText` calls.
- Added a delegated click listener on `$('transcript-body')` that finds `.tr-tts` clicks, reads the `data-tts-*` attributes, and calls `speakText(text, lang)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d881c3afa0832db242a8777abe8d26)