### PR TITLE
Fix portlet drag/reflow behavior and expand attachment MIME support

### DIFF
--- a/home.html
+++ b/home.html
@@ -29,12 +29,12 @@
   .column{flex:1;min-width:0;display:flex;flex-direction:column;gap:12px;min-height:0}
   .portlet{display:flex;flex-direction:column;border:1px solid var(--line);border-radius:12px;background:rgba(26,26,28,0.8);box-shadow:var(--shadow);overflow:hidden;flex:0 0 auto}
   .portlet.collapsed{max-height:44px}
-  .portlet.expanded{flex:1 1 auto;min-height:160px}
+  .portlet.expanded{flex:0 0 auto;min-height:220px;max-height:min(60vh,680px)}
   .portlet-header{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border-bottom:1px solid var(--line);cursor:pointer;background:rgba(255,255,255,0.03);user-select:none}
   .portlet-title{font-weight:800;font-size:13px}
   .portlet-actions{display:flex;gap:6px;align-items:center}
   .count{font-size:11px;background:rgba(134,170,240,0.2);color:var(--accent);padding:2px 8px;border-radius:999px;font-weight:700}
-  .portlet-body{flex:1;overflow:auto}
+  .portlet-body{flex:1;overflow:auto;min-height:0}
   .item{padding:10px 12px;border-bottom:1px solid var(--line)}
   .item:last-child{border-bottom:none}
   .headline{font-weight:700;font-size:13px;display:block;margin-bottom:6px}
@@ -91,6 +91,7 @@
   .notif{position:fixed;right:16px;bottom:16px;background:var(--success);color:#000;padding:10px 14px;border-radius:10px;box-shadow:var(--shadow);opacity:0;transform:translateY(8px);transition:all .25s}
   .notif.show{opacity:1;transform:translateY(0)}
   .danger{background:var(--warning)!important;color:#000}
+  .portlet.dragging{opacity:.6;border-color:var(--accent)}
 </style>
 </head>
 <body>
@@ -294,7 +295,7 @@ function buildDashboard(){
 }
 
 function makePortlet(sec, idx){
-  const card = document.createElement('div'); card.className='portlet collapsed'; card.dataset.section=String(idx);
+  const card = document.createElement('div'); card.className='portlet collapsed'; card.dataset.section=String(idx); card.draggable = true;
   const header = document.createElement('div'); header.className='portlet-header';
   const title = document.createElement('div'); title.className='portlet-title'; title.textContent = sec.label || '(Untitled)';
   const actions = document.createElement('div'); actions.className='portlet-actions';
@@ -302,6 +303,7 @@ function makePortlet(sec, idx){
   actions.appendChild(count); header.appendChild(title); header.appendChild(actions);
   const body = document.createElement('div'); body.className='portlet-body'; body.innerHTML='<div class="empty">No content yet</div>';
   header.addEventListener('click', ()=>{
+    if (card.classList.contains('dragging')) return;
     const column = card.parentElement;
     Array.from(column.children).forEach(el => { if (el!==card) { el.classList.remove('expanded'); el.classList.add('collapsed'); } });
     const isExpanded = card.classList.contains('expanded');
@@ -310,6 +312,29 @@ function makePortlet(sec, idx){
     } else {
       card.classList.remove('collapsed'); card.classList.add('expanded');
     }
+  });
+
+  card.addEventListener('dragstart', (e)=>{
+    card.classList.add('dragging');
+    window.__dragPortlet = card;
+    if (e.dataTransfer){ e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', card.dataset.section || ''); }
+  });
+  card.addEventListener('dragend', ()=>{ card.classList.remove('dragging'); window.__dragPortlet = null; });
+  card.addEventListener('dragover', (e)=>{ e.preventDefault(); if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'; });
+  card.addEventListener('drop', (e)=>{
+    e.preventDefault();
+    const dragging = window.__dragPortlet;
+    if (!dragging || dragging === card) return;
+    const from = Number(dragging.dataset.section);
+    const to = Number(card.dataset.section);
+    if (!Number.isInteger(from) || !Number.isInteger(to) || from < 0 || to < 0 || from === to) return;
+    const moved = state.sections.splice(from, 1)[0];
+    state.sections.splice(to, 0, moved);
+    buildConfigUI();
+    buildDashboard();
+    saveConfig();
+    refreshAll();
+    toast('Portlet order updated');
   });
   card.appendChild(header); card.appendChild(body); return card;
 }

--- a/kanban.html
+++ b/kanban.html
@@ -307,7 +307,7 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
     <div class="field">
       <label for="fFiles">Attachments</label>
       <div class="row">
-        <input id="fFiles" type="file" multiple />
+        <input id="fFiles" type="file" multiple accept="image/*,video/*,text/html,text/plain,text/rtf,text/markdown,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pdf,.xlsx,.docx,.pptx,.html,.htm,.txt,.rtf,.md" />
         <button id="btnClearFiles" type="button" class="btn small">Clear selection</button>
       </div>
       <div id="fileChips" class="chips" aria-live="polite"></div>


### PR DESCRIPTION
### Motivation
- Resolve broken drag-and-drop and spacing behavior for dashboard portlets so portlets scale and reorder correctly when layout/slider changes.
- Prevent accidental toggle of portlet expansion while dragging and provide visual drag feedback.
- Add requested document, text, image and video MIME types to attachment inputs so files like `.pdf`, `.xlsx`, `.docx`, `.pptx`, `.html`, `.txt`, `.rtf`, and `.md` are accepted.

### Description
- Adjusted expanded card sizing in `home.html` by changing `.portlet.expanded` to `flex:0 0 auto` with `min-height:220px` and `max-height:min(60vh,680px)`, and ensured `.portlet-body` has `min-height:0` to avoid large white gaps.
- Added `.portlet.dragging` CSS for visual feedback and a guard in the header click handler to ignore clicks while a portlet has the `dragging` class in `home.html`.
- Made dashboard portlets draggable in `home.html` by setting `card.draggable = true` and adding `dragstart`/`dragend`/`dragover`/`drop` handlers that update `state.sections`, call `buildConfigUI()`, `buildDashboard()`, `saveConfig()`, and `refreshAll()` to persist and reflect reordered portlets.
- Expanded the file input `#fFiles` `accept` attribute in `kanban.html` to include `image/*,video/*,text/html,text/plain,text/rtf,text/markdown,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation` and the common extensions `.pdf,.xlsx,.docx,.pptx,.html,.htm,.txt,.rtf,.md`.

### Testing
- No automated unit/integration test suite was run for this change (none available for these static HTML pages).
- Performed repository-level sanity checks by running `git -C /workspace/stuff status --short` and `git -C /workspace/stuff log -1 --oneline`, and committed the changes with `git -C /workspace/stuff commit`, which succeeded.
- Code changes were validated by automated text searches (`rg`) and by committing the edited files `home.html` and `kanban.html` without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6ad230e8832dbed56fda67f625e4)