### PR TITLE
Replace conflicted HTML pages with clean vanilla redirect, repolist, and repoblast tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GitHub Pages Repo Redirect</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #0b1020;
+      color: #e8ecff;
+    }
+    .card {
+      width: min(760px, 92vw);
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 14px;
+      padding: 20px;
+      backdrop-filter: blur(4px);
+    }
+    h1 { margin-top: 0; font-size: 1.3rem; }
+    p { line-height: 1.45; }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; }
+    input {
+      flex: 1 1 380px;
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid #4f5a8f;
+      background: #121a36;
+      color: #e8ecff;
+    }
+    button {
+      padding: 10px 14px;
+      border: 0;
+      border-radius: 10px;
+      background: #5e7cff;
+      color: white;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    #status { margin-top: 10px; min-height: 1.3em; }
+    a { color: #a9bdff; }
+    code { background: rgba(255,255,255,0.12); padding: 0.1em 0.35em; border-radius: 6px; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Repo Redirect</h1>
+    <p>Enter any of: <code>owner/repo</code>, <code>github.owner/repo</code>, or <code>github.com/owner/repo</code>.</p>
+    <form id="form" class="row" autocomplete="off">
+      <input id="repoInput" placeholder="owner/repo" aria-label="Repository">
+      <button type="submit">Go</button>
+    </form>
+    <div id="status" role="status" aria-live="polite"></div>
+  </main>
+  <script>
+    function parseRepoLike(value) {
+      if (!value) return null;
+      const v = value.trim().replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+      const q = v.match(/(?:^|[?&])repo=([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/);
+      if (q) return q[1];
+      let m = v.match(/^github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^github\.([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^([A-Za-z0-9_.-]+)\.github\.io\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/);
+      if (m) return m[1] + '/' + m[2];
+      return null;
+    }
+
+    function detectRepo() {
+      const url = new URL(window.location.href);
+      const qp = url.searchParams.get('repo');
+      if (qp) {
+        const parsed = parseRepoLike(qp);
+        if (parsed) return parsed;
+      }
+      const candidates = [
+        url.host + url.pathname,
+        url.pathname.slice(1),
+        decodeURIComponent(url.pathname.slice(1)),
+        decodeURIComponent(url.search)
+      ];
+      for (const c of candidates) {
+        const parsed = parseRepoLike(c);
+        if (parsed) return parsed;
+      }
+      return null;
+    }
+
+    function buildTarget(repo) {
+      const [owner, name] = repo.split('/');
+      return `https://${owner}.github.io/${name}/repolist.html`;
+    }
+
+    const statusEl = document.getElementById('status');
+    const inputEl = document.getElementById('repoInput');
+    const formEl = document.getElementById('form');
+
+    function go(repo) {
+      const parsed = parseRepoLike(repo);
+      if (!parsed) {
+        statusEl.textContent = 'Could not parse repo. Use owner/repo style input.';
+        return;
+      }
+      const target = buildTarget(parsed);
+      statusEl.innerHTML = `Redirecting to <a href="${target}">${target}</a>`;
+      window.location.replace(target);
+    }
+
+    formEl.addEventListener('submit', (e) => {
+      e.preventDefault();
+      go(inputEl.value);
+    });
+
+    const detected = detectRepo();
+    if (detected) {
+      inputEl.value = detected;
+      go(detected);
+    } else {
+      statusEl.textContent = 'No repo detected automatically. Enter one manually.';
+    }
+  </script>
+</body>
+</html>

--- a/repoblast.html
+++ b/repoblast.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RepoBlast Deployment Tool</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0b1020; color: #e8ecff; }
+    .wrap { width: min(1100px, 96vw); margin: 18px auto 30px; }
+    h1 { margin: 0 0 10px; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    @media (max-width: 850px) { .grid { grid-template-columns: 1fr; } }
+    .panel { background: #101735; border: 1px solid #293563; border-radius: 12px; padding: 12px; }
+    label { display: block; margin: 8px 0 4px; font-size: 0.9rem; }
+    input, button {
+      width: 100%; box-sizing: border-box; border-radius: 10px; border: 1px solid #46558d;
+      background: #111a39; color: #e8ecff; padding: 10px 12px;
+    }
+    button { background: #5e7cff; border: 0; cursor: pointer; margin-top: 10px; font-weight: 700; }
+    #repos { max-height: 300px; overflow: auto; border: 1px solid #2d3a66; border-radius: 10px; padding: 8px; }
+    .repo-item { display: flex; gap: 8px; align-items: center; padding: 4px 2px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+    th, td { text-align: left; padding: 8px; border-bottom: 1px solid #2f3c68; }
+    .ok { color: #b8ffc6; }
+    .bad { color: #ffb6b6; }
+    #status { margin-top: 10px; min-height: 1.35em; }
+    .hint { opacity: 0.85; font-size: 0.92rem; }
+    code { background: rgba(255,255,255,0.1); padding: 0.1em 0.35em; border-radius: 6px; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>RepoBlast Deployment Tool</h1>
+    <p class="hint">Deploys dynamic <code>index.html</code> and <code>repolist.html</code> to selected repositories using GitHub Contents API.</p>
+    <div class="grid">
+      <section class="panel">
+        <label for="owner">Owner (user or org)</label>
+        <input id="owner" placeholder="GitHub owner">
+
+        <label for="token">GitHub Token (required for writes)</label>
+        <input id="token" type="password" placeholder="ghp_...">
+
+        <button id="loadRepos">Load Repositories</button>
+        <div id="repos"></div>
+        <button id="deploy">Deploy to Selected Repos</button>
+      </section>
+
+      <section class="panel">
+        <h2 style="margin-top:0;font-size:1.1rem;">Deployment Results</h2>
+        <div id="status" role="status" aria-live="polite"></div>
+        <table>
+          <thead><tr><th>Repository</th><th>index.html</th><th>repolist.html</th><th>Result</th></tr></thead>
+          <tbody id="results"></tbody>
+        </table>
+      </section>
+    </div>
+  </main>
+  <script>
+    function defaultOwnerFromHost() {
+      const host = window.location.hostname || '';
+      const m = host.match(/^([A-Za-z0-9_.-]+)\.github\.io$/i);
+      return m ? m[1] : 'acmeproducts';
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>'"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[c]));
+    }
+
+    function templateIndex() {
+      return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Repo Redirect</title></head>
+<body style="font-family:system-ui,Segoe UI,Roboto,sans-serif;padding:20px">
+<script>
+(function(){
+  function p(v){if(!v)return null;v=v.trim().replace(/^https?:\\/\\//i,'').replace(/^www\\./i,'');
+    var q=v.match(/(?:^|[?&])repo=([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)/);if(q)return q[1];
+    var m=v.match(/^github\\.com\\/([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^github\\.([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^([A-Za-z0-9_.-]+)\\.github\\.io\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/);if(m)return m[1]+'/'+m[2];return null;}
+  var u=new URL(location.href),r=p(u.searchParams.get('repo'))||p(u.host+u.pathname)||p(u.pathname.slice(1));
+  if(!r){document.body.innerHTML='<h2>Enter repo</h2><input id="i" placeholder="owner/repo"><button id="b">Go</button>';document.getElementById('b').onclick=function(){var x=p(document.getElementById('i').value);if(x)location.href='https://'+x.split('/')[0]+'.github.io/'+x.split('/')[1]+'/repolist.html';};return;}
+  var s=r.split('/');location.replace('https://'+s[0]+'.github.io/'+s[1]+'/repolist.html');
+})();
+</script></body></html>`;
+    }
+
+    function templateRepoList() {
+      return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Repo File List</title></head>
+<body style="font-family:system-ui,Segoe UI,Roboto,sans-serif;padding:16px"><h1>Repository File List</h1><div id="app">Loading...</div>
+<script>
+(function(){
+  function p(v){if(!v)return null;v=v.trim().replace(/^https?:\\/\\//i,'').replace(/^www\\./i,'');
+    var q=v.match(/(?:^|[?&])repo=([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)/);if(q)return q[1];
+    var m=v.match(/^github\\.com\\/([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^github\\.([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^([A-Za-z0-9_.-]+)\\.github\\.io\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
+    m=v.match(/^([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/);if(m)return m[1]+'/'+m[2];return null;}
+  var u=new URL(location.href),r=p(u.searchParams.get('repo'))||p(u.host+u.pathname)||p(u.pathname.slice(1));
+  if(!r){document.getElementById('app').innerHTML='Add ?repo=owner/repo';return;}
+  var s=r.split('/'),o=s[0],n=s[1];
+  fetch('https://api.github.com/repos/'+o+'/'+n).then(function(x){return x.json()}).then(function(meta){
+    return fetch('https://api.github.com/repos/'+o+'/'+n+'/git/trees/'+encodeURIComponent(meta.default_branch)+'?recursive=1').then(function(x){return x.json()}).then(function(tree){return {branch:meta.default_branch,tree:tree.tree||[]};});
+  }).then(function(data){
+    var rows=data.tree.filter(function(i){return i.type==='blob';}).map(function(i){
+      var launch=/\\.html?$/i.test(i.path)?'<a target="_blank" href="https://'+o+'.github.io/'+n+'/'+i.path+'">Launch</a> · ':'';
+      return '<tr><td>'+i.path+'</td><td>'+(i.size||0)+'</td><td>'+launch+'<a target="_blank" href="https://github.com/'+o+'/'+n+'/blob/'+data.branch+'/'+i.path+'">GitHub</a></td></tr>';
+    }).join('');
+    document.getElementById('app').innerHTML='<table border="1" cellpadding="6" cellspacing="0"><thead><tr><th>Name</th><th>Size</th><th>Actions</th></tr></thead><tbody>'+rows+'</tbody></table>';
+  }).catch(function(e){document.getElementById('app').textContent='Error: '+e;});
+})();
+</script></body></html>`;
+    }
+
+    async function ghFetch(url, token, opts = {}) {
+      const headers = Object.assign({
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }, opts.headers || {});
+      const res = await fetch(url, Object.assign({}, opts, { headers }));
+      const text = await res.text();
+      let json = null;
+      try { json = text ? JSON.parse(text) : null; } catch (_) {}
+      if (!res.ok) {
+        throw new Error(`${res.status} ${res.statusText}: ${(json && (json.message || JSON.stringify(json))) || text}`);
+      }
+      return json;
+    }
+
+    async function listRepos(owner, token) {
+      const userUrl = `https://api.github.com/users/${encodeURIComponent(owner)}/repos?per_page=100&type=owner&sort=full_name`;
+      return ghFetch(userUrl, token);
+    }
+
+    function b64Utf8(str) {
+      return btoa(unescape(encodeURIComponent(str)));
+    }
+
+    async function upsertFile(owner, repo, path, content, token, message) {
+      const base = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodeURIComponent(path)}`;
+      let sha = undefined;
+      try {
+        const existing = await ghFetch(base, token);
+        sha = existing.sha;
+      } catch (_) {}
+      const body = { message, content: b64Utf8(content) };
+      if (sha) body.sha = sha;
+      return ghFetch(base, token, { method: 'PUT', body: JSON.stringify(body) });
+    }
+
+    function setStatus(msg, bad = false) {
+      const el = document.getElementById('status');
+      el.textContent = msg;
+      el.className = bad ? 'bad' : 'ok';
+    }
+
+    function addResultRow(repo, indexMsg, listMsg, ok) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${escapeHtml(repo)}</td><td>${escapeHtml(indexMsg)}</td><td>${escapeHtml(listMsg)}</td><td class="${ok ? 'ok' : 'bad'}">${ok ? 'OK' : 'FAILED'}</td>`;
+      document.getElementById('results').appendChild(tr);
+    }
+
+    async function loadRepos() {
+      const owner = document.getElementById('owner').value.trim();
+      const token = document.getElementById('token').value.trim();
+      if (!owner) { setStatus('Owner required.', true); return; }
+      if (!token) { setStatus('Token required to list private repos and write.', true); return; }
+      setStatus(`Loading repos for ${owner}...`);
+      const reposWrap = document.getElementById('repos');
+      reposWrap.innerHTML = '';
+      try {
+        const repos = await listRepos(owner, token);
+        if (!repos.length) {
+          reposWrap.textContent = 'No repositories found.';
+          setStatus('No repositories found.', true);
+          return;
+        }
+        for (const r of repos) {
+          const div = document.createElement('div');
+          div.className = 'repo-item';
+          div.innerHTML = `<input type="checkbox" value="${escapeHtml(r.name)}" id="repo_${escapeHtml(r.name)}"> <label for="repo_${escapeHtml(r.name)}">${escapeHtml(r.full_name)}</label>`;
+          reposWrap.appendChild(div);
+        }
+        setStatus(`Loaded ${repos.length} repos for ${owner}.`);
+      } catch (err) {
+        setStatus(err.message || String(err), true);
+      }
+    }
+
+    async function deploySelected() {
+      const owner = document.getElementById('owner').value.trim();
+      const token = document.getElementById('token').value.trim();
+      if (!owner || !token) { setStatus('Owner and token are required.', true); return; }
+      const checked = Array.from(document.querySelectorAll('#repos input[type="checkbox"]:checked'));
+      if (!checked.length) { setStatus('Select at least one repository.', true); return; }
+
+      document.getElementById('results').innerHTML = '';
+      let okCount = 0;
+      setStatus(`Deploying to ${checked.length} repos...`);
+
+      for (const cb of checked) {
+        const repo = cb.value;
+        let indexMsg = 'pending', listMsg = 'pending', ok = true;
+        try {
+          await upsertFile(owner, repo, 'index.html', templateIndex(), token, 'Deploy dynamic index redirect page');
+          indexMsg = 'updated';
+        } catch (err) {
+          ok = false;
+          indexMsg = `error: ${err.message || err}`;
+        }
+        try {
+          await upsertFile(owner, repo, 'repolist.html', templateRepoList(), token, 'Deploy dynamic repolist app');
+          listMsg = 'updated';
+        } catch (err) {
+          ok = false;
+          listMsg = `error: ${err.message || err}`;
+        }
+        if (ok) okCount++;
+        addResultRow(repo, indexMsg, listMsg, ok);
+      }
+
+      setStatus(`Done. Success: ${okCount}/${checked.length}.`, okCount !== checked.length);
+    }
+
+    document.getElementById('owner').value = defaultOwnerFromHost();
+    document.getElementById('loadRepos').addEventListener('click', loadRepos);
+    document.getElementById('deploy').addEventListener('click', deploySelected);
+  </script>
+</body>
+</html>

--- a/repolist.html
+++ b/repolist.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Repo File List</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; background: #0a0f1f; color: #e8ecff; }
+    .wrap { width: min(1100px, 96vw); margin: 20px auto; }
+    h1 { margin: 0 0 14px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+    input, button {
+      border-radius: 10px;
+      border: 1px solid #445085;
+      background: #111a38;
+      color: #e8ecff;
+      padding: 10px 12px;
+      font-size: 0.95rem;
+    }
+    input { flex: 1 1 340px; }
+    button { background: #5e7cff; border: 0; cursor: pointer; font-weight: 600; }
+    #status { margin: 8px 0 12px; min-height: 1.35em; }
+    .error { color: #ffb2b2; }
+    table { width: 100%; border-collapse: collapse; background: #101732; border-radius: 12px; overflow: hidden; }
+    th, td { border-bottom: 1px solid #28345f; padding: 10px 12px; text-align: left; }
+    th { background: #131d42; user-select: none; cursor: pointer; }
+    th[data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #a8bcff; }
+    tbody tr:hover { background: #18224b; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    a { color: #a9bdff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Repository File List</h1>
+    <div class="controls">
+      <input id="repoInput" placeholder="owner/repo or github.com/owner/repo">
+      <button id="loadBtn">Load</button>
+    </div>
+    <div id="status" role="status" aria-live="polite"></div>
+    <table>
+      <thead>
+        <tr>
+          <th data-key="name">Name</th>
+          <th data-key="date">Date</th>
+          <th data-key="size">Size</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+  </main>
+  <script>
+    const state = { files: [], sortKey: 'name', sortDir: 'asc' };
+
+    function parseRepoLike(value) {
+      if (!value) return null;
+      const v = value.trim().replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+      const q = v.match(/(?:^|[?&])repo=([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/);
+      if (q) return q[1];
+      let m = v.match(/^github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^github\.([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^([A-Za-z0-9_.-]+)\.github\.io\/([A-Za-z0-9_.-]+)/i);
+      if (m) return m[1] + '/' + m[2];
+      m = v.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/);
+      if (m) return m[1] + '/' + m[2];
+      return null;
+    }
+
+    function detectRepo() {
+      const url = new URL(window.location.href);
+      const qp = url.searchParams.get('repo');
+      if (qp) {
+        const parsed = parseRepoLike(qp);
+        if (parsed) return parsed;
+      }
+      const candidates = [
+        url.host + url.pathname,
+        url.pathname.slice(1),
+        decodeURIComponent(url.pathname.slice(1)),
+        decodeURIComponent(url.search)
+      ];
+      for (const c of candidates) {
+        const parsed = parseRepoLike(c);
+        if (parsed) return parsed;
+      }
+      return null;
+    }
+
+    function fmtDate(iso) {
+      if (!iso) return '-';
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return '-';
+      return d.toLocaleString();
+    }
+
+    function fmtSize(bytes) {
+      if (!Number.isFinite(bytes) || bytes < 0) return '-';
+      if (bytes < 1024) return bytes + ' B';
+      const units = ['KB', 'MB', 'GB'];
+      let n = bytes / 1024;
+      let i = 0;
+      while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+      return `${n.toFixed(1)} ${units[i]}`;
+    }
+
+    function setStatus(text, isError = false) {
+      const el = document.getElementById('status');
+      el.textContent = text;
+      el.className = isError ? 'error' : '';
+    }
+
+    async function fetchJson(url) {
+      const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`GitHub API ${res.status}: ${body.slice(0, 200)}`);
+      }
+      return res.json();
+    }
+
+    async function loadRepo(repo) {
+      const parsed = parseRepoLike(repo);
+      if (!parsed) throw new Error('Could not parse repo. Use owner/repo style input.');
+      const [owner, name] = parsed.split('/');
+      setStatus(`Loading ${owner}/${name}...`);
+
+      const repoMeta = await fetchJson(`https://api.github.com/repos/${owner}/${name}`);
+      const branch = repoMeta.default_branch;
+      const tree = await fetchJson(`https://api.github.com/repos/${owner}/${name}/git/trees/${encodeURIComponent(branch)}?recursive=1`);
+      const blobs = (tree.tree || []).filter(item => item.type === 'blob');
+
+      const shaQueue = blobs.slice(0, 2000).map(item => item.sha);
+      const commitDates = new Map();
+      for (let i = 0; i < shaQueue.length; i += 100) {
+        const slice = shaQueue.slice(i, i + 100).join(',');
+        const commits = await fetchJson(`https://api.github.com/repos/${owner}/${name}/commits?per_page=100&sha=${encodeURIComponent(branch)}`);
+        for (const c of commits) {
+          for (const f of c.files || []) {
+            if (!commitDates.has(f.filename)) {
+              commitDates.set(f.filename, c.commit?.committer?.date || null);
+            }
+          }
+        }
+        if (commits.length < 100) break;
+      }
+
+      state.files = blobs.map(item => ({
+        path: item.path,
+        name: item.path.split('/').pop(),
+        size: Number.isFinite(item.size) ? item.size : 0,
+        date: commitDates.get(item.path) || null,
+        rawUrl: `https://${owner}.github.io/${name}/${item.path}`,
+        ghUrl: `https://github.com/${owner}/${name}/blob/${branch}/${item.path}`
+      }));
+
+      state.repo = { owner, name, branch };
+      render();
+      setStatus(`Loaded ${state.files.length} files from ${owner}/${name} (${branch}).`);
+    }
+
+    function sortedFiles() {
+      const files = [...state.files];
+      const key = state.sortKey;
+      const dir = state.sortDir === 'asc' ? 1 : -1;
+      files.sort((a, b) => {
+        let av = a[key], bv = b[key];
+        if (key === 'name') {
+          av = av.toLowerCase();
+          bv = bv.toLowerCase();
+        } else if (key === 'date') {
+          av = av ? new Date(av).getTime() : 0;
+          bv = bv ? new Date(bv).getTime() : 0;
+        }
+        if (av < bv) return -1 * dir;
+        if (av > bv) return 1 * dir;
+        return 0;
+      });
+      return files;
+    }
+
+    function render() {
+      const tbody = document.getElementById('rows');
+      tbody.innerHTML = '';
+      for (const f of sortedFiles()) {
+        const tr = document.createElement('tr');
+        const ext = f.name.toLowerCase();
+        const canLaunch = ext.endsWith('.html') || ext.endsWith('.htm');
+        tr.innerHTML = `
+          <td class="mono">${f.path}</td>
+          <td>${fmtDate(f.date)}</td>
+          <td>${fmtSize(f.size)}</td>
+          <td>
+            ${canLaunch ? `<a href="${f.rawUrl}" target="_blank" rel="noopener">Launch</a> · ` : ''}
+            <a href="${f.ghUrl}" target="_blank" rel="noopener">GitHub</a>
+          </td>`;
+        tbody.appendChild(tr);
+      }
+
+      document.querySelectorAll('th[data-key]').forEach(th => {
+        const active = th.dataset.key === state.sortKey;
+        th.dataset.active = active ? 'true' : 'false';
+        th.dataset.dir = active ? (state.sortDir === 'asc' ? '▲' : '▼') : '';
+      });
+    }
+
+    document.getElementById('loadBtn').addEventListener('click', async () => {
+      try {
+        await loadRepo(document.getElementById('repoInput').value);
+      } catch (err) {
+        setStatus(err.message || String(err), true);
+      }
+    });
+
+    document.getElementById('repoInput').addEventListener('keydown', async (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        document.getElementById('loadBtn').click();
+      }
+    });
+
+    document.querySelectorAll('th[data-key]').forEach(th => {
+      th.addEventListener('click', () => {
+        const key = th.dataset.key;
+        if (state.sortKey === key) {
+          state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+        } else {
+          state.sortKey = key;
+          state.sortDir = key === 'name' ? 'asc' : 'desc';
+        }
+        render();
+      });
+    });
+
+    (async function init() {
+      const detected = detectRepo();
+      if (detected) {
+        document.getElementById('repoInput').value = detected;
+        try {
+          await loadRepo(detected);
+        } catch (err) {
+          setStatus(err.message || String(err), true);
+        }
+      } else {
+        setStatus('No repo detected automatically. Enter owner/repo and click Load.');
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace merge-conflict fallout by fully replacing the three GitHub Pages tools with clean, self-contained vanilla HTML/JS implementations that reliably detect repo context and avoid preserving conflicted markers.
- Provide a small redirect page (`index.html`), a browsable file-list app (`repolist.html`), and a deployment utility (`repoblast.html`) that can be used across GitHub Pages repos.

### Description
- Replaced `index.html` with a self-contained redirect page that auto-detects `owner/repo` from `?repo=owner/repo`, `github.com/owner/repo`, `github.owner/repo`, or `owner.github.io/repo/...`, accepts manual input, and redirects to `https://{owner}.github.io/{repo}/repolist.html`.
- Replaced `repolist.html` with a self-contained file browser that detects repo context (same parsing rules), fetches the repo default branch and recursive tree via the GitHub API, renders a sortable table with `Name`, `Date`, `Size`, and `Actions`, and provides `Launch` (for `.html/.htm`) and `GitHub` links with error/status handling.
- Replaced `repoblast.html` with a self-contained deployment tool that derives a default owner from `*.github.io` (fallback `acmeproducts`), lists owner repositories via the GitHub API, accepts a token for writes, and `PUT`s generated `index.html` and `repolist.html` to selected repos via the GitHub Contents API (creating or updating files) while reporting per-repo results.
- All three target files were fully replaced (no conflicted content preserved) and implemented as self-contained HTML/CSS/JS with inline templates and no external dependencies.

### Testing
- Verified the new files were staged and committed successfully with `git add` and `git commit`, producing a commit (short SHA `963bdaa`).
- Confirmed repository status with `git status --short` which showed the three new files, and inspected file contents with `nl` to ensure replacements were written as intended.
- Created the PR payload via the automated `mcp__make_pr` call which returned the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e430c6081c832d842a8ea2f2fa534f)