### PR TITLE
Prevent notes interactions from triggering card drag

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -1161,6 +1161,7 @@ function renderCard(card){
   });
   notesPreview.addEventListener("click", (e)=>{
     if(e.target.closest("a")) return;
+    if(hasActiveTextSelection()) return;
     e.stopPropagation();
     showInlineNotesEditor();
   });
@@ -1178,6 +1179,18 @@ function renderCard(card){
     }
     e.stopPropagation();
   });
+  const restoreCardDraggable=()=>{
+    if(!hasActiveEditableInCard(el)) el.draggable=true;
+  };
+  notesWrap.addEventListener("pointerdown", (e)=>{
+    e.stopPropagation();
+    el.draggable=false;
+  });
+  notesWrap.addEventListener("pointerup", (e)=>{
+    e.stopPropagation();
+    restoreCardDraggable();
+  });
+  notesWrap.addEventListener("pointercancel", restoreCardDraggable);
   notesWrap.append(notesInput, notesPreview);
   showInlineNotesPreview();
 


### PR DESCRIPTION
### Motivation
- Allow selecting and interacting with text inside the inline Notes area without starting a card drag operation or unexpectedly switching to edit mode.
- Ensure pointer interactions inside the Notes region temporarily disable card dragging so text selection and clicks behave as expected.

### Description
- Added a guard `if(hasActiveTextSelection()) return;` to the `notesPreview` `click` handler to avoid entering the editor when the user is actively selecting text.
- Added `notesWrap` `pointerdown`, `pointerup`, and `pointercancel` handlers and a helper `restoreCardDraggable()` to set `el.draggable = false` while interacting and restore draggability afterwards.

### Testing
- No automated tests were run for this UI/interaction change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8c46e828832d9378c28787f972d2)