### PR TITLE
Improve file-list UI/UX: open column, CSV links, delete-all, check-all, and layout refinements

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -16,7 +16,10 @@
     input, button { width: 100%; box-sizing: border-box; border-radius: 10px; border: 1px solid #46558d; background: #111a39; color: #e8ecff; padding: 10px 12px; }
     button { background: #5e7cff; border: 0; cursor: pointer; margin-top: 10px; font-weight: 700; }
     #repos { max-height: 300px; overflow: auto; border: 1px solid #2d3a66; border-radius: 10px; padding: 8px; }
-    .repo-item { display: flex; gap: 8px; align-items: center; padding: 4px 2px; }
+    .repo-list-controls { margin: 8px 0; display: flex; justify-content: flex-start; }
+    .repo-list-controls button { width: auto; margin-top: 0; padding: 6px 10px; font-size: 0.82rem; }
+    .repo-item { display: flex; gap: 8px; align-items: center; justify-content: flex-start; padding: 4px 2px; text-align: left; }
+    .repo-item label { margin: 0; }
     table { width: 100%; border-collapse: collapse; margin-top: 10px; }
     th, td { text-align: left; padding: 7px 8px; border-bottom: 1px solid #2f3c68; font-size: 0.83rem; line-height: 1.2; }
     th { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: #c4d0ff; }
@@ -39,7 +42,7 @@
         <label for="token">GitHub Token (required for writes)</label>
         <input id="token" type="password" placeholder="ghp_...">
 
-        <button id="loadRepos">Load Repositories</button>
+        <div class="repo-list-controls"><button id="checkAllRepos" type="button">Check All</button></div>
         <div id="repos"></div>
         <button id="deploy">Deploy to Selected Repos</button>
       </section>
@@ -155,7 +158,7 @@
       cursor: default;
     }
     [data-sort-key] { cursor: pointer; }
-    [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #2563eb; }
+    [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #64748b; }
 
     tbody td {
       border-bottom: 1px solid #e3e8f3;
@@ -171,10 +174,12 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 140px; max-width: 140px; min-width: 120px; }
+    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
     .desc-cell { min-width: 300px; width: 48%; }
-    .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
-    .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .open-cell, .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
+    .open-cell, .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
+    .changed-cell { width: 6ch; min-width: 6ch; padding: 7px 2px; }
     .file-primary {
       display: inline-block;
       font-weight: 600;
@@ -183,25 +188,24 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 20ch;
+      max-width: 55ch;
       vertical-align: middle;
     }
     .file-external {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 15px;
-      height: 15px;
-      margin-left: 4px;
+      width: 22px;
+      height: 22px;
       border: 1px solid #cbd5e1;
-      border-radius: 3px;
-      color: #475569;
-      font-size: 0.64rem;
+      border-radius: 6px;
+      color: #64748b;
+      background: #f8fafc;
       line-height: 1;
       text-decoration: none;
       vertical-align: middle;
     }
-    .file-external:hover { background: #f8fafc; text-decoration: none; }
+    .file-external:hover { background: #e2e8f0; text-decoration: none; }
     .commit-msg {
       font-size: 0.76rem;
       color: #475569;
@@ -238,11 +242,11 @@
       pointer-events: none;
     }
     .action-btn.delete {
-      background: #fef2f2;
-      color: #b91c1c;
-      border-color: #fecaca;
+      color: #64748b;
+      border-color: #cbd5e1;
+      background: #f8fafc;
     }
-    .action-btn.delete:hover { background: #fee2e2; }
+    .action-btn.delete:hover { background: #e2e8f0; }
 
     .recycle {
       margin: 12px 0;
@@ -290,6 +294,17 @@
       cursor: pointer;
     }
     .mini:hover { background: #edf3ff; }
+    .sort-chip {
+      border-color: #cbd5e1;
+      background: #f8fafc;
+      color: #64748b;
+    }
+    .sort-chip:hover { background: #e2e8f0; }
+    [data-sort-key][data-active="true"].sort-chip {
+      background: #e2e8f0;
+      border-color: #cbd5e1;
+      color: #475569;
+    }
     .mini.danger {
       border-color: #fecaca;
       background: #fef2f2;
@@ -347,6 +362,7 @@
     <section id="recycle" class="recycle" style="display:none;">
       <div id="recycleHeader" class="recycle-header"><span id="recycleChev" class="chev">▸</span><span id="recycleLabel">Recently Deleted (0)</span></div>
       <div id="recycleList" class="recycle-list"></div>
+      <div style="padding: 0 10px 10px;"><button id="deleteAllDeletedBtn" class="mini danger" type="button" style="display:none;">Delete All</button></div>
     </section>
 
     <section class="card">
@@ -354,12 +370,13 @@
       <table>
         <thead>
           <tr>
-            <th><button class="mini" type="button" data-sort-key="name">Filename</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="name">Filename</button></th>
+            <th>Open</th>
             <th>Delete</th>
             <th>Edit</th>
-            <th><button class="mini" type="button" data-sort-key="commitMessage">Description</button></th>
-            <th><button class="mini" type="button" data-sort-key="size">Size</button></th>
-            <th><button class="mini" type="button" data-sort-key="changed">Changed</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="commitMessage">Description</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="size">Size</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="changed">Changed</button></th>
           </tr>
         </thead>
         <tbody id="rows"></tbody>
@@ -435,19 +452,19 @@
     function shortCommitMessage(message) {
       const line = String(message || '').split('\n')[0].trim();
       if (!line) return '—';
-      return line.length > 120 ? \`\${line.slice(0, 120)}…\` : line;
+      return line.length > 131 ? \`\${line.slice(0, 131)}…\` : line;
     }
 
     function shortFileName(path) {
       const full = String(path || '');
-      return full.length > 20 ? \`\${full.slice(0, 20)}…\` : full;
+      return full.length > 55 ? \`\${full.slice(0, 55)}…\` : full;
     }
 
     function commitWrappedPreview(message) {
       const text = shortCommitMessage(message || '');
       if (!text || text === '—') return '—';
       const parts = [];
-      for (let i = 0; i < text.length; i += 36) parts.push(text.slice(i, i + 36));
+      for (let i = 0; i < text.length; i += 130) parts.push(text.slice(i, i + 130));
       if (parts.join('').length < text.length) parts.push('…');
       return parts.join('\n');
     }
@@ -600,11 +617,14 @@
     function renderRecycleBin() {
       const wrap = document.getElementById('recycle');
       const list = loadDeleted();
+      const deleteAllBtn = document.getElementById('deleteAllDeletedBtn');
       if (!list.length) {
         wrap.style.display = 'none';
+        deleteAllBtn.style.display = 'none';
         return;
       }
       wrap.style.display = 'block';
+      deleteAllBtn.style.display = 'inline-flex';
       document.getElementById('recycleLabel').textContent = \`Recently Deleted (\${list.length})\`;
       document.getElementById('recycleChev').textContent = state.recycleOpen ? '▾' : '▸';
       wrap.classList.toggle('open', state.recycleOpen);
@@ -625,20 +645,22 @@
       const tbody = document.getElementById('rows');
       const files = sortedFiles();
       if (!files.length) {
-        tbody.innerHTML = '<tr><td colspan="6" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
       } else {
         tbody.innerHTML = files.map((f) => {
           const canLaunch = /\.html?$/i.test(f.path);
           return \`<tr>
             <td class="mono name-cell" title="\${esc(f.path)}">
               \${canLaunch ? \`<a class="file-primary" href="\${esc(f.pagesUrl)}" target="_blank" rel="noopener" title="\${esc(f.path)}">\${esc(shortFileName(f.path))}</a>\` : \`<span class="file-primary" title="\${esc(f.path)}">\${esc(shortFileName(f.path))}</span>\`}
-              <a class="file-external" href="\${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for \${esc(f.path)}">↗</a>
+            </td>
+            <td class="open-cell">
+              <a class="file-external" href="\${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for \${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path fill="currentColor" d="M5 5h6v2H7v10h10v-4h2v6H5z"></path></svg></a>
             </td>
             <td class="delete-cell">
-              <button class="action-btn delete" type="button" data-delete="\${esc(f.path)}" aria-label="Delete \${esc(f.path)}">×</button>
+              <button class="action-btn delete" type="button" data-delete="\${esc(f.path)}" aria-label="Delete \${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M9 3h6l1 2h4v2H4V5h4l1-2zm1 6h2v9h-2V9zm4 0h2v9h-2V9zM7 9h2v9H7V9z"></path></svg></button>
             </td>
             <td class="edit-cell">
-              <button class="action-btn" type="button" data-edit="\${esc(f.path)}" aria-label="Edit \${esc(f.path)}">✎</button>
+              <button class="action-btn" type="button" data-edit="\${esc(f.path)}" aria-label="Edit \${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M3 17.25V21h3.75L17.8 9.94l-3.75-3.75L3 17.25zm18-11.5a1 1 0 0 0 0-1.41l-1.34-1.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75L21 5.75z"></path></svg></button>
             </td>
             <td class="desc-cell" title="\${esc(f.commitMessage || '')}">
               <span class="commit-msg">\${esc(commitWrappedPreview(f.commitMessage || ''))}</span>
@@ -664,11 +686,12 @@
       if (!files.length) return;
       const q = (v) => \`"\${String(v ?? '').replace(/"/g, '""')}"\`;
       const rows = ['filename,pages_url,blob_url,description,size,updated_when,updated_iso'];
+      const asLink = (v) => \`=HYPERLINK(\"\${String(v ?? '').replace(/\"/g, '\"\"')}\",\"\${String(v ?? '').replace(/\"/g, '\"\"')}\")\`;
       for (const f of files) {
         rows.push([
           q(f.path),
-          q(f.pagesUrl || ''),
-          q(f.ghListingUrl || ''),
+          q(asLink(f.pagesUrl || '')),
+          q(asLink(f.ghListingUrl || '')),
           q(f.commitMessage || ''),
           q(f.size),
           q(fmtAgo(f.changed)),
@@ -870,6 +893,16 @@
       state.recycleOpen = !state.recycleOpen;
       renderRecycleBin();
     });
+    document.getElementById('deleteAllDeletedBtn').addEventListener('click', () => {
+      const list = loadDeleted();
+      if (!list.length) return;
+      if (!window.confirm(\`Delete all \${list.length} recently deleted entries forever? This cannot be undone.\`)) return;
+      const purged = loadPurgedSet();
+      for (const item of list) purged.add(item.path);
+      savePurgedSet(purged);
+      saveDeleted([]);
+      render();
+    });
 
     document.querySelectorAll('[data-sort-key]').forEach((el) => {
       el.addEventListener('click', () => {
@@ -1006,7 +1039,21 @@
     tokenEl.addEventListener('input', persistDeployAuth);
     ownerEl.addEventListener('blur', persistDeployAuth);
     tokenEl.addEventListener('blur', persistDeployAuth);
-    document.getElementById('loadRepos').addEventListener('click', loadRepos);
+    document.getElementById('checkAllRepos').addEventListener('click', () => {
+      const boxes = Array.from(document.querySelectorAll('#repos input[type="checkbox"]'));
+      if (!boxes.length) return;
+      const shouldCheck = boxes.some((box) => !box.checked);
+      boxes.forEach((box) => { box.checked = shouldCheck; });
+    });
+    let loadReposTimer = null;
+    function scheduleLoadRepos() {
+      clearTimeout(loadReposTimer);
+      loadReposTimer = setTimeout(() => { loadRepos(); }, 350);
+    }
+    ownerEl.addEventListener('input', scheduleLoadRepos);
+    tokenEl.addEventListener('input', scheduleLoadRepos);
+    ownerEl.addEventListener('change', scheduleLoadRepos);
+    tokenEl.addEventListener('change', scheduleLoadRepos);
     document.getElementById('deploy').addEventListener('click', deploySelected);
     if (ownerEl.value && tokenEl.value) loadRepos();
   </script>

--- a/repolist.html
+++ b/repolist.html
@@ -67,7 +67,7 @@
       cursor: default;
     }
     [data-sort-key] { cursor: pointer; }
-    [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #2563eb; }
+    [data-sort-key][data-active="true"]::after { content: attr(data-dir); margin-left: 6px; color: #64748b; }
 
     tbody td {
       border-bottom: 1px solid #e3e8f3;
@@ -83,10 +83,12 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 140px; max-width: 140px; min-width: 120px; }
+    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
     .desc-cell { min-width: 300px; width: 48%; }
-    .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
-    .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .open-cell, .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
+    .open-cell, .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
+    .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
+    .changed-cell { width: 6ch; min-width: 6ch; padding: 7px 2px; }
     .file-primary {
       display: inline-block;
       font-weight: 600;
@@ -95,25 +97,24 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 20ch;
+      max-width: 55ch;
       vertical-align: middle;
     }
     .file-external {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 15px;
-      height: 15px;
-      margin-left: 4px;
+      width: 22px;
+      height: 22px;
       border: 1px solid #cbd5e1;
-      border-radius: 3px;
-      color: #475569;
-      font-size: 0.64rem;
+      border-radius: 6px;
+      color: #64748b;
+      background: #f8fafc;
       line-height: 1;
       text-decoration: none;
       vertical-align: middle;
     }
-    .file-external:hover { background: #f8fafc; text-decoration: none; }
+    .file-external:hover { background: #e2e8f0; text-decoration: none; }
     .commit-msg {
       font-size: 0.76rem;
       color: #475569;
@@ -150,11 +151,11 @@
       pointer-events: none;
     }
     .action-btn.delete {
-      background: #fef2f2;
-      color: #b91c1c;
-      border-color: #fecaca;
+      color: #64748b;
+      border-color: #cbd5e1;
+      background: #f8fafc;
     }
-    .action-btn.delete:hover { background: #fee2e2; }
+    .action-btn.delete:hover { background: #e2e8f0; }
 
     .recycle {
       margin: 12px 0;
@@ -202,6 +203,17 @@
       cursor: pointer;
     }
     .mini:hover { background: #edf3ff; }
+    .sort-chip {
+      border-color: #cbd5e1;
+      background: #f8fafc;
+      color: #64748b;
+    }
+    .sort-chip:hover { background: #e2e8f0; }
+    [data-sort-key][data-active="true"].sort-chip {
+      background: #e2e8f0;
+      border-color: #cbd5e1;
+      color: #475569;
+    }
     .mini.danger {
       border-color: #fecaca;
       background: #fef2f2;
@@ -259,6 +271,7 @@
     <section id="recycle" class="recycle" style="display:none;">
       <div id="recycleHeader" class="recycle-header"><span id="recycleChev" class="chev">▸</span><span id="recycleLabel">Recently Deleted (0)</span></div>
       <div id="recycleList" class="recycle-list"></div>
+      <div style="padding: 0 10px 10px;"><button id="deleteAllDeletedBtn" class="mini danger" type="button" style="display:none;">Delete All</button></div>
     </section>
 
     <section class="card">
@@ -266,12 +279,13 @@
       <table>
         <thead>
           <tr>
-            <th><button class="mini" type="button" data-sort-key="name">Filename</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="name">Filename</button></th>
+            <th>Open</th>
             <th>Delete</th>
             <th>Edit</th>
-            <th><button class="mini" type="button" data-sort-key="commitMessage">Description</button></th>
-            <th><button class="mini" type="button" data-sort-key="size">Size</button></th>
-            <th><button class="mini" type="button" data-sort-key="changed">Changed</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="commitMessage">Description</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="size">Size</button></th>
+            <th><button class="mini sort-chip" type="button" data-sort-key="changed">Changed</button></th>
           </tr>
         </thead>
         <tbody id="rows"></tbody>
@@ -347,19 +361,19 @@
     function shortCommitMessage(message) {
       const line = String(message || '').split('\n')[0].trim();
       if (!line) return '—';
-      return line.length > 120 ? `${line.slice(0, 120)}…` : line;
+      return line.length > 131 ? `${line.slice(0, 131)}…` : line;
     }
 
     function shortFileName(path) {
       const full = String(path || '');
-      return full.length > 20 ? `${full.slice(0, 20)}…` : full;
+      return full.length > 55 ? `${full.slice(0, 55)}…` : full;
     }
 
     function commitWrappedPreview(message) {
       const text = shortCommitMessage(message || '');
       if (!text || text === '—') return '—';
       const parts = [];
-      for (let i = 0; i < text.length; i += 36) parts.push(text.slice(i, i + 36));
+      for (let i = 0; i < text.length; i += 130) parts.push(text.slice(i, i + 130));
       if (parts.join('').length < text.length) parts.push('…');
       return parts.join('\n');
     }
@@ -523,11 +537,14 @@
     function renderRecycleBin() {
       const wrap = document.getElementById('recycle');
       const list = loadDeleted();
+      const deleteAllBtn = document.getElementById('deleteAllDeletedBtn');
       if (!list.length) {
         wrap.style.display = 'none';
+        deleteAllBtn.style.display = 'none';
         return;
       }
       wrap.style.display = 'block';
+      deleteAllBtn.style.display = 'inline-flex';
       document.getElementById('recycleLabel').textContent = `Recently Deleted (${list.length})`;
       document.getElementById('recycleChev').textContent = state.recycleOpen ? '▾' : '▸';
       wrap.classList.toggle('open', state.recycleOpen);
@@ -548,20 +565,22 @@
       const tbody = document.getElementById('rows');
       const files = sortedFiles();
       if (!files.length) {
-        tbody.innerHTML = '<tr><td colspan="6" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7" class="empty">No visible files. Restore files from Recently Deleted if needed.</td></tr>';
       } else {
         tbody.innerHTML = files.map((f) => {
           const canLaunch = /\.html?$/i.test(f.path);
           return `<tr>
             <td class="mono name-cell" title="${esc(f.path)}">
               ${canLaunch ? `<a class="file-primary" href="${esc(f.pagesUrl)}" target="_blank" rel="noopener" title="${esc(f.path)}">${esc(shortFileName(f.path))}</a>` : `<span class="file-primary" title="${esc(f.path)}">${esc(shortFileName(f.path))}</span>`}
-              <a class="file-external" href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for ${esc(f.path)}">↗</a>
+            </td>
+            <td class="open-cell">
+              <a class="file-external" href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path fill="currentColor" d="M5 5h6v2H7v10h10v-4h2v6H5z"></path></svg></a>
             </td>
             <td class="delete-cell">
-              <button class="action-btn delete" type="button" data-delete="${esc(f.path)}" aria-label="Delete ${esc(f.path)}">×</button>
+              <button class="action-btn delete" type="button" data-delete="${esc(f.path)}" aria-label="Delete ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M9 3h6l1 2h4v2H4V5h4l1-2zm1 6h2v9h-2V9zm4 0h2v9h-2V9zM7 9h2v9H7V9z"></path></svg></button>
             </td>
             <td class="edit-cell">
-              <button class="action-btn" type="button" data-edit="${esc(f.path)}" aria-label="Edit ${esc(f.path)}">✎</button>
+              <button class="action-btn" type="button" data-edit="${esc(f.path)}" aria-label="Edit ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M3 17.25V21h3.75L17.8 9.94l-3.75-3.75L3 17.25zm18-11.5a1 1 0 0 0 0-1.41l-1.34-1.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75L21 5.75z"></path></svg></button>
             </td>
             <td class="desc-cell" title="${esc(f.commitMessage || '')}">
               <span class="commit-msg">${esc(commitWrappedPreview(f.commitMessage || ''))}</span>
@@ -587,11 +606,12 @@
       if (!files.length) return;
       const q = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`;
       const rows = ['filename,pages_url,blob_url,description,size,updated_when,updated_iso'];
+      const asLink = (v) => `=HYPERLINK("${String(v ?? '').replace(/"/g, '""')}","${String(v ?? '').replace(/"/g, '""')}")`;
       for (const f of files) {
         rows.push([
           q(f.path),
-          q(f.pagesUrl || ''),
-          q(f.ghListingUrl || ''),
+          q(asLink(f.pagesUrl || '')),
+          q(asLink(f.ghListingUrl || '')),
           q(f.commitMessage || ''),
           q(f.size),
           q(fmtAgo(f.changed)),
@@ -794,6 +814,16 @@
     document.getElementById('recycleHeader').addEventListener('click', () => {
       state.recycleOpen = !state.recycleOpen;
       renderRecycleBin();
+    });
+    document.getElementById('deleteAllDeletedBtn').addEventListener('click', () => {
+      const list = loadDeleted();
+      if (!list.length) return;
+      if (!window.confirm(`Delete all ${list.length} recently deleted entries forever? This cannot be undone.`)) return;
+      const purged = loadPurgedSet();
+      for (const item of list) purged.add(item.path);
+      savePurgedSet(purged);
+      saveDeleted([]);
+      render();
     });
 
     document.querySelectorAll('[data-sort-key]').forEach((el) => {


### PR DESCRIPTION
### Motivation

- Make the repository file listing and the deploy tool easier to scan and operate by exposing an explicit "Open" column, compact action icons, and bulk controls.
- Improve readability of long filenames and commit messages and make CSV exports more useful by encoding URLs as spreadsheet hyperlinks.

### Description

- Added an explicit `Open` column with an inline SVG link to the GitHub blob for each file and adjusted table layout and cell widths to accommodate it.
- Replaced textual action glyphs with compact SVG icons and refined action button styles including `.action-btn.delete` and `.file-external` visual updates.
- Increased truncation thresholds for filenames and commit messages (`shortFileName`, `shortCommitMessage`, and `commitWrappedPreview`) and adjusted wrapping chunk sizes and `max-width` for `.file-primary` to surface more content.
- Introduced `sort-chip` styling for sort buttons and changed the active sort indicator color for consistency with the updated palette.
- CSV export now wraps `pagesUrl` and `ghListingUrl` values with an `=HYPERLINK(...)` formula so links are clickable in spreadsheets (`exportCsv` change).
- Added a `Delete All` control for the Recently Deleted section and a handler that purges all recently deleted entries permanently (`deleteAllDeletedBtn`).
- In the deploy UI (`repoblast.html`) added a `Check All` control to toggle repository checkboxes and a scheduled auto `loadRepos` trigger when owner/token inputs change to reduce manual clicks.
- Adjusted various CSS sizing, paddings and hover states across `repoblast.html` and `repolist.html` to improve spacing and touch targets, and updated `colspan` counts for the empty-state rows.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dba56520832dab8f2cad72effc1d)