### PR TITLE
Stabilize WebRTC renegotiation and add relay reconnect handling in diag.html

### DIFF
--- a/diag.html
+++ b/diag.html
@@ -26,7 +26,7 @@
 <body>
   <div class="card">
     <h1>Bridge Diagnostic (Push-Button)</h1>
-    <div class="muted">Load → Create link → Send → Join → Type status → Export log</div>
+    <div class="muted">Host taps Start Session. Joiner opens link. Camera/mic prompt is the only required browser step.</div>
   </div>
 
   <div class="card">
@@ -36,11 +36,9 @@
       <label>Room <input id="room" placeholder="auto-created by Host"></label>
     </div>
     <div class="row" style="margin-top:8px">
-      <button id="hostStart" class="primary">1) Host: Start / Create Session</button>
-      <button id="copyInvite">2) Host: Copy Invite Link</button>
-      <button id="joinNow" class="primary">3) Joiner: Answer / Join</button>
-      <button id="mediaBtn">4) Enable Camera + Mic</button>
-      <button id="rtcBtn">5) Start AV Connection</button>
+      <button id="hostStart" class="primary">Start Session</button>
+      <button id="copyInvite">Copy Invite Link</button>
+      <button id="mediaBtn">Retry Camera + Mic</button>
     </div>
     <div class="row" style="margin-top:8px">
       <span class="pill">clientId: <span id="clientId"></span></span>
@@ -54,9 +52,9 @@
   </div>
 
   <div class="card">
-    <div class="step"><strong>Host steps:</strong> Tap button 1, then 2. Send link.</div>
-    <div class="step" style="margin-top:8px"><strong>Joiner steps:</strong> Open link, then tap button 3.</div>
-    <div class="step" style="margin-top:8px"><strong>Both:</strong> Tap 4, then 5. Then type status below and send.</div>
+    <div class="step"><strong>1) Start Session</strong> (host only) creates room + invite link + relay connection.</div>
+    <div class="step" style="margin-top:8px"><strong>2) Open Link</strong> (joiner) auto-connects and auto-starts media flow.</div>
+    <div class="step" style="margin-top:8px"><strong>3) Share status</strong> is optional; export logs anytime.</div>
   </div>
 
   <div class="card">
@@ -77,9 +75,11 @@
   const $ = (id)=>document.getElementById(id);
   const S = {
     id: sessionStorage.getItem('diag_client_id') || crypto.randomUUID(),
+    role: 'host',
     peerId: null, ws: null, pc: null, dc: null, room: null, seq: 0,
     localStream: null, remoteStream: null, makingOffer: false,
-    ignoreOffer: false, pendingAnswer: false
+    ignoreOffer: false, pendingAnswer: false, needsNegotiation: false,
+    wsGen: 0, reconnectAttempts: 0, reconnectTimer: null
   };
   sessionStorage.setItem('diag_client_id', S.id);
   $('clientId').textContent = S.id;
@@ -117,6 +117,49 @@
     S.ws.send(JSON.stringify(msg));
   }
 
+  function autoStatus(tag, text){
+    appendStatus(`${tag} | ${text}`, 'system');
+  }
+
+  async function tryNegotiation(pc){
+    if(!pc || S.makingOffer || pc.signalingState !== 'stable') return;
+    if(!S.needsNegotiation) return;
+    S.needsNegotiation = false;
+    try{
+      S.makingOffer = true;
+      await pc.setLocalDescription(await pc.createOffer());
+      sendRelay({type:'webrtc',signal:{description:pc.localDescription}});
+      line('ok','offer_sent',{});
+    }catch(err){
+      line('err','offer_error',{err:String(err)});
+      S.needsNegotiation = true;
+    }finally{
+      S.makingOffer = false;
+      if(S.needsNegotiation && pc.signalingState === 'stable') queueMicrotask(()=>tryNegotiation(pc));
+    }
+  }
+
+  function ensureLocalTracksAttached(){
+    if(!S.pc || !S.localStream) return;
+    const existing = new Set(S.pc.getSenders().map(s => s.track && s.track.id).filter(Boolean));
+    let added = false;
+    S.localStream.getTracks().forEach((t)=>{
+      if(existing.has(t.id)) return;
+      S.pc.addTrack(t, S.localStream);
+      added = true;
+      line('ok','track_attached',{kind:t.kind,trackId:t.id});
+    });
+    if(added){
+      S.needsNegotiation = true;
+      if(S.pc.signalingState === 'stable'){
+        line('ok','renegotiate_triggered',{});
+        queueMicrotask(()=>tryNegotiation(S.pc));
+      } else {
+        line('ok','renegotiate_pending',{state:S.pc.signalingState});
+      }
+    }
+  }
+
   function connectRelay(){
     S.room = $('room').value.trim();
     const relay = $('relay').value.trim();
@@ -124,14 +167,39 @@
     if(!relay || !S.room){ line('err','missing_relay_or_room',{}); return; }
 
     if(S.ws){ try{S.ws.close();}catch{} }
+    const gen = ++S.wsGen;
+    if(S.reconnectTimer){ clearTimeout(S.reconnectTimer); S.reconnectTimer = null; }
     const url = `${relay}?app=${encodeURIComponent(app)}&session=${encodeURIComponent(S.room)}&client=${encodeURIComponent(S.id)}`;
     line('ok','relay_connect_start',{url});
     S.ws = new WebSocket(url); refresh();
 
-    S.ws.onopen = ()=>{ line('ok','relay_open',{room:S.room}); refresh(); sendRelay({type:'hello'}); };
-    S.ws.onclose = (e)=>{ line('warn','relay_close',{code:e.code,reason:e.reason}); refresh(); };
-    S.ws.onerror = ()=>{ line('err','relay_error',{}); refresh(); };
+    S.ws.onopen = ()=>{
+      if(gen !== S.wsGen) return;
+      S.reconnectAttempts = 0;
+      line('ok','relay_open',{room:S.room});
+      autoStatus('relay_open', `role=${S.role} room=${S.room}`);
+      refresh();
+      sendRelay({type:'hello'});
+      ensurePc();
+      enableMedia();
+    };
+    S.ws.onclose = (e)=>{
+      if(gen !== S.wsGen) return;
+      line('warn','relay_close',{code:e.code,reason:e.reason});
+      refresh();
+      if(e.code === 1000) return;
+      const delay = Math.min(5000, 800 * Math.pow(2, S.reconnectAttempts));
+      S.reconnectAttempts += 1;
+      line('warn','relay_reconnect_scheduled',{attempt:S.reconnectAttempts,delayMs:delay});
+      S.reconnectTimer = setTimeout(()=>connectRelay(), delay);
+    };
+    S.ws.onerror = ()=>{
+      if(gen !== S.wsGen) return;
+      line('err','relay_error',{});
+      refresh();
+    };
     S.ws.onmessage = async (e)=>{
+      if(gen !== S.wsGen) return;
       let d; try{ d = JSON.parse(e.data);}catch{return;}
       if(!d) return;
       if(d.from===S.id){ line('warn','self_or_echo',{type:d.type}); return; }
@@ -148,14 +216,17 @@
       if(S.localStream) return line('warn','media_already_on',{});
       S.localStream = await navigator.mediaDevices.getUserMedia({audio:true,video:true});
       line('ok','media_ready',{tracks:S.localStream.getTracks().map(t=>t.kind)});
+      autoStatus('media_ok', S.localStream.getTracks().map(t=>t.kind).join(','));
+      ensureLocalTracksAttached();
     }catch(err){
       line('err','media_error',{err:String(err)});
+      autoStatus('media_error', String(err));
     }
   }
 
   function bindDc(dc){
     S.dc = dc; refresh();
-    dc.onopen = ()=>{ line('ok','dc_open',{}); refresh(); };
+    dc.onopen = ()=>{ line('ok','dc_open',{}); autoStatus('dc_open','ready'); refresh(); };
     dc.onclose = ()=>{ line('warn','dc_close',{}); refresh(); };
     dc.onmessage = (e)=>{
       if(String(e.data).startsWith('STATUS|')) appendStatus(String(e.data).slice(7), S.peerId || 'peer');
@@ -168,24 +239,22 @@
     const pc = new RTCPeerConnection({iceServers:[{urls:'stun:stun.l.google.com:19302'}]});
     S.pc = pc; refresh();
 
-    if(S.localStream){ S.localStream.getTracks().forEach(t=>pc.addTrack(t,S.localStream)); }
+    if(S.localStream){ ensureLocalTracksAttached(); }
 
     pc.onicecandidate = (e)=>{ if(e.candidate) sendRelay({type:'webrtc',signal:{candidate:e.candidate}}); };
-    pc.onconnectionstatechange = ()=>{ line('ok','pc_state',{state:pc.connectionState}); refresh(); };
+    pc.onconnectionstatechange = ()=>{
+      line('ok','pc_state',{state:pc.connectionState});
+      if(pc.connectionState === 'connected') autoStatus('pc_connected','ok');
+      refresh();
+    };
     pc.oniceconnectionstatechange = ()=>{ line('ok','ice_state',{state:pc.iceConnectionState}); refresh(); };
     pc.ondatachannel = (ev)=> bindDc(ev.channel);
 
-    const role = new URLSearchParams(location.search).get('role');
-    if(role !== 'joiner') bindDc(pc.createDataChannel('diag-status'));
+    if(S.role !== 'joiner') bindDc(pc.createDataChannel('diag-status'));
 
-    pc.onnegotiationneeded = async ()=>{
-      try{
-        S.makingOffer = true;
-        await pc.setLocalDescription(await pc.createOffer());
-        sendRelay({type:'webrtc',signal:{description:pc.localDescription}});
-        line('ok','offer_sent',{});
-      }catch(err){ line('err','offer_error',{err:String(err)}); }
-      finally{ S.makingOffer = false; }
+    pc.onnegotiationneeded = ()=>{
+      S.needsNegotiation = true;
+      queueMicrotask(()=>tryNegotiation(pc));
     };
 
     return pc;
@@ -205,6 +274,9 @@
         S.pendingAnswer = desc.type === 'answer';
         await pc.setRemoteDescription(desc);
         S.pendingAnswer = false;
+        if(S.needsNegotiation && pc.signalingState === 'stable'){
+          queueMicrotask(()=>tryNegotiation(pc));
+        }
 
         if(desc.type==='offer'){
           await pc.setLocalDescription(await pc.createAnswer());
@@ -240,9 +312,7 @@
     try{ await navigator.clipboard.writeText(txt); line('ok','invite_copied',{});}catch(err){line('err','copy_failed',{err:String(err)})}
   };
 
-  $('joinNow').onclick = ()=>{ connectRelay(); line('ok','join_clicked',{}); };
   $('mediaBtn').onclick = enableMedia;
-  $('rtcBtn').onclick = ()=>{ if(!S.ws||S.ws.readyState!==1) return line('warn','connect_first',{}); ensurePc(); line('ok','rtc_started',{}); };
 
   $('sendStatus').onclick = ()=>{
     const name = ($('name').value || 'device').trim();
@@ -259,9 +329,14 @@
   $('exportLog').onclick = ()=>{
     const lines = Array.from(logEl.children).map(n=>n.textContent);
     const payload = [
+      `role=${S.role}`,
       `clientId=${S.id}`,
       `peerId=${S.peerId || '-'}`,
       `room=${$('room').value || '-'}`,
+      `ws=${S.ws?['CONNECTING','OPEN','CLOSING','CLOSED'][S.ws.readyState]:'idle'}`,
+      `pc=${S.pc?S.pc.connectionState:'idle'}`,
+      `ice=${S.pc?S.pc.iceConnectionState:'idle'}`,
+      `dc=${S.dc?S.dc.readyState:'idle'}`,
       `--- STATUS BOARD ---`,
       board.value || '(none)',
       `--- EVENT LOG ---`,
@@ -281,13 +356,12 @@
 
   // Query param prefill + optional auto join
   const q = new URLSearchParams(location.search);
+  S.role = q.get('role') === 'joiner' ? 'joiner' : 'host';
   if(q.get('room')) $('room').value = q.get('room');
-  if(q.get('role')==='joiner' && q.get('room')){
+  if(S.role==='joiner' && q.get('room')){
     $('name').value = 'B';
-    if(q.get('auto')==='1'){
-      line('ok','auto_join_from_link',{});
-      connectRelay();
-    }
+    line('ok','auto_join_from_link',{});
+    connectRelay();
   } else {
     $('name').value = 'A';
   }


### PR DESCRIPTION
### Motivation
- Bridge sessions were failing intermittently due to overlapping offer/answer races and SDP m-line ordering errors when media was attached late.  
- Transient relay WebSocket disconnects and stale socket callbacks caused unreliable host/join flows.  
- The diagnostic UX must remain auto-join/auto-media friendly while emitting clearer telemetry for debugging.

### Description
- Added a negotiation scheduler `tryNegotiation` and a `S.needsNegotiation` flag so offers are created only when `pc.signalingState === 'stable'` and no offer is already in progress, preventing overlapping offer races.  
- Updated `ensureLocalTracksAttached` to attach only missing tracks, mark pending negotiation, and invoke the scheduler when safe to avoid duplicate senders and m-line ordering collisions.  
- Introduced WebSocket generation guards (`S.wsGen`) and automatic reconnect logic with bounded exponential backoff (`S.reconnectAttempts`, `S.reconnectTimer`) to ignore stale socket callbacks and recover from abnormal closes.  
- Improved telemetry and logging by emitting automatic status events (`relay_open`, `media_ok/media_error`, `pc_connected`, `dc_open`) and expanding exported log payload to include `role`, `ws`, `pc`, `ice`, and `dc` states.

### Testing
- Parsed the inline `<script>` with `node -e "new Function(require('fs').readFileSync('diag.html','utf8').match(/<script>[\s\S]*<\/script>/)[0].replace('<script>','').replace('</script>',''))"` to verify there are no syntax/parse errors, and it succeeded.  
- Verified the file diff and created a commit using `git add diag.html && git commit -m "Stabilize bridge negotiation and relay reconnect behavior"`, and the commit succeeded.  
- No browser end-to-end tests were executed in this environment; runtime validation (permission flows, real relay and peer interactions) should be performed in-browser or via a CI browser test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d566665c832da71614a52e1e4299)