### PR TITLE
Remove stale addBtn listener to fix startup error

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -883,7 +883,6 @@ function buildInlineTagEditor(tagArr){
 
   tagIn.addEventListener("keydown", e=>{ if(e.key==="Enter"||e.key===","){ e.preventDefault(); e.stopPropagation(); commitInput(); } });
   tagIn.addEventListener("input", ()=> renderSuggestions());
-  addBtn.addEventListener("click", e=>{ e.stopPropagation(); commitInput(); });
 
   renderAssigned(); renderSuggestions();
   return wrap;


### PR DESCRIPTION
### Motivation
- The inline tag editor previously referenced a removed `addBtn`, causing a `ReferenceError` on startup when the UI no longer provides that element.

### Description
- Remove the single stale line binding `addBtn.addEventListener("click", ...)` from `buildInlineTagEditor` in `kanban.html` to eliminate the undefined reference.

### Testing
- Ran `rg -n "addBtn" kanban.html` to confirm the identifier is no longer present and inspected the `git` diff for a one-line removal, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea86d6c3b8832d9b640de1e5210e14)