### PR TITLE
Revamp repolist and repoblast layout for compact, professional readability

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -18,7 +18,8 @@
     #repos { max-height: 300px; overflow: auto; border: 1px solid #2d3a66; border-radius: 10px; padding: 8px; }
     .repo-item { display: flex; gap: 8px; align-items: center; padding: 4px 2px; }
     table { width: 100%; border-collapse: collapse; margin-top: 10px; }
-    th, td { text-align: left; padding: 8px; border-bottom: 1px solid #2f3c68; }
+    th, td { text-align: left; padding: 7px 8px; border-bottom: 1px solid #2f3c68; font-size: 0.83rem; line-height: 1.2; }
+    th { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: #c4d0ff; }
     .ok { color: #b8ffc6; }
     .bad { color: #ffb6b6; }
     #status { margin-top: 10px; min-height: 1.35em; }
@@ -46,7 +47,7 @@
       <section class="panel">
         <h2 style="margin-top:0;font-size:1.1rem;">Deployment Results</h2>
         <div id="status" role="status" aria-live="polite"></div>
-        <table>
+        <table class="results-table">
           <thead><tr><th>Repository</th><th>index.html</th><th>repolist.html</th><th>Result</th></tr></thead>
           <tbody id="results"></tbody>
         </table>
@@ -156,9 +157,10 @@
     tbody td {
       border-bottom: 1px solid #e3e8f3;
       border-right: 1px solid #ebf0f7;
-      padding: 10px 12px;
-      font-size: 0.92rem;
+      padding: 7px 10px;
+      font-size: 0.88rem;
       vertical-align: middle;
+      line-height: 1.25;
     }
     tbody td:last-child { border-right: 0; }
     tbody tr:nth-child(odd) td { background: #ffffff; }
@@ -166,20 +168,34 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { min-width: 180px; max-width: 220px; }
-    .changed-cell { min-width: 110px; max-width: 130px; white-space: nowrap; }
-    .commit-msg { font-weight: 600; color: #0f172a; margin-top: 2px; white-space: pre-wrap; word-break: break-word; font-size: 0.8rem; line-height: 1.2; }
-    .commit-ago { font-size: 0.84rem; color: #64748b; }
+    .name-cell { min-width: 220px; max-width: 320px; }
+    .changed-cell { min-width: 300px; width: 42%; }
+    .commit-msg {
+      font-weight: 600;
+      color: #0f172a;
+      font-size: 0.82rem;
+      line-height: 1.15;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .commit-ago {
+      display: block;
+      margin-top: 2px;
+      font-size: 0.78rem;
+      color: #64748b;
+      white-space: nowrap;
+    }
     a { color: #1d4ed8; text-decoration: none; font-weight: 600; }
     a:hover { text-decoration: underline; }
 
-    .actions { display: flex; align-items: center; justify-content: center; gap: 4px; }
+    .actions { display: flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; }
     .link-icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       border: 1px solid #cbd5e1;
       border-radius: 6px;
       background: #fff;
@@ -197,8 +213,8 @@
       background: #f1f5f9;
       color: #64748b;
       border-radius: 999px;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       padding: 0;
       font-size: 0.8rem;
       line-height: 1;
@@ -264,8 +280,8 @@
       background: #ffffff;
       color: #334155;
       border-radius: 8px;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       padding: 0;
       cursor: pointer;
       font-size: 0.8rem;
@@ -299,7 +315,9 @@
       .wrap { width: min(1200px, 99vw); margin: 10px auto 16px; }
       .controls { grid-template-columns: 1fr; }
       th, td { padding: 8px; }
-      .link-icon, .edit-btn { width: 26px; height: 26px; }
+      .changed-cell { min-width: 200px; width: auto; }
+      .commit-msg { max-width: 48vw; }
+      .link-icon, .edit-btn, .row-delete { width: 26px; height: 26px; }
     }
   </style>
 </head>
@@ -328,7 +346,7 @@
             <th data-key="ghListingUrl">Document</th>
             <th>Delete</th>
             <th data-key="size">Size</th>
-            <th data-key="changed">Updated When</th>
+            <th data-key="changed">Last Update</th>
           </tr>
         </thead>
         <tbody id="rows"></tbody>
@@ -604,14 +622,10 @@
             <td class="actions"><a class="link-icon" href="\${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for \${esc(f.path)}">Gh</a></td>
             <td class="actions"><button class="row-delete" type="button" data-delete="\${esc(f.path)}" aria-label="Delete \${esc(f.path)}">×</button></td>
             <td>\${esc(fmtSize(f.size))}</td>
-            <td class="commit-ago">\${esc(fmtAgo(f.changed))}</td>
-          </tr>
-          <tr>
-            <td></td>
             <td class="changed-cell" title="\${esc(f.commitMessage || '')}">
               <div class="commit-msg">\${esc(commitWrappedPreview(f.commitMessage || ''))}</div>
+              <span class="commit-ago">\${esc(fmtAgo(f.changed))}</span>
             </td>
-            <td colspan="5"></td>
           </tr>\`;
         }).join('');
         document.querySelectorAll('[data-delete]').forEach((btn) => btn.addEventListener('click', () => softDelete(btn.getAttribute('data-delete'))));

--- a/repolist.html
+++ b/repolist.html
@@ -69,9 +69,10 @@
     tbody td {
       border-bottom: 1px solid #e3e8f3;
       border-right: 1px solid #ebf0f7;
-      padding: 10px 12px;
-      font-size: 0.92rem;
+      padding: 7px 10px;
+      font-size: 0.88rem;
       vertical-align: middle;
+      line-height: 1.25;
     }
     tbody td:last-child { border-right: 0; }
     tbody tr:nth-child(odd) td { background: #ffffff; }
@@ -79,20 +80,34 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { min-width: 180px; max-width: 220px; }
-    .changed-cell { min-width: 110px; max-width: 130px; white-space: nowrap; }
-    .commit-msg { font-weight: 600; color: #0f172a; margin-top: 2px; white-space: pre-wrap; word-break: break-word; font-size: 0.8rem; line-height: 1.2; }
-    .commit-ago { font-size: 0.84rem; color: #64748b; }
+    .name-cell { min-width: 220px; max-width: 320px; }
+    .changed-cell { min-width: 300px; width: 42%; }
+    .commit-msg {
+      font-weight: 600;
+      color: #0f172a;
+      font-size: 0.82rem;
+      line-height: 1.15;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .commit-ago {
+      display: block;
+      margin-top: 2px;
+      font-size: 0.78rem;
+      color: #64748b;
+      white-space: nowrap;
+    }
     a { color: #1d4ed8; text-decoration: none; font-weight: 600; }
     a:hover { text-decoration: underline; }
 
-    .actions { display: flex; align-items: center; justify-content: center; gap: 4px; }
+    .actions { display: flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; }
     .link-icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       border: 1px solid #cbd5e1;
       border-radius: 6px;
       background: #fff;
@@ -110,8 +125,8 @@
       background: #f1f5f9;
       color: #64748b;
       border-radius: 999px;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       padding: 0;
       font-size: 0.8rem;
       line-height: 1;
@@ -177,8 +192,8 @@
       background: #ffffff;
       color: #334155;
       border-radius: 8px;
-      width: 20px;
-      height: 20px;
+      width: 22px;
+      height: 22px;
       padding: 0;
       cursor: pointer;
       font-size: 0.8rem;
@@ -212,7 +227,9 @@
       .wrap { width: min(1200px, 99vw); margin: 10px auto 16px; }
       .controls { grid-template-columns: 1fr; }
       th, td { padding: 8px; }
-      .link-icon, .edit-btn { width: 26px; height: 26px; }
+      .changed-cell { min-width: 200px; width: auto; }
+      .commit-msg { max-width: 48vw; }
+      .link-icon, .edit-btn, .row-delete { width: 26px; height: 26px; }
     }
   </style>
 </head>
@@ -241,7 +258,7 @@
             <th data-key="ghListingUrl">Document</th>
             <th>Delete</th>
             <th data-key="size">Size</th>
-            <th data-key="changed">Updated When</th>
+            <th data-key="changed">Last Update</th>
           </tr>
         </thead>
         <tbody id="rows"></tbody>
@@ -530,14 +547,10 @@
             <td class="actions"><a class="link-icon" href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for ${esc(f.path)}">Gh</a></td>
             <td class="actions"><button class="row-delete" type="button" data-delete="${esc(f.path)}" aria-label="Delete ${esc(f.path)}">×</button></td>
             <td>${esc(fmtSize(f.size))}</td>
-            <td class="commit-ago">${esc(fmtAgo(f.changed))}</td>
-          </tr>
-          <tr>
-            <td></td>
             <td class="changed-cell" title="${esc(f.commitMessage || '')}">
               <div class="commit-msg">${esc(commitWrappedPreview(f.commitMessage || ''))}</div>
+              <span class="commit-ago">${esc(fmtAgo(f.changed))}</span>
             </td>
-            <td colspan="5"></td>
           </tr>`;
         }).join('');
         document.querySelectorAll('[data-delete]').forEach((btn) => btn.addEventListener('click', () => softDelete(btn.getAttribute('data-delete'))));


### PR DESCRIPTION
### Motivation
- The file-list UI regressed to very tall, sparse rows and needs a compact, efficient layout for quick scanning and high information density.
- The embedded `repolist` template used by the deployment tool must stay visually consistent, so the same presentation improvements are applied to `repoblast.html`.

### Description
- Reduced table row padding and font sizes and tightened line-height to increase row density across `repolist.html` and the `repolist` template inside `repoblast.html`.
- Converted the two-row-per-file layout into a single compact row by combining the commit summary and relative update time into a single `Last Update` column and renaming the header accordingly.
- Expanded the filename column, constrained the commit message with ellipsis to avoid wrapping, and adjusted action icon sizing/spacing so controls remain horizontal and space-efficient.
- Applied matching presentation/typography tweaks to the RepoBlast results table and ensured mobile breakpoints keep icons inline and readable.

### Testing
- Validated inline script syntax by extracting the `<script>` blocks and compiling them with `node` (`new Function(...)`) to ensure no JS syntax errors; this check passed.
- Confirmed both `repolist.html` and `repoblast.html` were updated to mirror the visual changes and that the template used by the deployment tool contains the revised markup (file updates applied).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e548d41e08832d956bbe205a41e0f2)