### PR TITLE
Support multi-tag entry and separate suggestion behavior for new vs existing cards

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -1353,12 +1353,21 @@ function refillSelects(){ $("#fPlatform").innerHTML = state.platforms.map(p=>`<o
 
 /* ===== Tagging UI ===== */
 const tagInput=$("#tagInput"), tagChips=$("#tagChips"), tagSuggestions=$("#tagSuggestions"), hiddenTags=$("#fTags");
+function isNewCardEditor(){ return !editingId; }
+function parseTagsFromInput(value){
+  return String(value||"")
+    .split(",")
+    .map(s=>s.trim().toLowerCase())
+    .filter(Boolean);
+}
 function commitTagFromInput(){
-  const raw = tagInput.value.trim().toLowerCase();
-  if(!raw) return;
-  const selected = getFilteredTagSuggestions(raw).find(t=>!activeTags.includes(t));
-  const nextTag = selected || raw;
-  if(nextTag && !activeTags.includes(nextTag)) activeTags.push(nextTag);
+  const tagsToAdd=parseTagsFromInput(tagInput.value);
+  if(!tagsToAdd.length) return;
+  tagsToAdd.forEach(rawTag=>{
+    const selected = getFilteredTagSuggestions(rawTag).find(t=>!activeTags.includes(t));
+    const nextTag = selected || rawTag;
+    if(nextTag && !activeTags.includes(nextTag)) activeTags.push(nextTag);
+  });
   tagInput.value="";
   renderTagChips();
   renderTagSuggestions();
@@ -1378,16 +1387,25 @@ function renderTagChips(){
 function renderTagSuggestions(){
   tagSuggestions.innerHTML=""; if(!tagHistory.length) return;
   const query=tagInput.value.trim().toLowerCase();
-  const suggestions=getFilteredTagSuggestions(query);
+  const showAllForNewCard=isNewCardEditor();
+  const suggestions=showAllForNewCard ? getFilteredTagSuggestions("") : getFilteredTagSuggestions(query);
+  if(!showAllForNewCard && !query) return;
   const seen=new Set();
   suggestions.forEach(t=>{
     const k=t.toLowerCase(); if(seen.has(k)) return; seen.add(k);
     const el=document.createElement("span"); el.className="chip";
     const txt=document.createElement("span"); txt.textContent=t;
-    const rm=document.createElement("span"); rm.textContent="×"; rm.className="remove"; rm.title="delete tag from active cards";
-    el.append(txt,rm);
+    el.append(txt);
+    let rm=null;
+    if(showAllForNewCard){
+      rm=document.createElement("span");
+      rm.textContent="×";
+      rm.className="remove";
+      rm.title="delete tag from active cards";
+      el.append(rm);
+    }
     el.onclick=(e)=>{
-      if(e.target===rm){ removeTagFromActiveCards(t); return; }
+      if(rm && e.target===rm){ removeTagFromActiveCards(t); return; }
       if(!activeTags.includes(t)){ activeTags.push(t); renderTagChips(); }
     };
     tagSuggestions.appendChild(el);


### PR DESCRIPTION
### Motivation
- Improve tag assignment UX so new cards expose the full tag pool and allow maintenance while existing cards use a type-to-match workflow, and support assigning multiple tags at once via comma-separated entry.

### Description
- Added `isNewCardEditor()` helper and `parseTagsFromInput()` to parse comma-separated tags from the input.
- Updated `commitTagFromInput()` to accept and commit multiple tags in one action while preserving suggestion-based matching when available.
- Modified `renderTagSuggestions()` to show the full tag pool (including the delete `×` control) when editing a new card and to restrict suggestions to case-insensitive matches while typing for existing cards.
- Ensured selected suggestions still perform one-click assignment and that `#fTags` (hidden field) is kept in sync with active chips.

### Testing
- Parsed the embedded script in `kanban.html` with Node using `node -e "const fs=require('fs'); const s=fs.readFileSync('kanban.html','utf8'); new Function(s.match(/<script>([\\s\\S]*)<\\/script>/)[1]); console.log('script parse ok')"` which succeeded.
- Committed the change with `git commit` and verified `kanban.html` was the only modified file.
- No automated UI tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e611d5ce18832d8d0dea5ce8c2982d)