### PR TITLE
Prefer pointer location for lane detection during touch drag

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -741,7 +741,7 @@ function pointerFromCardMove(cardEl, e){
   if(!pointerDrag.active && moved>12){ pointerDrag.active=true; draggingId=pointerDrag.id; cardEl.classList.add("dragging"); }
   if(!pointerDrag.active) return;
   e.preventDefault();
-  const laneBody=e.target.closest('.lane-body') || document.elementFromPoint(e.clientX,e.clientY)?.closest('.lane-body');
+  const laneBody=document.elementFromPoint(e.clientX, e.clientY)?.closest('.lane-body') || e.target.closest('.lane-body');
   if(!laneBody) return;
   const {index,targetEl}=getDropTarget(laneBody,e.clientY);
   laneBody.dataset.dropIndex=index;
@@ -757,7 +757,7 @@ function pointerFromCardEnd(cardEl, e){
   draggingId=null;
   if(wasActive){
     suppressNextCardClick=true;
-    const laneBody=e.target.closest('.lane-body') || document.elementFromPoint(e.clientX,e.clientY)?.closest('.lane-body');
+    const laneBody=document.elementFromPoint(e.clientX, e.clientY)?.closest('.lane-body') || e.target.closest('.lane-body');
     if(laneBody){ moveToStageAt(dragId,laneBody.closest('.lane').dataset.stage,Number(laneBody.dataset.dropIndex??0)); }
     setHighlight(null);
     return;


### PR DESCRIPTION
### Motivation
- Fix incorrect lane resolution during touch/pointer drags where a captured pointer target could bias the destination so lane detection follows the finger/touch position.

### Description
- In `pointerFromCardMove(cardEl, e)` and `pointerFromCardEnd(cardEl, e)` prefer `document.elementFromPoint(e.clientX, e.clientY)?.closest('.lane-body')` and fall back to `e.target.closest('.lane-body')`, while leaving `card.setPointerCapture?.(e.pointerId)` behavior unchanged.

### Testing
- No automated tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee95c5ea58832d839170c6ebc5fb3f)