### PR TITLE
Improve tag suggestion UX, click-to-assign, drag/selection guards, and persist card collapse state

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -703,9 +703,16 @@ let suppressNextCardClick=false;
 function isInteractiveCardTarget(target){
   return !!target?.closest?.('a,button,input,textarea,select,label,[contenteditable="true"]');
 }
+function hasActiveTextSelection(){
+  const sel = window.getSelection?.();
+  return !!sel && !sel.isCollapsed && String(sel).trim().length>0;
+}
+function isTextSelectableCardTarget(target){
+  return !!target?.closest?.('.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
+}
 function pointerFromCardStart(card, e){
   if(e.pointerType==="mouse") return;
-  if(isInteractiveCardTarget(e.target)) return;
+  if(isInteractiveCardTarget(e.target) || isTextSelectableCardTarget(e.target) || hasActiveTextSelection()) return;
   pointerDrag={id:card.id,pointerId:e.pointerId,startX:e.clientX,startY:e.clientY,startAt:Date.now(),active:false};
   card.setPointerCapture?.(e.pointerId);
 }
@@ -834,7 +841,12 @@ function buildInlineTagEditor(tagArr){
 
   function renderSuggestions(){
     sugEl.innerHTML = "";
-    tagHistory.filter(t=>!tagArr.includes(t)).forEach(t=>{
+    const query = tagIn.value.trim().toLowerCase();
+    const show = query.length>0;
+    sugLabel.style.display = show ? "" : "none";
+    sugEl.style.display = show ? "" : "none";
+    if(!show) return;
+    tagHistory.filter(t=>!tagArr.includes(t) && t.toLowerCase().includes(query)).forEach(t=>{
       const chip = document.createElement("span"); chip.className = "chip";
       const txt = document.createElement("span"); txt.textContent = t;
       const rx = document.createElement("span"); rx.className = "sug-x"; rx.textContent = "×"; rx.title = "remove from list";
@@ -857,6 +869,7 @@ function buildInlineTagEditor(tagArr){
   }
 
   tagIn.addEventListener("keydown", e=>{ if(e.key==="Enter"||e.key===","){ e.preventDefault(); e.stopPropagation(); commitInput(); } });
+  tagIn.addEventListener("input", ()=> renderSuggestions());
   addBtn.addEventListener("click", e=>{ e.stopPropagation(); commitInput(); });
 
   renderAssigned(); renderSuggestions();
@@ -866,7 +879,12 @@ function buildInlineTagEditor(tagArr){
 function renderCard(card){
   const el=document.createElement("article"); el.className="card"; el.draggable=true; el.dataset.id=card.id;
   el.addEventListener("dragstart", e=>{
-    if(isInteractiveCardTarget(e.target) || e.target.closest('.card-links,.live-notes-preview,.attachment-list')){
+    if(
+      isInteractiveCardTarget(e.target) ||
+      isTextSelectableCardTarget(e.target) ||
+      hasActiveTextSelection() ||
+      e.target.closest('.card-links,.live-notes-preview,.attachment-list')
+    ){
       e.preventDefault();
       return;
     }
@@ -1309,6 +1327,7 @@ function commitTagFromInput(){
 }
 tagInput.addEventListener("keydown", (e)=>{ if(e.key==="Enter" || e.key===","){ e.preventDefault(); commitTagFromInput(); } });
 tagInput.addEventListener("blur", ()=>{ commitTagFromInput(); });
+tagInput.addEventListener("input", ()=> renderTagSuggestions());
 function renderTagChips(){
   tagChips.innerHTML="";
   activeTags.forEach(t=>{
@@ -1319,17 +1338,21 @@ function renderTagChips(){
   hiddenTags.value = activeTags.join(",");
 }
 function renderTagSuggestions(){
-  tagSuggestions.innerHTML=""; if(!tagHistory.length) return;
+  tagSuggestions.innerHTML="";
+  const query = tagInput.value.trim().toLowerCase();
+  if(!query || !tagHistory.length) return;
   const seen=new Set();
   tagHistory.forEach(t=>{
-    const k=t.toLowerCase(); if(seen.has(k)) return; seen.add(k);
+    const k=t.toLowerCase();
+    if(!k.includes(query) || seen.has(k) || activeTags.includes(t)) return;
+    seen.add(k);
     const el=document.createElement("span"); el.className="chip";
     const txt=document.createElement("span"); txt.textContent=t;
     const rm=document.createElement("span"); rm.textContent="×"; rm.className="remove"; rm.title="remove from history";
     el.append(txt,rm);
     el.onclick=(e)=>{
       if(e.target===rm){ tagHistory=saveTagHistory(tagHistory.filter(x=>x!==t)); renderTagSuggestions(); return; }
-      if(!activeTags.includes(t)){ activeTags.push(t); renderTagChips(); }
+      if(!activeTags.includes(t)){ activeTags.push(t); renderTagChips(); renderTagSuggestions(); }
     };
     tagSuggestions.appendChild(el);
   });
@@ -1412,11 +1435,11 @@ $("#bKeySwitch").addEventListener("click", ()=>{
   // reload state from the new slot
   const fresh = loadState();
   if(fresh){
-    Object.assign(state, fresh);
-    state.collapsed   = state.collapsed||{};
-    state.cardCollapsed = state.cardCollapsed||{};
-    state.archive     = Array.isArray(state.archive)?state.archive:[];
-    state.layout      = state.layout||"auto";
+    state = fresh;
+    state.collapsed = (state.collapsed && typeof state.collapsed==="object") ? state.collapsed : {};
+    state.cardCollapsed = (state.cardCollapsed && typeof state.cardCollapsed==="object") ? state.cardCollapsed : {};
+    state.archive = Array.isArray(state.archive) ? state.archive : [];
+    state.layout = state.layout || "auto";
   } else {
     state.cards=[]; state.archive=[]; state.collapsed={}; state.cardCollapsed={};
   }
@@ -1928,11 +1951,11 @@ function sanitizeMarkdownImages(s){
     updateKeyLabel();
     const fresh = loadState();
     if(fresh){
-      Object.assign(state, fresh);
-      state.collapsed = state.collapsed||{};
-      state.cardCollapsed = state.cardCollapsed||{};
-      state.archive = Array.isArray(state.archive)?state.archive:[];
-      state.layout = state.layout||"auto";
+      state = fresh;
+      state.collapsed = (state.collapsed && typeof state.collapsed==="object") ? state.collapsed : {};
+      state.cardCollapsed = (state.cardCollapsed && typeof state.cardCollapsed==="object") ? state.cardCollapsed : {};
+      state.archive = Array.isArray(state.archive) ? state.archive : [];
+      state.layout = state.layout || "auto";
     } else {
       state.cards=[]; state.archive=[]; state.collapsed={}; state.cardCollapsed={};
     }


### PR DESCRIPTION
### Motivation
- Make tag suggestion behavior less intrusive by showing suggestions only while the user types a non-space character and matching suggestions case-insensitively.
- Allow fast single-click assignment of suggested tags and remove assigned tags from the current suggestion pool without deleting already-assigned tags when history items are removed.
- Prevent drag-and-drop from interfering with normal text selection and interactions inside card content.
- Ensure per-card expanded/collapsed state is restored exactly as saved when loading or switching boards.

### Description
- In `kanban.html` updated inline tag editor (`buildInlineTagEditor`) to hide suggestions when the input is empty, filter suggestions case-insensitively using the typed query, show/hide suggestion UI on `input`, and assign a clicked suggestion immediately while removing it from the visible pool (`L804-L874`).
- In `kanban.html` updated modal tag suggestions (handlers around `#tagInput` / `renderTagSuggestions`) to show suggestions only when `tagInput` contains non-space text, filter case-insensitively, add an `input` listener to refresh suggestions, and make suggestion click immediately add the tag and refresh the pool (`L1315-L1359`).
- Added robust drag/selection guards by introducing `hasActiveTextSelection()` and `isTextSelectableCardTarget()` and updated `pointerFromCardStart` and card `dragstart` checks to avoid starting a drag when interacting with interactive/selectable content or when there is an active text selection (`L703-L716`, `L879-L900`).
- Preserved existing Enter/comma tag-commit behavior and left other board features unchanged.
- Fixed board-load / board-switch hydration so loaded board JSON is assigned to `state = fresh` and its `collapsed` / `cardCollapsed` fields are preserved (updated both switch paths), ensuring persisted per-card open/closed state is restored on load (`L1429-L1445`, `L1946-L1961`).

### Testing
- Ran `git diff --check` which completed with no errors (success).
- Ran `git status --short` to confirm the single modified file `kanban.html` (success).
- Created a commit (`git commit`) for the change which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e621b686d8832d8b05814866b49920)