### PR TITLE
Fix RepoBlast template parsing and add launch/delete controls to RepoList

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -83,15 +83,16 @@
   if(!r){document.body.innerHTML='<h2>Enter repo</h2><input id="i" placeholder="owner/repo"><button id="b">Go</button>';document.getElementById('b').onclick=function(){var x=p(document.getElementById('i').value);if(x)location.href='https://'+x.split('/')[0]+'.github.io/'+x.split('/')[1]+'/repolist.html';};return;}
   var s=r.split('/');location.replace('https://'+s[0]+'.github.io/'+s[1]+'/repolist.html');
 })();
-</script></body></html>`;
+<\/script></body></html>`;
     }
 
     function templateRepoList() {
       return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Repo File List</title></head>
-<body style="font-family:system-ui,Segoe UI,Roboto,sans-serif;padding:16px"><h1>Repository File List</h1><div id="app">Loading...</div>
+<body style="font-family:system-ui,Segoe UI,Roboto,sans-serif;padding:16px"><h1>Repository File List</h1><div id="app">Loading...</div><p><button id="toggleDeleted" type="button">Show Deleted</button></p>
 <script>
 (function(){
+  var deleted={},showDeleted=false;
   function p(v){if(!v)return null;v=v.trim().replace(/^https?:\\/\\//i,'').replace(/^www\\./i,'');
     var q=v.match(/(?:^|[?&])repo=([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)/);if(q)return q[1];
     var m=v.match(/^github\\.com\\/([A-Za-z0-9_.-]+)\\/([A-Za-z0-9_.-]+)/i);if(m)return m[1]+'/'+m[2];
@@ -104,14 +105,28 @@
   fetch('https://api.github.com/repos/'+o+'/'+n).then(function(x){return x.json()}).then(function(meta){
     return fetch('https://api.github.com/repos/'+o+'/'+n+'/git/trees/'+encodeURIComponent(meta.default_branch)+'?recursive=1').then(function(x){return x.json()}).then(function(tree){return {branch:meta.default_branch,tree:tree.tree||[]};});
   }).then(function(data){
+    function enc(path){return String(path).split('/').map(function(s){return encodeURIComponent(s)}).join('/');}
+    function pages(path){
+      var ep=enc(path);
+      if(n.toLowerCase()===String(o).toLowerCase()+'.github.io') return 'https://'+o+'.github.io/'+ep;
+      return 'https://'+o+'.github.io/'+n+'/'+ep;
+    }
+    function draw(){
     var rows=data.tree.filter(function(i){return i.type==='blob';}).map(function(i){
-      var launch=/\\.html?$/i.test(i.path)?'<a target="_blank" href="https://'+o+'.github.io/'+n+'/'+i.path+'">Launch</a> · ':'';
-      return '<tr><td>'+i.path+'</td><td>'+(i.size||0)+'</td><td>'+launch+'<a target="_blank" href="https://github.com/'+o+'/'+n+'/blob/'+data.branch+'/'+i.path+'">GitHub</a></td></tr>';
+      if(!showDeleted&&deleted[i.path]) return '';
+      var isHtml=/\\.html?$/i.test(i.path),btn=deleted[i.path]?'Restore':'❌ Delete';
+      var launch=isHtml?'<a target="_blank" href="'+pages(i.path)+'">Launch</a> · <a target="_blank" href="https://'+o+'.github.io/'+enc(i.path)+'">Launch (root)</a> · ':'';
+      var style=deleted[i.path]?' style="opacity:.6;text-decoration:line-through"':'';
+      return '<tr'+style+'><td>'+i.path+'</td><td>'+(i.size||0)+'</td><td>'+launch+'<a target="_blank" href="https://github.com/'+o+'/'+n+'/blob/'+data.branch+'/'+enc(i.path)+'">GitHub Blob</a> · <details><summary>⌄</summary><button data-path="'+i.path+'">'+btn+'</button></details></td></tr>';
     }).join('');
     document.getElementById('app').innerHTML='<table border="1" cellpadding="6" cellspacing="0"><thead><tr><th>Name</th><th>Size</th><th>Actions</th></tr></thead><tbody>'+rows+'</tbody></table>';
+    Array.prototype.forEach.call(document.querySelectorAll('button[data-path]'),function(b){b.onclick=function(){var k=b.getAttribute('data-path');deleted[k]=!deleted[k];draw();};});
+    }
+    draw();
+    document.getElementById('toggleDeleted').onclick=function(){showDeleted=!showDeleted;this.textContent=showDeleted?'Hide Deleted':'Show Deleted';draw();};
   }).catch(function(e){document.getElementById('app').textContent='Error: '+e;});
 })();
-</script></body></html>`;
+<\/script></body></html>`;
     }
 
     async function ghFetch(url, token, opts = {}) {

--- a/repolist.html
+++ b/repolist.html
@@ -30,6 +30,54 @@
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     a { color: #a9bdff; text-decoration: none; }
     a:hover { text-decoration: underline; }
+    .deleted { opacity: 0.6; }
+    .deleted .mono { text-decoration: line-through; }
+    .actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    details.row-menu { display: inline-block; }
+    details.row-menu > summary {
+      list-style: none;
+      cursor: pointer;
+      user-select: none;
+      display: inline-flex;
+      width: 28px;
+      height: 28px;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid #445085;
+      border-radius: 8px;
+      background: #111a38;
+      color: #e8ecff;
+    }
+    details.row-menu > summary::-webkit-details-marker { display: none; }
+    .menu-panel {
+      margin-top: 6px;
+      background: #0f1833;
+      border: 1px solid #2b3866;
+      border-radius: 8px;
+      padding: 6px;
+      min-width: 150px;
+    }
+    .danger {
+      background: #7a1022;
+      color: #ffd8de;
+      border: 1px solid #b83b52;
+      border-radius: 8px;
+      padding: 6px 8px;
+      cursor: pointer;
+      width: 100%;
+      text-align: left;
+    }
+    .ghost {
+      background: #1c2a56;
+      color: #dbe4ff;
+      border: 1px solid #42518a;
+      border-radius: 8px;
+      padding: 6px 8px;
+      cursor: pointer;
+      width: 100%;
+      text-align: left;
+      margin-top: 6px;
+    }
   </style>
 </head>
 <body>
@@ -38,6 +86,7 @@
     <div class="controls">
       <input id="repoInput" placeholder="owner/repo or github.com/owner/repo">
       <button id="loadBtn">Load</button>
+      <button id="toggleDeletedBtn" type="button">Show Deleted</button>
     </div>
     <div id="status" role="status" aria-live="polite"></div>
     <table>
@@ -53,7 +102,13 @@
     </table>
   </main>
   <script>
-    const state = { files: [], sortKey: 'name', sortDir: 'asc' };
+    const state = {
+      files: [],
+      sortKey: 'name',
+      sortDir: 'asc',
+      deletedPaths: new Set(),
+      showDeleted: false
+    };
 
     function parseRepoLike(value) {
       if (!value) return null;
@@ -154,17 +209,31 @@
         name: item.path.split('/').pop(),
         size: Number.isFinite(item.size) ? item.size : 0,
         date: commitDates.get(item.path) || null,
-        rawUrl: `https://${owner}.github.io/${name}/${item.path}`,
-        ghUrl: `https://github.com/${owner}/${name}/blob/${branch}/${item.path}`
+        pagesUrl: buildPagesUrl(owner, name, item.path),
+        rootPagesUrl: `https://${owner}.github.io/${encodePath(item.path)}`,
+        ghBlobUrl: `https://github.com/${owner}/${name}/blob/${branch}/${encodePath(item.path)}`
       }));
 
       state.repo = { owner, name, branch };
+      state.deletedPaths = new Set();
       render();
       setStatus(`Loaded ${state.files.length} files from ${owner}/${name} (${branch}).`);
     }
 
+    function encodePath(path) {
+      return path.split('/').map(seg => encodeURIComponent(seg)).join('/');
+    }
+
+    function buildPagesUrl(owner, repo, path) {
+      const encodedPath = encodePath(path);
+      if (repo.toLowerCase() === `${owner.toLowerCase()}.github.io`) {
+        return `https://${owner}.github.io/${encodedPath}`;
+      }
+      return `https://${owner}.github.io/${repo}/${encodedPath}`;
+    }
+
     function sortedFiles() {
-      const files = [...state.files];
+      const files = state.files.filter(file => state.showDeleted || !state.deletedPaths.has(file.path));
       const key = state.sortKey;
       const dir = state.sortDir === 'asc' ? 1 : -1;
       files.sort((a, b) => {
@@ -187,19 +256,42 @@
       const tbody = document.getElementById('rows');
       tbody.innerHTML = '';
       for (const f of sortedFiles()) {
+        const isDeleted = state.deletedPaths.has(f.path);
         const tr = document.createElement('tr');
+        tr.className = isDeleted ? 'deleted' : '';
         const ext = f.name.toLowerCase();
         const canLaunch = ext.endsWith('.html') || ext.endsWith('.htm');
+        const toggleLabel = isDeleted ? 'Restore' : '❌ Delete';
+        const toggleClass = isDeleted ? 'ghost' : 'danger';
         tr.innerHTML = `
           <td class="mono">${f.path}</td>
           <td>${fmtDate(f.date)}</td>
           <td>${fmtSize(f.size)}</td>
-          <td>
-            ${canLaunch ? `<a href="${f.rawUrl}" target="_blank" rel="noopener">Launch</a> · ` : ''}
-            <a href="${f.ghUrl}" target="_blank" rel="noopener">GitHub</a>
+          <td class="actions">
+            ${canLaunch ? `<a href="${f.pagesUrl}" target="_blank" rel="noopener">Launch</a>` : ''}
+            ${canLaunch ? `<a href="${f.rootPagesUrl}" target="_blank" rel="noopener">Launch (root)</a>` : ''}
+            <a href="${f.ghBlobUrl}" target="_blank" rel="noopener">GitHub Blob</a>
+            <details class="row-menu">
+              <summary title="Row actions">⌄</summary>
+              <div class="menu-panel">
+                <button type="button" class="${toggleClass}" data-path="${f.path}">${toggleLabel}</button>
+              </div>
+            </details>
           </td>`;
         tbody.appendChild(tr);
       }
+      tbody.querySelectorAll('button[data-path]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const path = btn.dataset.path;
+          if (!path) return;
+          if (state.deletedPaths.has(path)) {
+            state.deletedPaths.delete(path);
+          } else {
+            state.deletedPaths.add(path);
+          }
+          render();
+        });
+      });
 
       document.querySelectorAll('th[data-key]').forEach(th => {
         const active = th.dataset.key === state.sortKey;
@@ -221,6 +313,12 @@
         e.preventDefault();
         document.getElementById('loadBtn').click();
       }
+    });
+
+    document.getElementById('toggleDeletedBtn').addEventListener('click', () => {
+      state.showDeleted = !state.showDeleted;
+      document.getElementById('toggleDeletedBtn').textContent = state.showDeleted ? 'Hide Deleted' : 'Show Deleted';
+      render();
     });
 
     document.querySelectorAll('th[data-key]').forEach(th => {


### PR DESCRIPTION
### Motivation
- Prevent generated HTML templates from breaking the outer script by ensuring embedded `</script>` sequences are escaped in `repoblast.html` template strings.
- Provide richer file actions in the RepoList UI so users can open Pages (repo and root), view the GitHub blob, and mark files for delete/restore behind a compact chevron menu.

### Description
- Escape embedded closing script tag in generated templates returned by `templateIndex()` and `templateRepoList()` in `repoblast.html` so the outer script block remains valid.
- Extend the generated `repolist.html` template emitted by `repoblast.html` to include Pages launch links (repo-scoped and root user Pages), encoded blob links, a per-row collapsible chevron menu, and a toggle for showing deleted entries.
- Update standalone `repolist.html` with new UI and behavior: deleted-row styling, `Show Deleted` toggle, `❌ Delete` / `Restore` actions tucked inside a `details` chevron, `Launch` and `Launch (root)` links for HTML files, and `GitHub Blob` links; added helper functions `encodePath()` and `buildPagesUrl()` for correct URL encoding.
- Maintain in-memory deletion state (`deletedPaths`) and ensure sorting, rendering, and action handlers work with the new controls.

### Testing
- Ran a JavaScript compile check that extracts `<script>` blocks from both `repoblast.html` and `repolist.html` and invoked `new Function(...)` on each block, and the check completed with no syntax errors.
- Verified the generated template strings no longer contain raw `</script>` sequences that would prematurely close the outer script (manual inspection as part of validation).
- No automated unit tests were added; changes are limited to front-end templates and client-side behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e446225ed8832d865aea5c790c2dd4)