### PR TITLE
kanban: remove inline tag-suggestions and stabilize tag input matching

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -300,7 +300,6 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
       <div class="tag-input-row">
         <input id="tagInput" placeholder="type a tag, press Enter" />
       </div>
-      <div class="suggestions" id="tagSuggestions" aria-label="Previously used tags"></div>
       <input id="fTags" class="hidden" />
     </div>
 
@@ -521,8 +520,6 @@ function removeTagFromActiveCards(tag){
   if(changed){
     scheduleSave();
     render();
-  }else{
-    renderTagSuggestions();
   }
 }
 
@@ -1305,7 +1302,7 @@ function openEditor(id=null, presetStage=null){
   activeTags = c?.tags ? [...c.tags] : [];
   currentFiles = Array.isArray(c?.files) ? c.files.slice() : [];
   pendingFiles = [];
-  renderTagChips(); renderTagSuggestions();
+  renderTagChips();
   renderFileChips();
   $("#fFiles").value = ""; // reset file input
   editDialog.showModal(); $("#fTitle").focus();
@@ -1352,29 +1349,34 @@ function collectEditorData(){ return { platform:$("#fPlatform").value, stage:$("
 function refillSelects(){ $("#fPlatform").innerHTML = state.platforms.map(p=>`<option>${p}</option>`).join(""); $("#fStage").innerHTML = state.stages.map(s=>`<option>${s}</option>`).join(""); }
 
 /* ===== Tagging UI ===== */
-const tagInput=$("#tagInput"), tagChips=$("#tagChips"), tagSuggestions=$("#tagSuggestions"), hiddenTags=$("#fTags");
-function isNewCardEditor(){ return !editingId; }
+const tagInput=$("#tagInput"), tagChips=$("#tagChips"), hiddenTags=$("#fTags");
 function parseTagsFromInput(value){
   return String(value||"")
     .split(",")
     .map(s=>s.trim().toLowerCase())
     .filter(Boolean);
 }
+function resolveExistingTag(rawTag){
+  const q=String(rawTag||"").trim().toLowerCase();
+  if(!q) return "";
+  const exact=tagHistory.find(t=>t.toLowerCase()===q);
+  if(exact) return exact;
+  const startsWith=tagHistory.filter(t=>t.toLowerCase().startsWith(q));
+  if(startsWith.length===1) return startsWith[0];
+  return q;
+}
 function commitTagFromInput(){
   const tagsToAdd=parseTagsFromInput(tagInput.value);
   if(!tagsToAdd.length) return;
   tagsToAdd.forEach(rawTag=>{
-    const selected = getFilteredTagSuggestions(rawTag).find(t=>!activeTags.includes(t));
-    const nextTag = selected || rawTag;
+    const nextTag = resolveExistingTag(rawTag);
     if(nextTag && !activeTags.includes(nextTag)) activeTags.push(nextTag);
   });
   tagInput.value="";
   renderTagChips();
-  renderTagSuggestions();
 }
 tagInput.addEventListener("keydown", (e)=>{ if(e.key==="Enter" || e.key===","){ e.preventDefault(); commitTagFromInput(); } });
 tagInput.addEventListener("blur", ()=>{ commitTagFromInput(); });
-tagInput.addEventListener("input", ()=> renderTagSuggestions());
 function renderTagChips(){
   tagChips.innerHTML="";
   activeTags.forEach(t=>{
@@ -1383,37 +1385,6 @@ function renderTagChips(){
     tagChips.appendChild(el);
   });
   hiddenTags.value = activeTags.join(",");
-}
-function renderTagSuggestions(){
-  tagSuggestions.innerHTML=""; if(!tagHistory.length) return;
-  const query=tagInput.value.trim().toLowerCase();
-  const showAllForNewCard=isNewCardEditor();
-  const suggestions=showAllForNewCard ? getFilteredTagSuggestions("") : getFilteredTagSuggestions(query);
-  if(!showAllForNewCard && !query) return;
-  const seen=new Set();
-  suggestions.forEach(t=>{
-    const k=t.toLowerCase(); if(seen.has(k)) return; seen.add(k);
-    const el=document.createElement("span"); el.className="chip";
-    const txt=document.createElement("span"); txt.textContent=t;
-    el.append(txt);
-    let rm=null;
-    if(showAllForNewCard){
-      rm=document.createElement("span");
-      rm.textContent="×";
-      rm.className="remove";
-      rm.title="delete tag from active cards";
-      el.append(rm);
-    }
-    el.onclick=(e)=>{
-      if(rm && e.target===rm){ removeTagFromActiveCards(t); return; }
-      if(!activeTags.includes(t)){ activeTags.push(t); renderTagChips(); }
-    };
-    tagSuggestions.appendChild(el);
-  });
-}
-function getFilteredTagSuggestions(query=""){
-  const q=String(query||"").trim().toLowerCase();
-  return tagHistory.filter(t=>(!q || t.includes(q)));
 }
 
 /* ===== Attachments ===== */


### PR DESCRIPTION
### Motivation
- Users reported the suggested-tags row under the tag entry caused a visual jump and prevented adding a second tag when interacting with suggestions.
- The goal was to remove the brittle suggestion click/blur interaction and preserve convenient reuse of existing tags via deterministic matching.

### Description
- Removed the inline suggestions element and all suggestion-rendering logic from the card editor UI in `kanban.html`.
- Added `resolveExistingTag(rawTag)` which resolves a typed tag to an existing tag by exact match first, then a unique-prefix match, otherwise returns the typed value.
- Updated `commitTagFromInput()` to use `resolveExistingTag()` and removed calls to suggestion-render functions so tag commits no longer rely on the suggestion row.
- Cleaned up calls to the removed suggestion rendering from `openEditor()` and `removeTagFromActiveCards()` to avoid dangling interactions.

### Testing
- Ran `rg -n "tagSuggestions|renderTagSuggestions|getFilteredTagSuggestions" kanban.html` to confirm no remaining references to the removed suggestion functions and the suggestion element, which succeeded (no matches).
- Committed the change with `git commit` to validate repository operations succeeded, which succeeded.
- Verified `git status --short` to ensure the working tree is clean after the commit, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6154840f8832dafaede630f6554d0)