### PR TITLE
Tighten open-icon column spacing and improve filename truncation

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -174,21 +174,35 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
+    .name-cell {
+      width: 240px;
+      max-width: 240px;
+      min-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .open-cell {
+      width: 30px;
+      min-width: 30px;
+      max-width: 30px;
+      text-align: center;
+      padding: 5px 0;
+      white-space: nowrap;
+    }
     .desc-cell { min-width: 300px; width: 48%; }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
     .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
     .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
-      display: inline-block;
+      display: block;
       font-weight: 600;
       color: #0f172a;
       line-height: 1.2;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 40ch;
+      max-width: 100%;
       vertical-align: middle;
     }
     .file-external {
@@ -341,7 +355,8 @@
       .controls { grid-template-columns: 1fr; }
       .status-row { flex-wrap: wrap; }
       th, td { padding: 6px 6px; }
-      .name-cell { min-width: 110px; width: 120px; }
+      .name-cell { min-width: 110px; width: 160px; max-width: 160px; }
+      .open-cell { width: 24px; min-width: 24px; max-width: 24px; padding: 5px 0; }
       .desc-cell { min-width: 220px; width: auto; }
       .action-btn { width: 20px; height: 20px; }
     }

--- a/repolist.html
+++ b/repolist.html
@@ -83,21 +83,35 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
+    .name-cell {
+      width: 240px;
+      max-width: 240px;
+      min-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .open-cell {
+      width: 30px;
+      min-width: 30px;
+      max-width: 30px;
+      text-align: center;
+      padding: 5px 0;
+      white-space: nowrap;
+    }
     .desc-cell { min-width: 300px; width: 48%; }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
     .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
     .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
-      display: inline-block;
+      display: block;
       font-weight: 600;
       color: #0f172a;
       line-height: 1.2;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 40ch;
+      max-width: 100%;
       vertical-align: middle;
     }
     .file-external {
@@ -250,7 +264,8 @@
       .controls { grid-template-columns: 1fr; }
       .status-row { flex-wrap: wrap; }
       th, td { padding: 6px 6px; }
-      .name-cell { min-width: 110px; width: 120px; }
+      .name-cell { min-width: 110px; width: 160px; max-width: 160px; }
+      .open-cell { width: 24px; min-width: 24px; max-width: 24px; padding: 5px 0; }
       .desc-cell { min-width: 220px; width: auto; }
       .action-btn { width: 20px; height: 20px; }
     }


### PR DESCRIPTION
### Motivation
- Free up horizontal space for the filename column by removing extra right-side padding around the open/link icon.  
- Ensure filenames truncate reliably to the visible column width with an ellipsis while keeping the full path discoverable on hover.  
- Keep the deployed `repoblast.html` template consistent with local `repolist.html` so behavior matches when pages are published.

### Description
- Added a constrained `.open-cell` (fixed narrow width, centered, small padding) to tighten spacing around the open/link icon.  
- Increased `.name-cell` width and made it overflow-hidden so the filename column can use the freed space.  
- Changed `.file-primary` to `display: block` with `max-width: 100%` to make text truncation (`text-overflow: ellipsis`) respect the actual column width.  
- Applied the same CSS/layout changes to both `repolist.html` and the embedded `templateRepoList()` in `repoblast.html`, and adjusted mobile breakpoints for the tighter layout.

### Testing
- Ran `git diff --check` to validate there are no whitespace/format issues and it passed.  
- Verified working tree changes with `git status --short` which listed the two modified files.  
- Created a commit via `git commit -m "Tighten open icon column and improve filename truncation"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eeee4224832dbed235349d31e391)