### PR TITLE
Add throttled foreground GitHub sync checks

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -449,6 +449,8 @@ let remoteBoardSha = null;
 let autoSyncTimer = null;
 let autoSyncInFlight = null;
 let syncBootstrapComplete = false;
+let lastFocusCheckAt = 0;
+const FOCUS_SYNC_THROTTLE_MS = 15000;
 function trySave(key, value){ try{ localStorage.setItem(key, value); return localStorage.getItem(key)===value; }catch(e){ console.warn(e); return false; } }
 function loadPersistedGithubToken(){
   const keys=[GITHUB_PAT_KEY,...LEGACY_GITHUB_PAT_KEYS];
@@ -1537,6 +1539,16 @@ function queueAutoSync(reason="change"){
     });
   }, 900);
 }
+function checkForRemoteUpdateOnFocus(){
+  if(!syncBootstrapComplete) return;
+  if(autoSyncInFlight) return;
+  const now=Date.now();
+  if(now-lastFocusCheckAt < FOCUS_SYNC_THROTTLE_MS) return;
+  lastFocusCheckAt=now;
+  syncBoardWithGitHub("tab focus check", { silent:true }).catch(err=>{
+    console.warn("Foreground sync check failed", err);
+  });
+}
 function triggerRealtimeDriveSync(){
   if(typeof pushStateToRemote==="function") pushStateToRemote();
   queueAutoSync("local update");
@@ -1750,28 +1762,31 @@ async function pullBoardFromGitHub(options={}){
     throw err;
   }
 }
-async function syncBoardWithGitHub(reason="sync"){
+async function syncBoardWithGitHub(reason="sync", options={}){
   clearAutoSync();
   if(autoSyncInFlight) return autoSyncInFlight;
+  const { silent=false } = options || {};
   autoSyncInFlight=(async()=>{
     const cfg=getGitHubSyncConfig();
-    setStatus(`Syncing with GitHub (${cfg.owner}/${cfg.repo}:${cfg.path})…`);
+    if(!silent) setStatus(`Syncing with GitHub (${cfg.owner}/${cfg.repo}:${cfg.path})…`);
     const remote=await fetchGitHubBoard(cfg);
     remoteBoardSha=remote.sha || null;
     const localTs=boardTimestamp(state);
     const remoteTs=boardTimestamp(remote.board);
     if(boardsEqual(remote.board, state)){
-      setStatus(`GitHub already up to date (${cfg.owner}/${cfg.repo}:${cfg.path})`);
+      if(!silent) setStatus(`GitHub already up to date (${cfg.owner}/${cfg.repo}:${cfg.path})`);
       return { action:"noop", remote };
     }
     if(remoteTs > localTs){
       applyImportedBoard(remote.board, `GitHub (${cfg.owner}/${cfg.repo}:${cfg.path})`, { skipAutoSync:true });
-      toast("GitHub updated","Loaded newer board from repository");
-      setStatus(`Pulled newer board from ${cfg.owner}/${cfg.repo}:${cfg.path}`);
+      if(!silent){
+        toast("GitHub updated","Loaded newer board from repository");
+        setStatus(`Pulled newer board from ${cfg.owner}/${cfg.repo}:${cfg.path}`);
+      }
       return { action:"pull", remote };
     }
     await pushBoardToGitHub({ silent:true, reason, expectedSha:remote.sha || null });
-    toast("GitHub updated","Pushed latest local board to repository");
+    if(!silent) toast("GitHub updated","Pushed latest local board to repository");
     return { action:"push", remote };
   })();
   try{
@@ -1955,6 +1970,10 @@ window.addEventListener("beforeunload", ()=>{ if(dirty) persistNow(); });
 
 $("#btnPushGitHub").addEventListener("click", ()=>{ syncBoardWithGitHub("manual sync").catch(err=>console.warn("Manual sync failed", err)); });
 $("#btnPullGitHub").addEventListener("click", ()=>{ pullBoardFromGitHub({ reason:"manual pull" }).catch(err=>console.warn("Manual pull failed", err)); });
+document.addEventListener("visibilitychange", ()=>{
+  if(document.visibilityState==="visible") checkForRemoteUpdateOnFocus();
+});
+window.addEventListener("focus", checkForRemoteUpdateOnFocus);
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce noisy GitHub API calls when users switch back to the tab by performing a lightweight foreground sync check with a throttle and silent behavior.
- Ensure foreground checks do not change user-visible status or block UI unless a real remote change is detected.

### Description
- Added a throttling gate (`lastFocusCheckAt`, `FOCUS_SYNC_THROTTLE_MS`) and a new helper `checkForRemoteUpdateOnFocus()` that returns early if `syncBootstrapComplete` is false or a sync is already running, then calls `syncBoardWithGitHub("tab focus check", { silent:true })` for a background-safe check in `kanban.html`.
- Extended `syncBoardWithGitHub` to accept an `options` object with `silent` to suppress success toasts and status churn for background checks while preserving existing conflict-safe logic (`remoteTs > localTs` pulls remote, otherwise push local).
- Wired event listeners for `document.visibilitychange` to trigger only when `document.visibilityState === "visible"` and a `window.focus` fallback, both invoking `checkForRemoteUpdateOnFocus()`.
- Kept existing behavior: no forced full rerender unless `applyImportedBoard()` is called on a detected newer remote; background checks are minimal and non-blocking.

### Testing
- Parsed the inline JavaScript from `kanban.html` using `node` (`new Function(js)`) to verify script syntax, and the parse succeeded.
- Attempted to run a Python compile check that treated JS as Python which failed due to expected syntax differences, so it is an irrelevant failure and did not block validation of the JS changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d53ca8d8832db00fdfb92ffa185a)