### PR TITLE
Avoid rapid SpeechRecognition restart on silent sessions and add `mic.html` benchmark

### DIFF
--- a/bridge1.html
+++ b/bridge1.html
@@ -347,7 +347,7 @@ var deviceId=localStorage.getItem('tb_dev')||(function(){var id=crypto.randomUUI
 var ws=null,pc=null,videoStream=null,remoteStream=null;
 var micOn=true,camOn=true,makingOffer=false,ignoreOffer=false;
 var SpeechRec=window.SpeechRecognition||window.webkitSpeechRecognition;
-var recognizer=null,recognizing=false,speechGen=0,wantSpeech=true,recognizerActive=false,restartScheduled=false,restartTimer=null,restartBackoff=250,lastRestartTs=0,speechBlockedUntil=0,endBurst=[],endBurstWarned=false;
+var recognizer=null,recognizing=false,speechGen=0,wantSpeech=true,recognizerActive=false,restartScheduled=false,restartTimer=null,restartBackoff=250,lastRestartTs=0,speechBlockedUntil=0,endBurst=[],endBurstWarned=false,speechHeardSinceStart=false;
 var mediaRequestInFlight=null,lastSpeechEventTs=0,lastVisibilityChangeTs=0,lastVisibilityState='visible',lastVisibilitySpeechActionTs=0;
 
 // Mic capture policy: keep WebRTC uplink audio disabled in this bridge pass.
@@ -754,7 +754,7 @@ function startSpeech(){
   recognizer=new SpeechRec();recognizer.lang=locale;
   recognizer.interimResults=false;
   recognizer.continuous=true;recognizer.maxAlternatives=1;
-  recognizer.onstart=function(){if(gen===speechGen){recognizing=true;recognizerActive=true;restartBackoff=250;endBurst=[];endBurstWarned=false;lastSpeechEventTs=Date.now();log('speech_onstart',{gen:gen},'ok')}};
+  recognizer.onstart=function(){if(gen===speechGen){recognizing=true;recognizerActive=true;restartBackoff=250;endBurst=[];endBurstWarned=false;speechHeardSinceStart=false;lastSpeechEventTs=Date.now();log('speech_onstart',{gen:gen},'ok')}};
   recognizer.onresult=function(e){
     if(gen!==speechGen)return;
     var text='';for(var i=e.resultIndex;i<e.results.length;i++)if(e.results[i].isFinal)text+=e.results[i][0].transcript;
@@ -763,6 +763,7 @@ function startSpeech(){
       if(gen!==speechGen)return;
       if(isDupe(text)){log('dedup',{t:text.slice(0,40)},'warn');return}
       lastSpeechEventTs=Date.now();
+      speechHeardSinceStart=true;
       recFinal(text);log('final',{t:text.slice(0,60)},'ok');
       var src=detectLang(text,room.myLang),tgt=room.theirLang,ss=++localSubSeq;
       showSub(text,'mine');
@@ -775,6 +776,12 @@ function startSpeech(){
     if(gen!==speechGen)return;
     recognizing=false;recognizerActive=false;recognizer=null;
     var now=Date.now();
+    if(!speechHeardSinceStart){
+      log('speech_onend_idle',{atMs:now},'warn');
+      flushSpeechRuntime('onend_idle');
+      scheduleSpeechRestart('onend_idle',12000);
+      return;
+    }
     var sinceSpeech=lastSpeechEventTs?now-lastSpeechEventTs:null;
     var countsTowardBurst=sinceSpeech===null||sinceSpeech<3000;
     endBurst=endBurst.filter(function(t){return now-t<8000});

--- a/mic.html
+++ b/mic.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mic Timeout PoC</title>
+<style>
+  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#0f1115;color:#e7eaf0;margin:0;padding:16px}
+  .card{max-width:760px;margin:0 auto;background:#171b22;border:1px solid #2a3240;border-radius:12px;padding:14px}
+  h1{font-size:20px;margin:0 0 10px}
+  p,li{color:#b8c0d0}
+  .row{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
+  button{background:#2d7ef7;color:#fff;border:0;border-radius:10px;padding:10px 12px;font-weight:600;cursor:pointer}
+  button.alt{background:#313845}
+  button:disabled{opacity:.5;cursor:default}
+  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  #status{padding:8px 10px;border-radius:8px;background:#111722;border:1px solid #263146;margin:8px 0}
+  #log{margin-top:10px;max-height:42vh;overflow:auto;background:#0c1018;border:1px solid #263146;border-radius:10px;padding:10px}
+  .line{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.5;border-bottom:1px solid rgba(255,255,255,.05);padding:2px 0}
+  .ok{color:#7ce5a2}.warn{color:#ffd166}.err{color:#ff7b7b}
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>mic.html — SpeechRecognition open-window benchmark</h1>
+    <p>Purpose: measure how long browser speech recognition stays open with no speech (target: Samsung devices + Chrome).</p>
+    <ul>
+      <li>Tap <b>Run 1 test</b> to measure one no-speech session.</li>
+      <li>Tap <b>Run 10 tests</b> to benchmark distribution.</li>
+      <li>Stay silent during each run for clean data.</li>
+    </ul>
+
+    <div class="row">
+      <button id="run1">Run 1 test</button>
+      <button id="run10">Run 10 tests</button>
+      <button id="stop" class="alt">Stop</button>
+      <button id="copy" class="alt">Copy results</button>
+      <button id="clear" class="alt">Clear</button>
+    </div>
+
+    <div id="status" class="mono">Idle</div>
+    <div class="mono" id="summary">No results yet.</div>
+    <div id="log"></div>
+  </div>
+
+<script>
+'use strict';
+(function(){
+  var SR=window.SpeechRecognition||window.webkitSpeechRecognition;
+  var logEl=document.getElementById('log');
+  var statusEl=document.getElementById('status');
+  var summaryEl=document.getElementById('summary');
+  var runs=[];
+  var running=false;
+  var cancelled=false;
+  var activeRec=null;
+
+  function nowIso(){return new Date().toISOString();}
+  function fmt(ms){return (ms/1000).toFixed(2)+'s';}
+  function log(msg,cls){
+    var row=document.createElement('div');
+    row.className='line '+(cls||'');
+    row.textContent='['+new Date().toLocaleTimeString()+'] '+msg;
+    logEl.appendChild(row);
+    logEl.scrollTop=logEl.scrollHeight;
+  }
+  function setStatus(text){statusEl.textContent=text;}
+  function median(arr){if(!arr.length)return 0;var s=arr.slice().sort(function(a,b){return a-b});var m=Math.floor(s.length/2);return s.length%2?s[m]:(s[m-1]+s[m])/2;}
+  function refreshSummary(){
+    if(!runs.length){summaryEl.textContent='No results yet.';return;}
+    var d=runs.map(function(r){return r.ms});
+    var min=Math.min.apply(null,d),max=Math.max.apply(null,d);
+    var avg=d.reduce(function(a,b){return a+b},0)/d.length;
+    var med=median(d);
+    summaryEl.textContent='n='+d.length+' | min='+fmt(min)+' | median='+fmt(med)+' | avg='+fmt(avg)+' | max='+fmt(max);
+  }
+
+  function buildResult(runId,startedAt,endedAt,reason,error){
+    return {
+      run:runId,
+      started_iso:new Date(startedAt).toISOString(),
+      ended_iso:new Date(endedAt).toISOString(),
+      ms:endedAt-startedAt,
+      sec:Number(((endedAt-startedAt)/1000).toFixed(3)),
+      reason:reason||'',
+      error:error||'',
+      ua:navigator.userAgent
+    };
+  }
+
+  function runOnce(runId){
+    return new Promise(function(resolve,reject){
+      if(!SR)return reject(new Error('SpeechRecognition not supported on this browser/device.'));
+      var rec=new SR();
+      activeRec=rec;
+      var tStart=0;
+      var settled=false;
+      var finalError='';
+
+      rec.lang='en-US';
+      rec.continuous=true;
+      rec.interimResults=true;
+      rec.maxAlternatives=1;
+
+      function finish(reason){
+        if(settled)return;
+        settled=true;
+        activeRec=null;
+        var tEnd=Date.now();
+        var result=buildResult(runId,tStart||tEnd,tEnd,reason,finalError);
+        runs.push(result);
+        log('Run '+runId+' ended: '+fmt(result.ms)+' reason='+reason+(finalError?(' error='+finalError):''), reason==='onend'?'ok':'warn');
+        refreshSummary();
+        resolve(result);
+      }
+
+      rec.onstart=function(){
+        tStart=Date.now();
+        setStatus('Run '+runId+': listening… stay silent');
+        log('Run '+runId+' started', 'ok');
+      };
+
+      rec.onresult=function(e){
+        // Keep silent for benchmark. We still log if speech/noise was detected.
+        for(var i=e.resultIndex;i<e.results.length;i++){
+          var txt=(e.results[i][0]&&e.results[i][0].transcript||'').trim();
+          if(txt)log('Run '+runId+' detected speech/noise: "'+txt.slice(0,60)+'"', 'warn');
+        }
+      };
+
+      rec.onerror=function(e){
+        finalError=e.error||'unknown';
+        log('Run '+runId+' error='+finalError, 'err');
+      };
+
+      rec.onend=function(){finish('onend');};
+
+      try{rec.start();}
+      catch(err){reject(err);}
+    });
+  }
+
+  async function runBatch(n){
+    if(running)return;
+    cancelled=false;
+    running=true;
+    setStatus('Preparing…');
+    for(var i=1;i<=n;i++){
+      if(cancelled)break;
+      try{await runOnce(runs.length+1);}catch(err){log('Run failed: '+(err&&err.message?err.message:String(err)),'err');break;}
+      if(i<n&&!cancelled)await new Promise(function(r){setTimeout(r,900);});
+    }
+    running=false;
+    setStatus(cancelled?'Stopped by user':'Idle');
+  }
+
+  function stop(){
+    cancelled=true;
+    if(activeRec){try{activeRec.stop();}catch(_){}}
+    setStatus('Stopping…');
+  }
+
+  function copyResults(){
+    if(!runs.length){log('No results to copy','warn');return;}
+    var header=['run','started_iso','ended_iso','ms','sec','reason','error','ua'];
+    var lines=[header.join(',')].concat(runs.map(function(r){
+      return [r.run,r.started_iso,r.ended_iso,r.ms,r.sec,r.reason,r.error,JSON.stringify(r.ua)].join(',');
+    }));
+    var text=lines.join('\n');
+    if(navigator.clipboard&&navigator.clipboard.writeText){
+      navigator.clipboard.writeText(text).then(function(){log('Results copied as CSV','ok');});
+    }else{
+      log('Clipboard API unavailable on this browser','warn');
+    }
+  }
+
+  document.getElementById('run1').onclick=function(){runBatch(1);};
+  document.getElementById('run10').onclick=function(){runBatch(10);};
+  document.getElementById('stop').onclick=stop;
+  document.getElementById('copy').onclick=copyResults;
+  document.getElementById('clear').onclick=function(){runs=[];logEl.innerHTML='';refreshSummary();setStatus('Idle');};
+
+  if(!SR){
+    setStatus('Unsupported: SpeechRecognition not available');
+    log('SpeechRecognition API missing. Test on Chrome Android/Samsung Internet WebView variants where available.','err');
+  }else{
+    log('Ready. UA='+navigator.userAgent,'ok');
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Prevent the speech-recognition loop where sessions that never hear audio repeatedly stop/start and destabilize live captions.  
- Provide a simple reproducible page to measure how long browser `SpeechRecognition` stays open with no speech for debugging and device benchmarking.

### Description
- Introduced a new runtime flag `speechHeardSinceStart` in `bridge1.html` and initialize it on recognizer start to detect whether any speech was received during the session.  
- Set `speechHeardSinceStart=true` in `recognizer.onresult` when final transcripts are produced, and bail out of normal restart logic in `recognizer.onend` if no speech was heard by flushing runtime state and scheduling a longer restart.  
- Adjusted `recognizer.onstart` to reset `speechHeardSinceStart`.  
- Added a new `mic.html` file which implements a standalone SpeechRecognition open-window benchmark UI with controls for `Run 1 test`, `Run 10 tests`, `Stop`, `Copy results`, and `Clear`, and produces CSV-exportable timing results and summary statistics.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d894178a2c832d98364c49b977adbc)