### PR TITLE
Fix accidental drag while editing card fields in kanban.html

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -701,11 +701,19 @@ document.addEventListener("dragover", e=> e.preventDefault());
 let pointerDrag=null;
 let suppressNextCardClick=false;
 function isInteractiveCardTarget(target){
-  return !!target?.closest?.('a,button,input,textarea,select,label,[contenteditable="true"]');
+  return !!target?.closest?.('a,button,input,textarea,select,label,[contenteditable]');
 }
 function hasActiveTextSelection(){
   const sel = window.getSelection?.();
   return !!sel && !sel.isCollapsed && String(sel).trim().length>0;
+}
+function hasActiveEditableInCard(cardEl){
+  const active = document.activeElement;
+  return !!(
+    active &&
+    cardEl?.contains(active) &&
+    active.matches?.('input,textarea,select,[contenteditable]')
+  );
 }
 function isTextSelectableCardTarget(target){
   return !!target?.closest?.('.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
@@ -878,11 +886,20 @@ function buildInlineTagEditor(tagArr){
 
 function renderCard(card){
   const el=document.createElement("article"); el.className="card"; el.draggable=true; el.dataset.id=card.id;
+  el.addEventListener("focusin", (e)=>{
+    if(e.target?.closest?.('input,textarea,select,[contenteditable]')) el.draggable=false;
+  });
+  el.addEventListener("focusout", ()=>{
+    requestAnimationFrame(()=>{
+      if(!hasActiveEditableInCard(el)) el.draggable=true;
+    });
+  });
   el.addEventListener("dragstart", e=>{
     if(
       isInteractiveCardTarget(e.target) ||
       isTextSelectableCardTarget(e.target) ||
       hasActiveTextSelection() ||
+      hasActiveEditableInCard(el) ||
       e.target.closest('.card-links,.live-notes-preview,.attachment-list')
     ){
       e.preventDefault();


### PR DESCRIPTION
## Summary
- prevent card drag initiation whenever focus is inside an editable control within a card
- broaden interactive target detection to all `[contenteditable]` elements
- guard `dragstart` against active in-card editable focus to stop accidental DnD while selecting or editing text

## Details
- Added `hasActiveEditableInCard(cardEl)` helper near existing drag/interaction utilities.
- In `renderCard(card)`:
  - set `el.draggable = false` on `focusin` for editable descendants (`input`, `textarea`, `select`, `[contenteditable]`)
  - restore `el.draggable = true` on `focusout` only when no editable remains focused in the same card
  - extended `dragstart` early-return conditions with `hasActiveEditableInCard(el)`
- Updated `isInteractiveCardTarget` selector from `[contenteditable="true"]` to `[contenteditable]`.

## Why
Users could trigger drag-and-drop when trying to select/edit text in card-edit fields. This patch prioritizes text interaction over drag behavior without rebuilding the board or changing data structures.

## Scope
- `kanban.html` only
- minimal behavior fix; no schema/data migration changes

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e624ce57c8832d96fef20d77f5ad75)