### PR TITLE
Wire local persistence into auto-sync queue

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -471,7 +471,11 @@ function persistNow(options={}){
   const ok = trySave(boardLS(), JSON.stringify(state));
   trySave(STABLE_KEY, JSON.stringify(state));
   if(ok){
-    clearAutoSync();
+    if(syncToGitHub && syncBootstrapComplete){
+      queueAutoSync("local update");
+    }else{
+      clearAutoSync();
+    }
   }
   setStatus(ok? "Saved" : "Local save failed (likely storage limit)");
   dirty=false;
@@ -1534,7 +1538,7 @@ function queueAutoSync(reason="change"){
   if(!syncBootstrapComplete) return;
   autoSyncTimer=setTimeout(()=>{
     autoSyncTimer=null;
-    syncBoardWithGitHub(reason).catch(err=>{
+    syncBoardWithGitHub(reason, { silent:true }).catch(err=>{
       console.warn("Auto sync failed", err);
     });
   }, 900);


### PR DESCRIPTION
### Motivation
- Ensure local board mutations that call `scheduleSave()` flow into a single, centralized remote sync trigger to avoid duplicated GitHub calls and race conditions.
- Keep import/pull workflows and existing guards intact while making background sync non-disruptive for users.

### Description
- Update `persistNow(options={})` to, after a successful local save, call `queueAutoSync("local update")` only when `syncToGitHub` is true and `syncBootstrapComplete` is true, otherwise clear any pending auto-sync timers.
- Make the auto-sync worker call `syncBoardWithGitHub(reason, { silent:true })` so background syncs are silent and failures are logged via `console.warn` without showing toasts.
- Preserve `scheduleSave()` as the single path from UI mutations to persistence and remote sync, without adding direct GitHub calls in mutation functions.

### Testing
- Ran a diff to confirm the intended changes with `git -C /workspace/stuff diff -- kanban.html | sed -n '1,200p'` and reviewed the patch, which showed the `persistNow` and `queueAutoSync` edits and succeeded.
- Inspected the updated file regions with `nl -ba /workspace/stuff/kanban.html | sed -n '462,492p'` and `nl -ba /workspace/stuff/kanban.html | sed -n '1528,1548p'`, and verified the new logic appears in the expected locations and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d60e8db4832d81c8ec8bffc4590b)