### PR TITLE
Adjust table column widths and text truncation in repo list and file list pages

### DIFF
--- a/repoblast.html
+++ b/repoblast.html
@@ -174,21 +174,39 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
-    .desc-cell { min-width: 300px; width: 48%; }
+    .name-cell {
+      width: 240px;
+      max-width: 240px;
+      min-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .open-cell {
+      width: 30px;
+      min-width: 30px;
+      max-width: 30px;
+      text-align: center;
+      padding: 5px 0;
+      white-space: nowrap;
+    }
+    .desc-cell {
+      min-width: 220px;
+      width: 34%;
+      max-width: 34%;
+    }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
     .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
     .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
-      display: inline-block;
+      display: block;
       font-weight: 600;
       color: #0f172a;
       line-height: 1.2;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 40ch;
+      max-width: 100%;
       vertical-align: middle;
     }
     .file-external {
@@ -207,10 +225,12 @@
     }
     .file-external:hover { background: #e2e8f0; text-decoration: none; }
     .commit-msg {
+      display: block;
       font-size: 0.76rem;
       color: #475569;
-      white-space: pre-line;
-      overflow-wrap: anywhere;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     a { color: #1d4ed8; text-decoration: none; font-weight: 600; }
     a:hover { text-decoration: underline; }
@@ -341,8 +361,9 @@
       .controls { grid-template-columns: 1fr; }
       .status-row { flex-wrap: wrap; }
       th, td { padding: 6px 6px; }
-      .name-cell { min-width: 110px; width: 120px; }
-      .desc-cell { min-width: 220px; width: auto; }
+      .name-cell { min-width: 110px; width: 160px; max-width: 160px; }
+      .open-cell { width: 24px; min-width: 24px; max-width: 24px; padding: 5px 0; }
+      .desc-cell { min-width: 180px; width: 42%; max-width: 42%; }
       .action-btn { width: 20px; height: 20px; }
     }
   </style>

--- a/repolist.html
+++ b/repolist.html
@@ -83,21 +83,39 @@
     tbody tr:hover td { background: #eef4ff; }
 
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; }
-    .name-cell { width: 180px; max-width: 180px; min-width: 150px; white-space: nowrap; }
-    .desc-cell { min-width: 300px; width: 48%; }
+    .name-cell {
+      width: 240px;
+      max-width: 240px;
+      min-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .open-cell {
+      width: 30px;
+      min-width: 30px;
+      max-width: 30px;
+      text-align: center;
+      padding: 5px 0;
+      white-space: nowrap;
+    }
+    .desc-cell {
+      min-width: 220px;
+      width: 34%;
+      max-width: 34%;
+    }
     .delete-cell, .edit-cell, .size-cell, .changed-cell { white-space: nowrap; }
     .delete-cell, .edit-cell { width: 38px; text-align: center; padding: 5px; }
     .size-cell { width: 6ch; min-width: 6ch; padding: 7px 4px; }
     .changed-cell { width: 8ch; min-width: 8ch; padding: 7px 4px; }
     .file-primary {
-      display: inline-block;
+      display: block;
       font-weight: 600;
       color: #0f172a;
       line-height: 1.2;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 40ch;
+      max-width: 100%;
       vertical-align: middle;
     }
     .file-external {
@@ -116,10 +134,12 @@
     }
     .file-external:hover { background: #e2e8f0; text-decoration: none; }
     .commit-msg {
+      display: block;
       font-size: 0.76rem;
       color: #475569;
-      white-space: pre-line;
-      overflow-wrap: anywhere;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     a { color: #1d4ed8; text-decoration: none; font-weight: 600; }
     a:hover { text-decoration: underline; }
@@ -250,8 +270,9 @@
       .controls { grid-template-columns: 1fr; }
       .status-row { flex-wrap: wrap; }
       th, td { padding: 6px 6px; }
-      .name-cell { min-width: 110px; width: 120px; }
-      .desc-cell { min-width: 220px; width: auto; }
+      .name-cell { min-width: 110px; width: 160px; max-width: 160px; }
+      .open-cell { width: 24px; min-width: 24px; max-width: 24px; padding: 5px 0; }
+      .desc-cell { min-width: 180px; width: 42%; max-width: 42%; }
       .action-btn { width: 20px; height: 20px; }
     }
   </style>


### PR DESCRIPTION
### Motivation
- Improve the table layout and truncation behavior in the repository and file list UIs to avoid overflow and long text wrapping. 
- Reserve a fixed column for an "open" icon/action to keep action columns aligned. 
- Make file names and commit messages behave more predictably across different viewport sizes.

### Description
- Updated `repoblast.html` and `repolist.html` CSS to expand `.name-cell` width and add overflow handling via `overflow: hidden` on ` .name-cell` to prevent layout breakage. 
- Added a new `.open-cell` class to reserve a fixed narrow column for open/action icons with defined `width`, `min-width`, and `text-align`. 
- Adjusted `.desc-cell` widths to be smaller (`min-width: 220px` / percentage widths) and added responsive rules for small screens. 
- Changed `.file-primary` and `.commit-msg` to `display: block` and applied `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to ensure truncation instead of wrapping, and increased `max-width` handling for consistency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eeee4224832dbed235349d31e391)