### PR TITLE
Restore renegotiation when peer joins active call (bridge.html)

### DIFF
--- a/bridge.html
+++ b/bridge.html
@@ -491,7 +491,19 @@ function handleRelay(d){
   if(d.type==='hello'){
     if(lobbyState===LS.waiting){room.solo=false;enterCall();return}
     // Already in call: partner arrived, clear solo banner
-    if(lobbyState===LS.call){room.solo=false;$('solo-banner').style.display='none';if(!pc)setupPC();}
+    if(lobbyState===LS.call){
+      room.solo=false;
+      $('solo-banner').style.display='none';
+      if(!pc)setupPC();
+      if(pc&&pc.signalingState==='stable'&&!makingOffer){
+        makingOffer=true;
+        pc.createOffer().then(function(offer){
+          return pc.setLocalDescription(offer);
+        }).then(function(){
+          relaySend({type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}});
+        }).catch(function(){}).finally(function(){makingOffer=false;});
+      }
+    }
     return;
   }
   if(d.type==='ping'){relaySend({type:'pong',transient:true});return}


### PR DESCRIPTION
### Motivation
- A recent change caused creators already in the active call to not renegotiate when a joiner arrived, which could leave the partner invisible (blank remote video) and block the expected direct call and transcription flow.

### Description
- In `bridge.html`'s `handleRelay` path for incoming `hello` while `lobbyState===LS.call`, added a guarded renegotiation that calls `setupPC()` if needed and creates/sets a new local offer and sends it via `relaySend` using the existing `webrtc-signal` payload shape when `pc.signalingState==='stable'` and `!makingOffer`, keeping the fix minimal and scoped to `bridge.html` only.

### Testing
- Ran `git diff -- bridge.html` to verify the change surface and confirm the patch is limited to `bridge.html`, which produced the single hunk shown; the command succeeded.
- Executed a lightweight JS check with `node -e "...new Function(...);"` to validate script syntax, which returned `JS syntax OK`.
- Ran `git status --short` to confirm no other files were modified, which showed only `bridge.html` as changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87f36642c832da04c3fc5db010b7f)