### PR TITLE
Fix Bridge peer identity collision across tabs

### DIFF
--- a/bridge.html
+++ b/bridge.html
@@ -331,7 +331,8 @@ var LANGS=[
 var TTS_LOCALE={en:'en-US',th:'th-TH',ja:'ja-JP',ko:'ko-KR',zh:'zh-CN',ar:'ar-SA',hi:'hi-IN',ru:'ru-RU',fr:'fr-FR',de:'de-DE',es:'es-ES',it:'it-IT',pt:'pt-BR',vi:'vi-VN',id:'id-ID',ms:'ms-MY',fil:'fil-PH',nl:'nl-NL',sv:'sv-SE',pl:'pl-PL',tr:'tr-TR'};
 
 var room={id:null,myLang:'',theirLang:'',role:null,name:'',solo:false};
-var deviceId=localStorage.getItem('tb_dev')||(function(){var id=crypto.randomUUID();localStorage.setItem('tb_dev',id);return id})();
+// Use a per-tab client id so host+joiner in the same browser profile are treated as different peers.
+var deviceId=sessionStorage.getItem('tb_dev_tab')||(function(){var id=(crypto.randomUUID?crypto.randomUUID():uid())+'-'+Date.now().toString(36);sessionStorage.setItem('tb_dev_tab',id);return id})();
 var ws=null,pc=null,videoStream=null,remoteStream=null;
 var micOn=true,camOn=true,makingOffer=false,ignoreOffer=false;
 var DG_LANGS={en:'en-US',th:'th',ja:'ja',ko:'ko',zh:'zh-CN',ar:'ar',hi:'hi',ru:'ru',fr:'fr',de:'de',es:'es',it:'it',pt:'pt-BR',vi:'vi',id:'id',ms:'ms',fil:'fil',nl:'nl',sv:'sv',pl:'pl',tr:'tr'};


### PR DESCRIPTION
### Motivation
- A persistent client id stored in `localStorage` caused host and joiner opened in the same browser profile to share the same `from` id, causing the relay to ignore their signaling/media/subtitle messages and breaking the join flow.

### Description
- Replace persistent `localStorage` client id with a per-tab id stored in `sessionStorage` at the `deviceId` initialization in `bridge.html`.
- Generate the per-tab id using `crypto.randomUUID()` when available or fall back to the existing `uid()` plus a timestamp and persist it to `sessionStorage` under `tb_dev_tab`.
- Add a short inline comment explaining why a per-tab id is required to avoid peer identity collisions.

### Testing
- Inspected the patch with `git diff -- bridge.html` to confirm the `deviceId` change, which displayed the intended replacement.
- Committed the change using `git commit -m "Fix Bridge peer identity collision across tabs"`, which succeeded.
- Verified workspace cleanliness with `git status --short`, which reported no outstanding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e878426dd4832d9d4d5fafb9964b0d)