### PR TITLE
Improve repolist links and GitHub auth persistence; deploy local repolist from repoblast

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -800,6 +800,11 @@
       el.className = bad ? 'bad' : 'ok';
     }
 
+    function persistDeployAuth() {
+      localStorage.setItem('repoblast:owner', ownerEl.value.trim());
+      localStorage.setItem('repoblast:token', tokenEl.value.trim());
+    }
+
     function addResultRow(repo, indexMsg, listMsg, ok) {
       const tr = document.createElement('tr');
       tr.innerHTML = `<td>${escapeHtml(repo)}</td><td>${escapeHtml(indexMsg)}</td><td>${escapeHtml(listMsg)}</td><td class="${ok ? 'ok' : 'bad'}">${ok ? 'OK' : 'FAILED'}</td>`;
@@ -811,6 +816,7 @@
       const token = document.getElementById('token').value.trim();
       if (!owner) return setStatus('Owner required.', true);
       if (!token) return setStatus('Token required to list private repos and write.', true);
+      persistDeployAuth();
       setStatus(`Loading repos for ${owner}...`);
       const reposWrap = document.getElementById('repos');
       reposWrap.innerHTML = '';
@@ -839,13 +845,23 @@
       document.getElementById('results').innerHTML = '';
       let okCount = 0;
       setStatus(`Deploying to ${checked.length} repos...`);
+      persistDeployAuth();
+      let repolistPayload = '';
+      try {
+        repolistPayload = await fetch('repolist.html', { cache: 'no-store' }).then((res) => {
+          if (!res.ok) throw new Error(`Unable to load local repolist.html (${res.status})`);
+          return res.text();
+        });
+      } catch (err) {
+        return setStatus(`Failed to read local repolist.html: ${err.message || err}`, true);
+      }
 
       for (const cb of checked) {
         const repo = cb.value;
         let indexMsg = 'pending', listMsg = 'pending', ok = true;
         try { await upsertFile(owner, repo, 'index.html', templateIndex(), token, 'Deploy dynamic index redirect page'); indexMsg = 'updated'; }
         catch (err) { ok = false; indexMsg = `error: ${err.message || err}`; }
-        try { await upsertFile(owner, repo, 'repolist.html', templateRepoList(), token, 'Deploy dynamic repolist app'); listMsg = 'updated'; }
+        try { await upsertFile(owner, repo, 'repolist.html', repolistPayload, token, 'Deploy dynamic repolist app'); listMsg = 'updated'; }
         catch (err) { ok = false; listMsg = `error: ${err.message || err}`; }
         if (ok) okCount++;
         addResultRow(repo, indexMsg, listMsg, ok);
@@ -858,10 +874,13 @@
     const tokenEl = document.getElementById('token');
     ownerEl.value = localStorage.getItem('repoblast:owner') || defaultOwnerFromHost();
     tokenEl.value = localStorage.getItem('repoblast:token') || '';
-    ownerEl.addEventListener('blur', () => localStorage.setItem('repoblast:owner', ownerEl.value.trim()));
-    tokenEl.addEventListener('blur', () => localStorage.setItem('repoblast:token', tokenEl.value.trim()));
+    ownerEl.addEventListener('input', persistDeployAuth);
+    tokenEl.addEventListener('input', persistDeployAuth);
+    ownerEl.addEventListener('blur', persistDeployAuth);
+    tokenEl.addEventListener('blur', persistDeployAuth);
     document.getElementById('loadRepos').addEventListener('click', loadRepos);
     document.getElementById('deploy').addEventListener('click', deploySelected);
+    if (ownerEl.value && tokenEl.value) loadRepos();
   </script>
 </body>
 </html>

--- a/repolist.html
+++ b/repolist.html
@@ -82,7 +82,30 @@
     a { color: #1d4ed8; text-decoration: none; font-weight: 600; }
     a:hover { text-decoration: underline; }
 
-    .actions { display: flex; align-items: center; justify-content: center; }
+    .actions { display: flex; align-items: center; justify-content: center; gap: 8px; }
+    .links-cell {
+      white-space: nowrap;
+      width: 180px;
+      min-width: 180px;
+    }
+    .link-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background: #fff;
+      color: #334155;
+      font-size: 0.86rem;
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .link-icon:hover {
+      background: #f8fafc;
+      text-decoration: none;
+    }
     .row-delete {
       border: 1px solid #cbd5e1;
       background: #f1f5f9;
@@ -207,11 +230,10 @@
         <thead>
           <tr>
             <th data-key="name">Name</th>
-            <th data-key="changed">Changed</th>
+            <th>Links</th>
+            <th>Commit</th>
             <th data-key="size">Size</th>
-            <th>Edit</th>
-            <th>Launch</th>
-            <th>Listing</th>
+            <th data-key="changed">Changed</th>
             <th>Delete</th>
           </tr>
         </thead>
@@ -317,11 +339,22 @@
       return `${m}m ago`;
     }
 
+    function currentToken() {
+      return (document.getElementById('tokenInput').value || '').trim();
+    }
+
+    function persistToken() {
+      localStorage.setItem(PAT_KEY, currentToken());
+    }
+
     async function fetchJson(url) {
-      const token = (document.getElementById('tokenInput').value || '').trim();
+      const token = currentToken();
       const headers = { Accept: 'application/vnd.github+json' };
-      if (token) headers.Authorization = `token ${token}`;
-      const res = await fetch(url, { headers });
+      if (token) headers.Authorization = `Bearer ${token}`;
+      let res = await fetch(url, { headers });
+      if (res.status === 401 && token) {
+        res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
+      }
       if (!res.ok) {
         const body = await res.text();
         throw new Error(`GitHub API ${res.status}: ${body.slice(0, 200)}`);
@@ -451,20 +484,22 @@
       const tbody = document.getElementById('rows');
       const files = sortedFiles();
       if (!files.length) {
-        tbody.innerHTML = '<tr><td colspan="7" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="6" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
       } else {
         tbody.innerHTML = files.map((f) => {
           const canLaunch = /\.html?$/i.test(f.path);
           return `<tr>
             <td class="mono">${esc(f.path)}</td>
+            <td class="actions links-cell">
+              <button class="edit-btn" type="button" data-edit="${esc(f.path)}" aria-label="Edit ${esc(f.path)}">✎</button>
+              ${canLaunch ? `<a class="link-icon" href="${esc(f.pagesUrl)}" target="_blank" rel="noopener" aria-label="Open Pages URL for ${esc(f.path)}">Pg</a>` : '<span class="link-icon" aria-hidden="true">—</span>'}
+              <a class="link-icon" href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for ${esc(f.path)}">Gh</a>
+            </td>
             <td class="changed-cell">
               <div class="commit-msg" title="${esc(f.commitMessage || '')}">${esc(shortCommitMessage(f.commitMessage || ''))}</div>
-              <div class="commit-ago">${esc(fmtAgo(f.changed))}</div>
             </td>
             <td>${esc(fmtSize(f.size))}</td>
-            <td class="actions"><button class="edit-btn" type="button" data-edit="${esc(f.path)}" aria-label="Edit ${esc(f.path)}">✎</button></td>
-            <td>${canLaunch ? `<a href="${esc(f.pagesUrl)}" target="_blank" rel="noopener">Launch</a>` : ''}</td>
-            <td><a href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener">Listing</a></td>
+            <td class="commit-ago">${esc(fmtAgo(f.changed))}</td>
             <td class="actions"><button class="row-delete" type="button" data-delete="${esc(f.path)}" aria-label="Delete ${esc(f.path)}">×</button></td>
           </tr>`;
         }).join('');
@@ -554,6 +589,9 @@
         setStatus(`Loaded ${state.files.length} files from ${owner}/${name} (${branch}).`);
       } catch (err) {
         const msg = err.message || String(err);
+        if (msg.includes('GitHub API 401')) {
+          setStatus('GitHub token was rejected (401). Re-enter PAT and it will persist automatically.', true);
+        } else
         if (msg.includes('GitHub API 403')) {
           setStatus('GitHub API rate limit hit. Add a PAT in the token box for higher limits.', true);
         } else {
@@ -582,7 +620,7 @@
     function b64Utf8(str) { return btoa(unescape(encodeURIComponent(str))); }
 
     async function githubWrite(path, body, method = 'PUT') {
-      const token = (document.getElementById('tokenInput').value || '').trim();
+      const token = currentToken();
       if (!token) throw new Error('GitHub PAT required for edits.');
       const [owner, name] = [state.repo.owner, state.repo.name];
       const url = `https://api.github.com/repos/${owner}/${name}/contents/${encodePath(path)}`;
@@ -590,7 +628,7 @@
         method,
         headers: {
           Accept: 'application/vnd.github+json',
-          Authorization: `token ${token}`,
+          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(body)
@@ -642,9 +680,8 @@
       }, 450);
     });
     document.getElementById('tokenInput').value = localStorage.getItem(PAT_KEY) || '';
-    document.getElementById('tokenInput').addEventListener('blur', () => {
-      localStorage.setItem(PAT_KEY, document.getElementById('tokenInput').value.trim());
-    });
+    document.getElementById('tokenInput').addEventListener('input', persistToken);
+    document.getElementById('tokenInput').addEventListener('blur', persistToken);
     document.getElementById('editCancel').addEventListener('click', closeEdit);
     document.getElementById('editSave').addEventListener('click', saveEdit);
     document.getElementById('editModal').addEventListener('click', (e) => {


### PR DESCRIPTION
### Motivation
- Fix repeated `GitHub API 401` friction and make token/owner persistence immediate while matching the requested file-list layout with fixed link actions next to filenames so users don't need to re-enter repo/owner context.

### Description
- Updated `repolist.html` to add a dedicated "Links" column to the right of the filename with fixed action icons (edit, Pages link, GitHub blob link), and reorganized metadata into separate Commit, Size, and Changed columns with supporting CSS for the icon layout.
- Hardened authentication in `repolist.html` by adding `currentToken()`/`persistToken()` helpers, persisting the PAT on input (not only blur), switching API auth usage to `Bearer`, retrying read requests unauthenticated on a 401 response, and showing a clearer 401 status message to prompt re-entry.
- Updated write paths to use the persisted token accessor (`githubWrite` now uses the new token accessor and `Bearer` header) so edits require the PAT and it is stored immediately.
- Modified `repoblast.html` to persist owner/token on input and blur via `persistDeployAuth()`, auto-load repositories when saved credentials exist, persist auth before load/deploy actions, and to deploy the current local `repolist.html` payload (fetched at deploy time) instead of an in-script template so deployed copies reflect the updated UI and auth fixes.

### Testing
- Ran repository source checks including `git diff --check` which reported no whitespace/patch issues and used search verification (`rg`) to confirm updated strings and injected helpers; these checks passed.
- Patch application tooling was used to apply and verify changes to `repolist.html` and `repoblast.html` with no apply failures.
- There are no project unit/browser tests executed in this environment, and no interactive/browser rendering tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a888173c832d887fe3b31708537e)