### PR TITLE
Revamp call UI — top ribbon controls, required room name, and typed translated compose strip

### DIFF
--- a/bridge.html
+++ b/bridge.html
@@ -76,9 +76,16 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .log-row .ts{color:#555;}.log-row .ev{color:var(--teal-bright);}
 .log-row.error .ev{color:#e74c3c;}.log-row.warn .ev{color:#f39c12;}.log-row.ok .ev{color:#2ecc71;}
 
-/* === CALL — 3-row flex: video | transcript | controls === */
+/* === CALL layout === */
 .call{position:fixed;inset:0;background:#000;z-index:5;display:none;flex-direction:column;}
 .call.active{display:flex;}
+.call-top-ribbon{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px 12px;background:rgba(10,10,10,.92);border-bottom:1px solid var(--surface2);flex-shrink:0;}
+.ribbon-left,.ribbon-center,.ribbon-right{display:flex;align-items:center;min-width:0;}
+.ribbon-left{flex:1;justify-content:flex-start;}
+.ribbon-center{flex:1.5;justify-content:center;}
+.ribbon-right{flex:1;justify-content:flex-end;gap:10px;}
+.ribbon-room-name{font-size:13px;font-weight:600;color:#fff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}
+.ribbon-flags{background:rgba(255,255,255,.08);color:#fff;border:1px solid rgba(255,255,255,.14);border-radius:999px;padding:3px 9px;font-size:14px;white-space:nowrap;}
 
 .call-videos{position:relative;background:#000;overflow:hidden;flex:1;min-height:0;transition:flex-basis .2s ease;}
 #remote-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000;z-index:1;}
@@ -128,13 +135,26 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .tr-tts svg{width:13px;height:13px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
 .tr-empty{color:var(--text-muted);font-size:12px;font-style:italic;padding:12px 0;}
 
-.call-controls{display:flex;align-items:center;justify-content:center;gap:14px;padding:8px 16px max(8px,env(safe-area-inset-bottom));background:var(--surface);flex-shrink:0;}
+.call-controls{display:flex;align-items:center;justify-content:flex-end;gap:10px;}
 .ctrl-btn{width:48px;height:48px;border-radius:50%;border:none;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,transform .1s;background:rgba(255,255,255,.1);color:#fff;}
 .ctrl-btn:hover{background:rgba(255,255,255,.18);}
 .ctrl-btn:active{transform:scale(.93);}
 .ctrl-btn.off{background:rgba(231,76,60,.2);color:var(--red);}
 .ctrl-btn.end-call{background:var(--red);color:#fff;width:56px;height:48px;border-radius:24px;}
 .ctrl-btn.end-call:hover{background:#c0392b;}
+.ctrl-btn.small{width:40px;height:40px;}
+.ctrl-btn.end-call.small{width:48px;height:40px;}
+
+.compose-strip{position:sticky;bottom:0;display:flex;align-items:center;gap:8px;padding:8px 10px max(10px,env(safe-area-inset-bottom));background:rgba(12,12,12,.96);border-top:1px solid var(--surface2);z-index:6;flex-shrink:0;}
+.compose-indicator{width:18px;height:18px;border-radius:50%;border:1px solid rgba(255,255,255,.35);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.compose-indicator::after{content:'';width:7px;height:7px;border-radius:50%;background:var(--teal-bright);}
+.compose-input{flex:1;min-width:0;background:var(--surface);color:var(--text);border:1px solid var(--surface2);border-radius:999px;padding:10px 14px;font-size:14px;font-family:"DM Sans",sans-serif;outline:none;}
+.compose-input:focus{border-color:var(--teal);}
+.compose-send{background:var(--teal);color:#fff;border:none;border-radius:999px;padding:9px 14px;font-size:13px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;}
+.compose-send:disabled{opacity:.45;cursor:default;}
+
+.typed-dot{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;border-radius:50%;border:1px solid rgba(255,255,255,.35);margin-left:6px;vertical-align:middle;}
+.typed-dot::after{content:'';width:5px;height:5px;border-radius:50%;background:var(--teal-bright);}
 
 #toast{position:fixed;bottom:90px;left:50%;transform:translateX(-50%) translateY(20px);background:rgba(255,255,255,.15);backdrop-filter:blur(12px);color:#fff;font-size:13px;font-weight:600;padding:10px 20px;border-radius:22px;z-index:100;opacity:0;transition:opacity .2s,transform .2s;pointer-events:none;}
 #toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
@@ -142,7 +162,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 @media(min-width:768px){
   .lobby-card{width:420px;}
   #local-video{width:min(18%,160px);}
-  .call-controls{gap:20px;padding:10px 24px;}
   .ctrl-btn{width:54px;height:54px;}
   .ctrl-btn.end-call{width:64px;height:54px;}
   .subtitle-line{font-size:16px;max-width:80%;}
@@ -151,21 +170,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 @media(max-height:500px) and (orientation:landscape){
   .call-transcript{flex-basis:34%;}
   #local-video{width:min(16%,90px);top:6px;right:6px;}
-  .call-controls{gap:10px;padding:6px 12px;}
   .ctrl-btn{width:40px;height:40px;}
   .ctrl-btn.end-call{width:48px;height:40px;}
   .subtitle-line{font-size:12px;padding:3px 8px;}
 }
 @media(max-width:400px){
-  .call-controls{gap:10px;}
   .ctrl-btn{width:44px;height:44px;}
   .ctrl-btn.end-call{width:52px;height:44px;}
 }
-
-/* Room info chip — center top of video */
-.call-info-wrap{position:absolute;top:8px;left:50%;transform:translateX(-50%);z-index:5;display:flex;flex-direction:column;align-items:center;gap:3px;pointer-events:none;}
-.room-name-chip{background:rgba(0,0,0,.72);color:#fff;border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:600;white-space:nowrap;max-width:min(78vw,260px);overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(5px);}
-.lang-flags-chip{background:rgba(0,0,0,.55);color:#fff;border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:2px 10px;font-size:15px;backdrop-filter:blur(4px);}
 </style>
 </head>
 <body>
@@ -176,8 +188,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <div class="lobby-sub">Video call with live subtitles</div>
     <div id="lobby-setup">
       <div style="display:flex;flex-direction:column;gap:12px;">
-        <div><div class="lobby-label" style="margin-bottom:6px;">Room name (optional)</div>
-        <input class="lobby-input" id="room-name" placeholder="e.g. English ↔ Thai session" maxlength="60"></div>
+        <div><div class="lobby-label" style="margin-bottom:6px;">Room name (required)</div>
+        <input class="lobby-input" id="room-name" placeholder="e.g. English ↔ Thai session" maxlength="60" oninput="syncBtn()"></div>
         <div><div class="lobby-label" style="margin-bottom:6px;">I speak</div>
         <select class="lobby-select" id="my-lang"></select></div>
         <div><div class="lobby-label" style="margin-bottom:6px;">They speak</div>
@@ -237,27 +249,32 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 </div>
 
 <div class="call" id="call-screen">
+  <div class="call-top-ribbon">
+    <div class="ribbon-left"><div class="ribbon-flags" id="lang-flags-chip">🌐 → 🌐</div></div>
+    <div class="ribbon-center"><div class="ribbon-room-name" id="room-name-chip">No room</div></div>
+    <div class="ribbon-right">
+      <div class="call-controls">
+        <button class="ctrl-btn small" id="mic-btn" onclick="toggleMic()" title="Mute/unmute">
+          <svg id="mic-on" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+          <svg id="mic-off" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/><line x1="2" y1="22" x2="22" y2="2" stroke="#e74c3c" stroke-width="2.5"/></svg>
+        </button>
+        <button class="ctrl-btn end-call small" onclick="hangUp()" title="End call">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.11 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4z" transform="rotate(135 12 12)"/></svg>
+        </button>
+        <button class="ctrl-btn small" id="cam-btn" onclick="toggleCam()" title="Camera">
+          <svg id="cam-on" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+          <svg id="cam-off" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/><line x1="2" y1="22" x2="22" y2="2" stroke="#e74c3c" stroke-width="2.5"/></svg>
+        </button>
+      </div>
+    </div>
+  </div>
   <div class="call-videos">
     <video id="remote-video" autoplay playsinline></video>
     <video id="local-video" autoplay muted playsinline></video>
     <div class="no-video-placeholder" id="no-video-msg">👤</div>
-    <div class="call-info-wrap"><div class="room-name-chip" id="room-name-chip">No room</div><div class="lang-flags-chip" id="lang-flags-chip">🌐 → 🌐</div></div>
     <div class="solo-banner" id="solo-banner" style="display:none;"><div class="solo-banner-text">Solo / test mode — waiting for partner</div></div>
     <div class="partner-speaking-indicator" id="partner-speaking-indicator" aria-hidden="true">…</div>
     <div class="subtitle-area" id="subtitle-area"></div>
-  </div>
-  <div class="call-controls">
-    <button class="ctrl-btn" id="mic-btn" onclick="toggleMic()" title="Mute/unmute">
-      <svg id="mic-on" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
-      <svg id="mic-off" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/><line x1="2" y1="22" x2="22" y2="2" stroke="#e74c3c" stroke-width="2.5"/></svg>
-    </button>
-    <button class="ctrl-btn end-call" onclick="hangUp()" title="End call">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.11 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4z" transform="rotate(135 12 12)"/></svg>
-    </button>
-    <button class="ctrl-btn" id="cam-btn" onclick="toggleCam()" title="Camera">
-      <svg id="cam-on" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-      <svg id="cam-off" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/><line x1="2" y1="22" x2="22" y2="2" stroke="#e74c3c" stroke-width="2.5"/></svg>
-    </button>
   </div>
   <div class="call-transcript" id="call-transcript">
     <div class="call-transcript-header">
@@ -284,6 +301,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     </div>
     <div id="transcript-body"><div class="tr-empty">Speak to see transcript here.</div></div>
     <div class="transcript-more-indicator" id="transcript-more-indicator" aria-hidden="true">↓</div>
+  </div>
+  <div class="compose-strip">
+    <span class="compose-indicator" aria-hidden="true"></span>
+    <input class="compose-input" id="compose-input" type="text" maxlength="320" placeholder="Type to send translated message…">
+    <button class="compose-send" id="compose-send" onclick="sendTypedMessage()">Send</button>
   </div>
 </div>
 <div id="toast"></div>
@@ -426,11 +448,12 @@ function renderRecent(){
 }
 
 function populateLangs(){['my-lang','their-lang'].forEach(function(id){var s=$(id);s.innerHTML='<option value="" disabled selected>Select language…</option>'+LANGS.map(function(l){return'<option value="'+l.code+'">'+l.flag+' '+l.label+'</option>'}).join('');s.onchange=syncBtn});syncBtn()}
-function syncBtn(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';$('create-btn').disabled=!($('my-lang').value&&$('their-lang').value&&k)}
+function syncBtn(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';var n=(($('room-name')&&$('room-name').value)||'').trim();$('create-btn').disabled=!($('my-lang').value&&$('their-lang').value&&k&&n)}
 
 async function createRoom(){
   room.myLang=$('my-lang').value;room.theirLang=$('their-lang').value;room.name=($('room-name').value||'').trim();
   if(!room.myLang||!room.theirLang){toast('Select both languages');return}
+  if(!room.name){toast('Room name is required');return}
   room.id=uid();room.role='creator';
   try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:true});$('preview-video').srcObject=videoStream}catch(_){toast('Camera needed');return}
   $('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=room.name?'📋 '+room.name:'';
@@ -481,13 +504,17 @@ function handleRelay(d){
   if(d.type==='webrtc-signal'){handleSig(d);return}
   if(d.type==='subtitle'){
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
-    addTr('partner',d.sourceText,d.text,d.sourceLang,d.targetLang,d.subtitleSeq);return;
+    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner',false);
+    addTr('partner',d.sourceText,d.text,d.sourceLang,d.targetLang,d.subtitleSeq,'spoken');return;
   }
   if(d.type==='subtitle-update'){
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
+    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner',false);
     patchTr('partner',d.subtitleSeq,d.text,d.sourceLang,d.targetLang);return;
+  }
+  if(d.type==='typed-message'){
+    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner',true);
+    addTr('partner',d.sourceText,d.text,d.sourceLang,d.targetLang,d.subtitleSeq,'typed');return;
   }
   if(d.type==='hangup'){toast('Partner left');cleanUp();return}
 }
@@ -605,10 +632,24 @@ function onDGFinal(text){
   if(isDupe(text)){log('dg_dedup',{t:text.slice(0,40)},'warn');return}
   recFinal(text);log('dg_final',{t:text.slice(0,60)},'ok');
   var src=detectLang(text,room.myLang),tgt=room.theirLang,ss=++localSubSeq;
-  showSub(text,'mine');
+  showSub(text,'mine',false);
   relaySend({type:'subtitle',subtitleSeq:ss,text:text,sourceText:text,sourceLang:src,targetLang:tgt,provisional:true});
-  addTr('me',text,text,src,tgt,ss);
+  addTr('me',text,text,src,tgt,ss,'spoken');
   translate(text,src,tgt).then(function(tr){tr=norm(tr)||text;if(tr!==text){relaySend({type:'subtitle-update',subtitleSeq:ss,text:tr,sourceText:text,sourceLang:src,targetLang:tgt});patchTr('me',ss,tr,src,tgt)}});
+}
+
+function sendTypedMessage(){
+  var input=$('compose-input');if(!input)return;
+  var srcText=norm(input.value);if(!srcText)return;
+  var src=room.myLang||'en',tgt=room.theirLang||'en',ss=++localSubSeq;
+  $('compose-send').disabled=true;
+  translate(srcText,src,tgt).then(function(out){
+    var translated=norm(out)||srcText;
+    showSub(translated,'mine',true);
+    addTr('me',srcText,translated,src,tgt,ss,'typed');
+    relaySend({type:'typed-message',subtitleSeq:ss,text:translated,sourceText:srcText,sourceLang:src,targetLang:tgt,inputMode:'typed'});
+    input.value='';
+  }).finally(function(){$('compose-send').disabled=false;input.focus();});
 }
 
 function startDeepgram(){
@@ -666,18 +707,21 @@ function stopDeepgram(){
   stopDGAudio();log('dg_stopped',{});
 }
 
-function showSub(text,cls){
+function showSub(text,cls,isTyped){
   var a=$('subtitle-area'),el=document.createElement('div');
-  el.className='subtitle-line '+cls;el.textContent=text;a.appendChild(el);
+  el.className='subtitle-line '+cls;
+  el.innerHTML=esc(text)+(isTyped?' <span class="typed-dot" title="Typed"></span>':'');
+  a.appendChild(el);
   while(a.children.length>2)a.children[0].remove();
   setTimeout(function(){if(el.parentNode)el.remove()},SUB_LINGER);
 }
 
-function addTr(who,src,tr,sL,tL,ss){
+function addTr(who,src,tr,sL,tL,ss,inputMode){
   src=norm(src);tr=norm(tr);if(!src&&!tr)return;if(!tr)tr=src;
   var prev=transcript.length?transcript[transcript.length-1]:null;
-  if(prev&&prev.who===who&&prev.sourceText===src&&Date.now()-prev.ts<5000)return;
-  var entry={who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
+  var mode=inputMode||'spoken';
+  if(prev&&prev.who===who&&prev.sourceText===src&&prev.inputMode===mode&&Date.now()-prev.ts<5000)return;
+  var entry={who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,inputMode:mode,ts:Date.now()};
   transcript.push(entry);if(transcript.length>MAX_TR)transcript.splice(0,transcript.length-MAX_TR);
   saveTr();appendTrDom(entry);
   if(transcriptTtsOn&&src)speakText(src,sL||room.myLang);
@@ -685,7 +729,7 @@ function addTr(who,src,tr,sL,tL,ss){
 function patchTr(who,ss,newTr,sL,tL){
   newTr=norm(newTr);if(!newTr)return;
   for(var i=transcript.length-1;i>=0;i--){if(transcript[i].who===who&&transcript[i].subtitleSeq===ss){if(transcript[i].translatedText===newTr)return;transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();renderTr();return}}
-  addTr(who,newTr,newTr,sL,tL,ss);
+  addTr(who,newTr,newTr,sL,tL,ss,'spoken');
 }
 function trHtml(e){
   var srcLang=e.srcLang||(e.who==='me'?room.myLang:room.theirLang)||'en';
@@ -695,8 +739,9 @@ function trHtml(e){
   var speaker=e.who==='me'?'You':'Partner';
   var srcText=e.sourceText||'';
   var tgtText=e.translatedText||srcText;
+  var typed=e.inputMode==='typed';
   return '<div class="tr-entry"><div class="tr-bubble">'
-    +'<div class="tr-head"><div class="tr-who '+(e.who==='me'?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
+    +'<div class="tr-head"><div class="tr-who '+(e.who==='me'?'mine':'')+'">'+esc(speaker)+(typed?'<span class="typed-dot" title="Typed message"></span>':'')+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
     +'<div class="tr-body">'
     +'<div class="tr-col source"><div class="tr-text">'+esc(srcText)+'</div>'
     +'<button class="tr-tts" type="button" data-tts-text="'+esc(srcText)+'" data-tts-lang="'+esc(srcLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button></div>'
@@ -754,6 +799,7 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key'))$('dg-key').value=localStorage
 populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
 $('call-transcript').addEventListener('click',function(ev){var btn=ev.target.closest('.tr-tts');if(!btn)return;speakText(btn.getAttribute('data-tts-text')||'',btn.getAttribute('data-tts-lang')||room.myLang||'en');});
+$('compose-input').addEventListener('keydown',function(ev){if(ev.key==='Enter'&&!ev.shiftKey){ev.preventDefault();sendTypedMessage();}});
 $('local-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('loadedmetadata',refreshRemoteVideo);

--- a/bridge.html
+++ b/bridge.html
@@ -544,10 +544,19 @@ function refreshRemoteVideo(){
   if(hasRemoteTrack&&rv.srcObject!==remoteStream){rv.srcObject=remoteStream;}
   rv.playsInline=true;rv.autoplay=true;
   if(hasRemoteTrack){
-    rv.muted=false;
+    // Start muted first so autoplay succeeds across stricter mobile/browser policies.
+    rv.muted=true;
     var tryPlay=rv.play&&rv.play();
-    if(tryPlay&&tryPlay.then){tryPlay.then(function(){rv.muted=false;log('rtc_unmuted',{},'ok');}).catch(function(e){log('rtc_play_err',{e:String(e)},'error');});}
-    setTimeout(function(){if(rv.srcObject){rv.muted=false;}},800);
+    if(tryPlay&&tryPlay.then){
+      tryPlay.then(function(){
+        rv.muted=false;
+        log('rtc_play_ok',{},'ok');
+      }).catch(function(e){
+        // Keep muted so remote video still renders even if unmuted autoplay is blocked.
+        rv.muted=true;
+        log('rtc_play_err',{e:String(e)},'error');
+      });
+    }
     $('solo-banner').style.display='none';
   }
   if(hasVideoTrack){


### PR DESCRIPTION
### Motivation

- Improve in-call ergonomics by moving video controls to a persistent top ribbon and surfacing language flags and room name prominently. 
- Add a sticky typed chat compose so users can send translated text messages when audio/invite flow is problematic. 
- Make room name required to avoid ambiguous/empty room labels.

### Description

- Updated `bridge.html` to introduce a top ribbon (`.call-top-ribbon`) with language flags left, centered room name, and controls (mic/end/camera) on the right, and removed the old floating room info chip. 
- Added a sticky bottom compose strip (`.compose-strip`) with input, send button, enter-to-send handling, and a dot-in-circle typed indicator (`.compose-indicator` / `.typed-dot`). 
- Implemented typed-message flow in the relay: added `sendTypedMessage()` to translate typed input, send `typed-message` via `relaySend`, and handle incoming `typed-message` in `handleRelay`. 
- Subtitles/transcript now show a small typed indicator and record an `inputMode` on transcript entries; `addTr`, `patchTr`, `trHtml`, and `showSub` were extended to support `inputMode` and typed rendering. 
- Enforced room-name requirement by updating `syncBtn()` and adding a check in `createRoom()` so the Start button requires a non-empty room name. 

### Testing

- Ran an inline JavaScript validation using `node -e` to extract and execute the page script, which returned `ok`. 
- Performed `git` operations to stage and commit the updated `bridge.html`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e868a585f0832da0b6f38798757a0e)