### PR TITLE
Tighten file-list 3-column UI behavior in repolist mirrors

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -150,8 +150,9 @@
       padding: 12px;
       text-align: left;
       user-select: none;
-      cursor: pointer;
+      cursor: default;
     }
+    [data-sort-key] { cursor: pointer; }
     [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #2563eb; }
 
     tbody td {
@@ -247,6 +248,7 @@
       color: #94a3b8;
       cursor: default;
       background: #f8fafc;
+      pointer-events: none;
     }
     .action-btn.delete {
       background: #fef2f2;
@@ -446,8 +448,7 @@
     }
 
     function shortFileName(path) {
-      const name = String(path || '').split('/').pop() || '';
-      return name.length > 20 ? \`\${name.slice(0, 20)}…\` : name;
+      return String(path || '').split('/').pop() || '';
     }
 
     function pathHint(path) {

--- a/repolist.html
+++ b/repolist.html
@@ -62,8 +62,9 @@
       padding: 12px;
       text-align: left;
       user-select: none;
-      cursor: pointer;
+      cursor: default;
     }
+    [data-sort-key] { cursor: pointer; }
     [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #2563eb; }
 
     tbody td {
@@ -159,6 +160,7 @@
       color: #94a3b8;
       cursor: default;
       background: #f8fafc;
+      pointer-events: none;
     }
     .action-btn.delete {
       background: #fef2f2;
@@ -358,8 +360,7 @@
     }
 
     function shortFileName(path) {
-      const name = String(path || '').split('/').pop() || '';
-      return name.length > 20 ? `${name.slice(0, 20)}…` : name;
+      return String(path || '').split('/').pop() || '';
     }
 
     function pathHint(path) {


### PR DESCRIPTION
### Motivation
- Clarify the 3-column `File` / `Details` / `Actions` UI by removing misleading clickable affordances on the header and making non-launchable action placeholders non-interactive while ensuring filenames render as the true basename.

### Description
- In both `repolist.html` and the mirrored template in `repoblast.html` changed table header cursor behavior to `cursor: default` and added `[data-sort-key] { cursor: pointer; }` so only actual sortable controls appear clickable.
- Made `.action-btn.ghost` non-interactive by adding `pointer-events: none` so placeholder Pages buttons keep visual parity but do not receive clicks, preserving consistent action-group hit areas.
- Simplified `shortFileName()` in both files to return the full basename (no JS truncation) and rely on existing CSS truncation for presentation.
- Scope limited to the `Repo File List` sections in `repolist.html` and the mirrored section in `repoblast.html` with minimal edits to avoid broad rewrites and preserve existing functionality.

### Testing
- Ran `rg -n "Repo File List|sort|File|Details|Actions|fmtAgo|shortCommit" repolist.html repoblast.html` to verify presence of relevant symbols and succeeded.
- Verified the produced diff with `git diff -- repolist.html repoblast.html` and inspected relevant line ranges with `nl -ba ... | sed -n` to confirm only intended changes were made, all checks passed.
- Committed the changes with `git add repolist.html repoblast.html && git commit -m "Tighten file-list 3-column UI behavior in repolist mirrors"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cf167290832d800969c61b222b50)