### PR TITLE
Prevent accidental drag while editing Kanban card fields

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -703,6 +703,17 @@ let suppressNextCardClick=false;
 function isInteractiveCardTarget(target){
   return !!target?.closest?.('a,button,input,textarea,select,label,[contenteditable="true"]');
 }
+function shieldInteractiveControl(el){
+  if(!el) return el;
+  ["pointerdown","pointerup","mousedown","mouseup","click"].forEach(ev=>{
+    el.addEventListener(ev, e=>e.stopPropagation());
+  });
+  el.addEventListener("dragstart", e=>{
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  return el;
+}
 function pointerFromCardStart(card, e){
   if(e.pointerType==="mouse") return;
   if(isInteractiveCardTarget(e.target)) return;
@@ -963,7 +974,10 @@ function renderCard(card){
   el.append(tagsRow);
 
   const detail=document.createElement("div"); detail.className="card-detail";
-  ["pointerdown","pointerup","mousedown","mouseup","dragstart"].forEach(ev=>detail.addEventListener(ev, e=>e.stopPropagation()));
+  ["pointerdown","pointerup","mousedown","mouseup","click","dragstart"].forEach(ev=>detail.addEventListener(ev, e=>{
+    if(ev==="dragstart") e.preventDefault();
+    e.stopPropagation();
+  }));
   if(isCollapsed) detail.classList.add("collapsed");
 
   const inlineState={
@@ -1070,22 +1084,27 @@ function renderCard(card){
   titleInput.value=inlineState.title;
   titleInput.placeholder="Card title";
   titleInput.addEventListener("input", ()=>{ inlineState.title=titleInput.value; });
+  shieldInteractiveControl(titleInput);
 
   const platformSelect=document.createElement("select");
   state.platforms.forEach(pl=>{ const opt=document.createElement("option"); opt.value=pl; opt.textContent=pl; if(pl===inlineState.platform) opt.selected=true; platformSelect.append(opt); });
   platformSelect.addEventListener("change", ()=>{ inlineState.platform=platformSelect.value; });
+  shieldInteractiveControl(platformSelect);
 
   const stageSelect=document.createElement("select");
   state.stages.forEach(st=>{ const opt=document.createElement("option"); opt.value=st; opt.textContent=st; if(st===inlineState.stage) opt.selected=true; stageSelect.append(opt); });
   stageSelect.addEventListener("change", ()=>{ inlineState.stage=stageSelect.value; });
+  shieldInteractiveControl(stageSelect);
 
   const devInput=document.createElement("input");
   devInput.type="url"; devInput.placeholder="https://dev…"; devInput.value=inlineState.dev;
   devInput.addEventListener("input", ()=>{ inlineState.dev=devInput.value; });
+  shieldInteractiveControl(devInput);
 
   const liveInput=document.createElement("input");
   liveInput.type="url"; liveInput.placeholder="https://live…"; liveInput.value=inlineState.live;
   liveInput.addEventListener("input", ()=>{ inlineState.live=liveInput.value; });
+  shieldInteractiveControl(liveInput);
 
   // NEW: inline tag editor replaces plain tagsInput
   const inlineTagEditor = buildInlineTagEditor(inlineState.tagArr);
@@ -1140,6 +1159,7 @@ function renderCard(card){
     e.stopPropagation();
   });
   notesWrap.append(notesInput, notesPreview);
+  shieldInteractiveControl(notesInput);
   showInlineNotesPreview();
 
   const attachmentsWrap=document.createElement("ul");


### PR DESCRIPTION
### Motivation
- Editing or selecting text inside card fields (notes, Dev/Live URLs, etc.) was triggering the board's drag-and-drop behavior, causing accidental drags and a poor editing experience.

### Description
- Added a reusable `shieldInteractiveControl(el)` helper in `kanban.html` to stop pointer/mouse/click events from bubbling and to block `dragstart` on interactive controls.
- Updated the card detail container event handling to explicitly `preventDefault` on `dragstart` and stop propagation for pointer/mouse/click events.
- Applied `shieldInteractiveControl` to inline card controls: `title` input, `platform` select, `stage` (lane) select, `dev` and `live` URL inputs, and the inline `notes` textarea.
- Changes are limited to `kanban.html` and only add event shielding to prevent edits from initiating card drags.

### Testing
- Ran `git diff --check` and it completed with no issues.
- No automated UI tests were available in this environment; changes were implemented as minimal, localized JavaScript edits and validated by static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6042c6dac832daa0ce6bcded41609)