### PR TITLE
Harden drag target detection for notes text selection

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -700,8 +700,12 @@ document.addEventListener("dragover", e=> e.preventDefault());
 
 let pointerDrag=null;
 let suppressNextCardClick=false;
+function targetClosest(target, selector){
+  const el = target instanceof Element ? target : target?.parentElement;
+  return el?.closest?.(selector) || null;
+}
 function isInteractiveCardTarget(target){
-  return !!target?.closest?.('a,button,input,textarea,select,label,[contenteditable]');
+  return !!targetClosest(target,'a,button,input,textarea,select,label,[contenteditable]');
 }
 function hasActiveTextSelection(){
   const sel = window.getSelection?.();
@@ -716,14 +720,14 @@ function hasActiveEditableInCard(cardEl){
   );
 }
 function isTextSelectableCardTarget(target){
-  return !!target?.closest?.('.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
+  return !!targetClosest(target,'.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
 }
 function hasActiveTextSelection(){
   const sel = window.getSelection?.();
   return !!sel && !sel.isCollapsed && String(sel).trim().length>0;
 }
 function isTextSelectableCardTarget(target){
-  return !!target?.closest?.('.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
+  return !!targetClosest(target,'.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
 }
 function pointerFromCardStart(card, e){
   if(e.pointerType==="mouse") return;
@@ -899,12 +903,13 @@ function renderCard(card){
     });
   });
   el.addEventListener("dragstart", e=>{
+    const dragTarget = e.target;
     if(
-      isInteractiveCardTarget(e.target) ||
-      isTextSelectableCardTarget(e.target) ||
+      isInteractiveCardTarget(dragTarget) ||
+      isTextSelectableCardTarget(dragTarget) ||
       hasActiveTextSelection() ||
       hasActiveEditableInCard(el) ||
-      e.target.closest('.card-links,.live-notes-preview,.attachment-list')
+      targetClosest(dragTarget,'.card-links,.live-notes-preview,.attachment-list')
     ){
       e.preventDefault();
       return;
@@ -1160,24 +1165,37 @@ function renderCard(card){
     showInlineNotesPreview();
   });
   notesPreview.addEventListener("click", (e)=>{
-    if(e.target.closest("a")) return;
+    if(targetClosest(e.target,"a")) return;
+    if(hasActiveTextSelection()) return;
     e.stopPropagation();
     showInlineNotesEditor();
   });
   notesPreview.addEventListener("pointerdown", (e)=>{
-    if(e.target.closest("a")){
+    if(targetClosest(e.target,"a")){
       e.stopPropagation();
       return;
     }
     e.stopPropagation();
   });
   notesPreview.addEventListener("pointerup", (e)=>{
-    if(e.target.closest("a")){
+    if(targetClosest(e.target,"a")){
       e.stopPropagation();
       return;
     }
     e.stopPropagation();
   });
+  const restoreCardDraggable=()=>{
+    if(!hasActiveEditableInCard(el)) el.draggable=true;
+  };
+  notesWrap.addEventListener("pointerdown", (e)=>{
+    e.stopPropagation();
+    el.draggable=false;
+  });
+  notesWrap.addEventListener("pointerup", (e)=>{
+    e.stopPropagation();
+    restoreCardDraggable();
+  });
+  notesWrap.addEventListener("pointercancel", restoreCardDraggable);
   notesWrap.append(notesInput, notesPreview);
   showInlineNotesPreview();
 


### PR DESCRIPTION
## Summary
- added `targetClosest()` helper to safely resolve selectors from event targets that may be text nodes
- switched drag guard checks to use `targetClosest()` so notes/interactive regions are reliably recognized during `dragstart`
- updated notes preview link checks (`click`/`pointerdown`/`pointerup`) to use the same safe target resolution

## Why previous fix failed
- some event targets during text selection are not guaranteed to be `Element` nodes
- `.closest(...)` checks on raw targets were inconsistent/fragile, so drag prevention logic could be skipped

## Testing
- not run (UI interaction change)

## Manual verification
1. Open card details and drag-select text inside Notes preview.
2. Confirm no card drag starts and no drag ghost appears.
3. Confirm notes links remain clickable.
4. Confirm dragging from non-interactive card areas still works.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8c46e828832d9378c28787f972d2)