### PR TITLE
Fix hangUp flow to always show thank-you screen (bridge5.html)

### DIFF
--- a/bridge5.html
+++ b/bridge5.html
@@ -1342,7 +1342,7 @@ function hidePartnerDisconnected(){
   var ov=$('partner-disconnected-overlay');if(ov)ov.classList.remove('show');
   var rco=$('remote-cam-off');if(rco)rco.classList.remove('show');
 }
-function hangUp(){relaySend({type:'hangup'});if(room.role==='joiner'){showThankYou('You ended the call.');}else{cleanUp();}}
+function hangUp(){relaySend({type:'hangup'});showThankYou('You ended the call.');}
 function cleanUp(){
   saveTr();stopDeepgram();recentFinals=[];pendingCandidates=[];savedOffer=null;savedCandidates=[];var _ci=$('chat-input');if(_ci){_ci.value='';_ci.style.height='';}clearTimeout(wsReconnectTimer);wsReconnectTimer=null;
   if(videoStream){videoStream.getTracks().forEach(function(t){t.stop()});videoStream=null}


### PR DESCRIPTION
### Motivation
- Ensure consistent end-of-call UX by preventing role-based branching in `hangUp()` that sent hosts back to the lobby instead of showing the thank-you screen.

### Description
- Update `hangUp()` in `bridge5.html` to always call `showThankYou('You ended the call.')` instead of conditionally calling `cleanUp()` based on `room.role`.

### Testing
- Ran a targeted pattern check with `rg -n "function hangUp" bridge5.html` to verify the updated function signature, which succeeded.
- Applied the patch and committed the change with `git add bridge5.html && git commit -m "Fix bridge5 hang up flow to show thank-you screen"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f240df48e0832db790960ffb36c180)