### PR TITLE
Update file-table truncation/recycle behavior and deploy repo-list UX

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -16,7 +16,10 @@
     input, button { width: 100%; box-sizing: border-box; border-radius: 10px; border: 1px solid #46558d; background: #111a39; color: #e8ecff; padding: 10px 12px; }
     button { background: #5e7cff; border: 0; cursor: pointer; margin-top: 10px; font-weight: 700; }
     #repos { max-height: 300px; overflow: auto; border: 1px solid #2d3a66; border-radius: 10px; padding: 8px; }
-    .repo-item { display: flex; gap: 8px; align-items: center; padding: 4px 2px; }
+    .repo-list-controls { margin: 8px 0; display: flex; justify-content: flex-start; }
+    .repo-list-controls button { width: auto; margin-top: 0; padding: 6px 10px; font-size: 0.82rem; }
+    .repo-item { display: flex; gap: 8px; align-items: center; justify-content: flex-start; padding: 4px 2px; text-align: left; }
+    .repo-item label { margin: 0; }
     table { width: 100%; border-collapse: collapse; margin-top: 10px; }
     th, td { text-align: left; padding: 7px 8px; border-bottom: 1px solid #2f3c68; font-size: 0.83rem; line-height: 1.2; }
     th { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: #c4d0ff; }
@@ -39,7 +42,7 @@
         <label for="token">GitHub Token (required for writes)</label>
         <input id="token" type="password" placeholder="ghp_...">
 
-        <button id="loadRepos">Load Repositories</button>
+        <div class="repo-list-controls"><button id="checkAllRepos" type="button">Check All</button></div>
         <div id="repos"></div>
         <button id="deploy">Deploy to Selected Repos</button>
       </section>
@@ -175,6 +178,8 @@
     .desc-cell { min-width: 300px; width: 48%; }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
+    .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
       display: inline-block;
       font-weight: 600;
@@ -183,7 +188,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 20ch;
+      max-width: 40ch;
       vertical-align: middle;
     }
     .file-external {
@@ -347,6 +352,7 @@
     <section id="recycle" class="recycle" style="display:none;">
       <div id="recycleHeader" class="recycle-header"><span id="recycleChev" class="chev">▸</span><span id="recycleLabel">Recently Deleted (0)</span></div>
       <div id="recycleList" class="recycle-list"></div>
+      <div style="padding: 0 10px 10px;"><button id="deleteAllDeletedBtn" class="mini danger" type="button" style="display:none;">Delete All</button></div>
     </section>
 
     <section class="card">
@@ -435,19 +441,19 @@
     function shortCommitMessage(message) {
       const line = String(message || '').split('\n')[0].trim();
       if (!line) return '—';
-      return line.length > 120 ? \`\${line.slice(0, 120)}…\` : line;
+      return line.length > 131 ? \`\${line.slice(0, 131)}…\` : line;
     }
 
     function shortFileName(path) {
       const full = String(path || '');
-      return full.length > 20 ? \`\${full.slice(0, 20)}…\` : full;
+      return full.length > 40 ? \`\${full.slice(0, 40)}…\` : full;
     }
 
     function commitWrappedPreview(message) {
       const text = shortCommitMessage(message || '');
       if (!text || text === '—') return '—';
       const parts = [];
-      for (let i = 0; i < text.length; i += 36) parts.push(text.slice(i, i + 36));
+      for (let i = 0; i < text.length; i += 130) parts.push(text.slice(i, i + 130));
       if (parts.join('').length < text.length) parts.push('…');
       return parts.join('\n');
     }
@@ -600,11 +606,14 @@
     function renderRecycleBin() {
       const wrap = document.getElementById('recycle');
       const list = loadDeleted();
+      const deleteAllBtn = document.getElementById('deleteAllDeletedBtn');
       if (!list.length) {
         wrap.style.display = 'none';
+        deleteAllBtn.style.display = 'none';
         return;
       }
       wrap.style.display = 'block';
+      deleteAllBtn.style.display = 'inline-flex';
       document.getElementById('recycleLabel').textContent = \`Recently Deleted (\${list.length})\`;
       document.getElementById('recycleChev').textContent = state.recycleOpen ? '▾' : '▸';
       wrap.classList.toggle('open', state.recycleOpen);
@@ -664,11 +673,12 @@
       if (!files.length) return;
       const q = (v) => \`"\${String(v ?? '').replace(/"/g, '""')}"\`;
       const rows = ['filename,pages_url,blob_url,description,size,updated_when,updated_iso'];
+      const asLink = (v) => \`=HYPERLINK(\"\${String(v ?? '').replace(/\"/g, '\"\"')}\",\"\${String(v ?? '').replace(/\"/g, '\"\"')}\")\`;
       for (const f of files) {
         rows.push([
           q(f.path),
-          q(f.pagesUrl || ''),
-          q(f.ghListingUrl || ''),
+          q(asLink(f.pagesUrl || '')),
+          q(asLink(f.ghListingUrl || '')),
           q(f.commitMessage || ''),
           q(f.size),
           q(fmtAgo(f.changed)),
@@ -870,6 +880,16 @@
       state.recycleOpen = !state.recycleOpen;
       renderRecycleBin();
     });
+    document.getElementById('deleteAllDeletedBtn').addEventListener('click', () => {
+      const list = loadDeleted();
+      if (!list.length) return;
+      if (!window.confirm(\`Delete all \${list.length} recently deleted entries forever? This cannot be undone.\`)) return;
+      const purged = loadPurgedSet();
+      for (const item of list) purged.add(item.path);
+      savePurgedSet(purged);
+      saveDeleted([]);
+      render();
+    });
 
     document.querySelectorAll('[data-sort-key]').forEach((el) => {
       el.addEventListener('click', () => {
@@ -1006,7 +1026,21 @@
     tokenEl.addEventListener('input', persistDeployAuth);
     ownerEl.addEventListener('blur', persistDeployAuth);
     tokenEl.addEventListener('blur', persistDeployAuth);
-    document.getElementById('loadRepos').addEventListener('click', loadRepos);
+    document.getElementById('checkAllRepos').addEventListener('click', () => {
+      const boxes = Array.from(document.querySelectorAll('#repos input[type="checkbox"]'));
+      if (!boxes.length) return;
+      const shouldCheck = boxes.some((box) => !box.checked);
+      boxes.forEach((box) => { box.checked = shouldCheck; });
+    });
+    let loadReposTimer = null;
+    function scheduleLoadRepos() {
+      clearTimeout(loadReposTimer);
+      loadReposTimer = setTimeout(() => { loadRepos(); }, 350);
+    }
+    ownerEl.addEventListener('input', scheduleLoadRepos);
+    tokenEl.addEventListener('input', scheduleLoadRepos);
+    ownerEl.addEventListener('change', scheduleLoadRepos);
+    tokenEl.addEventListener('change', scheduleLoadRepos);
     document.getElementById('deploy').addEventListener('click', deploySelected);
     if (ownerEl.value && tokenEl.value) loadRepos();
   </script>

--- a/repolist.html
+++ b/repolist.html
@@ -87,6 +87,8 @@
     .desc-cell { min-width: 300px; width: 48%; }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
+    .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
       display: inline-block;
       font-weight: 600;
@@ -95,7 +97,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 20ch;
+      max-width: 40ch;
       vertical-align: middle;
     }
     .file-external {
@@ -259,6 +261,7 @@
     <section id="recycle" class="recycle" style="display:none;">
       <div id="recycleHeader" class="recycle-header"><span id="recycleChev" class="chev">▸</span><span id="recycleLabel">Recently Deleted (0)</span></div>
       <div id="recycleList" class="recycle-list"></div>
+      <div style="padding: 0 10px 10px;"><button id="deleteAllDeletedBtn" class="mini danger" type="button" style="display:none;">Delete All</button></div>
     </section>
 
     <section class="card">
@@ -347,19 +350,19 @@
     function shortCommitMessage(message) {
       const line = String(message || '').split('\n')[0].trim();
       if (!line) return '—';
-      return line.length > 120 ? `${line.slice(0, 120)}…` : line;
+      return line.length > 131 ? `${line.slice(0, 131)}…` : line;
     }
 
     function shortFileName(path) {
       const full = String(path || '');
-      return full.length > 20 ? `${full.slice(0, 20)}…` : full;
+      return full.length > 40 ? `${full.slice(0, 40)}…` : full;
     }
 
     function commitWrappedPreview(message) {
       const text = shortCommitMessage(message || '');
       if (!text || text === '—') return '—';
       const parts = [];
-      for (let i = 0; i < text.length; i += 36) parts.push(text.slice(i, i + 36));
+      for (let i = 0; i < text.length; i += 130) parts.push(text.slice(i, i + 130));
       if (parts.join('').length < text.length) parts.push('…');
       return parts.join('\n');
     }
@@ -523,11 +526,14 @@
     function renderRecycleBin() {
       const wrap = document.getElementById('recycle');
       const list = loadDeleted();
+      const deleteAllBtn = document.getElementById('deleteAllDeletedBtn');
       if (!list.length) {
         wrap.style.display = 'none';
+        deleteAllBtn.style.display = 'none';
         return;
       }
       wrap.style.display = 'block';
+      deleteAllBtn.style.display = 'inline-flex';
       document.getElementById('recycleLabel').textContent = `Recently Deleted (${list.length})`;
       document.getElementById('recycleChev').textContent = state.recycleOpen ? '▾' : '▸';
       wrap.classList.toggle('open', state.recycleOpen);
@@ -587,11 +593,12 @@
       if (!files.length) return;
       const q = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`;
       const rows = ['filename,pages_url,blob_url,description,size,updated_when,updated_iso'];
+      const asLink = (v) => `=HYPERLINK("${String(v ?? '').replace(/"/g, '""')}","${String(v ?? '').replace(/"/g, '""')}")`;
       for (const f of files) {
         rows.push([
           q(f.path),
-          q(f.pagesUrl || ''),
-          q(f.ghListingUrl || ''),
+          q(asLink(f.pagesUrl || '')),
+          q(asLink(f.ghListingUrl || '')),
           q(f.commitMessage || ''),
           q(f.size),
           q(fmtAgo(f.changed)),
@@ -794,6 +801,16 @@
     document.getElementById('recycleHeader').addEventListener('click', () => {
       state.recycleOpen = !state.recycleOpen;
       renderRecycleBin();
+    });
+    document.getElementById('deleteAllDeletedBtn').addEventListener('click', () => {
+      const list = loadDeleted();
+      if (!list.length) return;
+      if (!window.confirm(`Delete all ${list.length} recently deleted entries forever? This cannot be undone.`)) return;
+      const purged = loadPurgedSet();
+      for (const item of list) purged.add(item.path);
+      savePurgedSet(purged);
+      saveDeleted([]);
+      render();
     });
 
     document.querySelectorAll('[data-sort-key]').forEach((el) => {


### PR DESCRIPTION
### Motivation
- Improve file-list readability by showing longer filenames and commit previews and tighten visual width for size/changed columns to reduce wasted space.
- Add a bulk cleanup affordance for Recently Deleted while preserving existing per-item restore/purge behavior.
- Make CSV exports produce clickable links in spreadsheets for `pages_url` and `blob_url`.
- Simplify and improve RepoBlast deploy-panel UX by left-justifying repo rows, adding a check-all control, and auto-loading repositories from owner/token input.

### Description
- Modified `shortFileName` to increase filename truncation from 20 to 40 characters and updated `.file-primary` `max-width` to `40ch` in CSS.
- Modified `shortCommitMessage` to increase preview max length from `120` to `131` characters and updated `commitWrappedPreview` to wrap lines at `130` characters.
- Tightened Size and Changed column visual width by adding `.size-cell` and `.changed-cell` explicit `width`/`min-width` and reduced padding.
- Added a `Delete All` button under the Recently Deleted area and wired it to prompt confirmation and then permanently purge all entries using the existing `loadPurgedSet`/`savePurgedSet` and `saveDeleted([])` flow; preserved single-item `Restore` and `Delete Forever` behavior.
- Updated CSV export to generate `HYPERLINK(...)` formulas for `pages_url` and `blob_url` so links open when opened in Excel/Sheets (`asLink` helper used when emitting CSV rows).
- Mirrored all file-table changes inside the `templateRepoList()` string in `repoblast.html` so deployed templates match the app behavior.
- Updated `repoblast.html` deploy panel: added `.repo-list-controls` and a `Check All` button with toggle behavior, left-justified `.repo-item` layout, removed the visible manual `Load Repositories` button and wired automatic loading via `scheduleLoadRepos()` on `owner`/`token` input/change; kept `deploy` wiring unchanged.
- Scope limited strictly to `repolist.html` and `repoblast.html` (the mirrored template and deploy-panel section) with no other refactors or new files.

### Testing
- Ran `git diff --check` on modified files and resolved issues; check passed.
- Ran targeted search checks with `rg` for the new/updated patterns (truncation, wrap threshold, column classes, `deleteAllDeletedBtn`, `asLink`, `checkAllRepos`) and verified the changes are present.
- Committed the changes successfully (`git commit` completed with the intended message).
- Note: no browser/UI screenshot automation was run in this environment; all verification was via static code checks and local commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dba56520832dab8f2cad72effc1d)