### PR TITLE
Harden dragstart guards in renderCard

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -899,12 +899,13 @@ function renderCard(card){
     });
   });
   el.addEventListener("dragstart", e=>{
+    const dragTarget = e.target;
     if(
-      isInteractiveCardTarget(e.target) ||
-      isTextSelectableCardTarget(e.target) ||
+      isInteractiveCardTarget(dragTarget) ||
+      isTextSelectableCardTarget(dragTarget) ||
       hasActiveTextSelection() ||
       hasActiveEditableInCard(el) ||
-      e.target.closest('.card-links,.live-notes-preview,.attachment-list')
+      dragTarget?.closest?.('.card-links,.live-notes-preview,.attachment-list')
     ){
       e.preventDefault();
       return;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `e.target` may be null or not an Element during the `dragstart` handler by normalizing the event target and using a safe `.closest` call.

### Description
- In `renderCard`'s `dragstart` handler normalize the event target with `const dragTarget = e.target;`, replace uses of `e.target` with `dragTarget`, and change the selector check to `dragTarget?.closest?.('.card-links,.live-notes-preview,.attachment-list')`, while preserving the existing `e.preventDefault()` and early-return behavior when any interactive/text-selectable condition is met.

### Testing
- No automated tests were executed in this environment; the change is minimal and scoped to `kanban.html`, and manual browser verification (text selection in notes/editor and drag behavior from non-interactive areas) is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea90109648832db170eb14678b5626)