### PR TITLE
Harden remote autoplay, normalize subtitles, and select DG model by language in bridge8.html

### DIFF
--- a/bridge8.html
+++ b/bridge8.html
@@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
       </div>
     </div>
     <div id="transcript-body"><div class="tr-empty">Speak or type to see transcript here.</div></div>
-    <div class="transcript-more-indicator" id="transcript-more-indicator" onclick="scrollToBottom()">↓</div>
+    <div class="transcript-more-indicator" id="transcript-more-indicator" onclick="scrollToBottom()">↑</div>
   </div>
   <div class="chat-compose-strip" id="chat-compose-strip">
     <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-icon-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file" style="background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;">📎</button><textarea class="chat-compose-ta" id="chat-input" placeholder="Type a message…" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)"></textarea>
@@ -930,14 +930,17 @@ function handleRelay(d){
   if(d.type==='chat-ack'){_chatOutbox.delete(d.chatId);log('chat_ack',{chatId:d.chatId});return;}
   if(d.type==='webrtc-signal'){handleSig(d);return}
   if(d.type==='subtitle'){
+    var subText=normalizeText(d.text||'','speech');
+    var subSource=normalizeText(d.sourceText||subText,'speech');
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
-    addTr('partner',d.sourceText,d.text,d.sourceLang,d.targetLang,d.subtitleSeq);return;
+    if(subText&&d.targetLang===room.myLang)showSub(subText,'partner');
+    addTr('partner',subSource,subText,d.sourceLang,d.targetLang,d.subtitleSeq);return;
   }
   if(d.type==='subtitle-update'){
+    var patchText=normalizeText(d.text||'','speech');
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
-    patchTr('partner',d.subtitleSeq,d.text,d.sourceLang,d.targetLang);return;
+    if(patchText&&d.targetLang===room.myLang)showSub(patchText,'partner');
+    patchTr('partner',d.subtitleSeq,patchText,d.sourceLang,d.targetLang);return;
   }
   if(d.type==='chat-msg'){handleChatMsg(d);return;}
   if(d.type==='cam-state'){var rco=$('remote-cam-off');if(rco){rco.classList.toggle('show',d.camOn===false);}var rcl=$('remote-cam-off-label');if(rcl)rcl.textContent=L('camera_off');return;}
@@ -985,36 +988,38 @@ async function enterCall(){
 
 // === REMOTE VIDEO ===
 function refreshRemoteVideo(){
-  var callEpoch=sessionEpoch;
-  var playToken=++remotePlayToken;
   var rv=$('remote-video');
   var tracks=remoteStream?remoteStream.getTracks():[];
   var hasVideoTrack=tracks.some(function(t){return t.kind==='video'&&t.readyState==='live'});
   var hasRemoteTrack=tracks.some(function(t){return t.readyState==='live'});
-  var streamKey=remoteStream&&remoteStream.id?remoteStream.id:tracks.map(function(t){return t.id;}).sort().join(',');
-  if(remoteUnmutedKey&&remoteUnmutedKey!==streamKey)remoteUnmutedKey='';
+  var streamId=remoteStream&&(remoteStream.id||'');
+  var unmutedKey=sessionEpoch+':'+streamId;
   log('rtc_refresh',{tracks:tracks.map(function(t){return t.kind+':'+t.readyState}).join(',')});
   if(hasRemoteTrack&&rv.srcObject!==remoteStream){rv.srcObject=remoteStream;}
   rv.playsInline=true;rv.autoplay=true;
   if(hasRemoteTrack){
     rv.muted=true;
-    if(!remotePlayPending){
-      remotePlayPending=true;
-      var tryPlay=rv.play&&rv.play();
-      if(tryPlay&&tryPlay.then){tryPlay.then(function(){
-        if(callEpoch!==sessionEpoch||playToken!==remotePlayToken)return;
-        remotePlayPending=false;rv.muted=false;
-        if(remoteUnmutedKey!==streamKey){remoteUnmutedKey=streamKey;log('rtc_unmuted',{},'ok');}
-      }).catch(function(e){
-        if(callEpoch!==sessionEpoch||playToken!==remotePlayToken)return;
-        remotePlayPending=false;log('rtc_play_err',{e:String(e)},'error');
-      });}
-      else{remotePlayPending=false;}
-    }
+    if(remotePlayPending)return;
+    remotePlayPending=true;
+    var playToken=++remotePlayToken;
+    var playEpoch=sessionEpoch;
+    var playStream=remoteStream;
+    var tryPlay=rv.play&&rv.play();
+    if(tryPlay&&tryPlay.then){tryPlay.then(function(){
+      remotePlayPending=false;
+      if(playToken!==remotePlayToken||playEpoch!==sessionEpoch||playStream!==remoteStream)return;
+      rv.muted=false;
+      if(remoteUnmutedKey!==unmutedKey){remoteUnmutedKey=unmutedKey;log('rtc_unmuted',{},'ok');}
+    }).catch(function(e){
+      remotePlayPending=false;
+      if(playToken!==remotePlayToken||playEpoch!==sessionEpoch||playStream!==remoteStream)return;
+      log('rtc_play_err',{e:String(e)},'error');
+    });}
+    else{remotePlayPending=false;}
     $('solo-banner').style.display='none';
   }
   if(hasVideoTrack){$('no-video-msg').style.display='none';}
-  else{$('no-video-msg').style.display='';if(!hasRemoteTrack&&rv.srcObject){rv.srcObject=null;remoteUnmutedKey='';}}
+  else{$('no-video-msg').style.display='';if(!hasRemoteTrack&&rv.srcObject){rv.srcObject=null;remoteUnmutedKey='';remotePlayToken++;remotePlayPending=false;}}
 }
 function bindRemoteTrackState(track){
   if(!track||track._tbBound)return;track._tbBound=true;
@@ -1023,8 +1028,8 @@ function bindRemoteTrackState(track){
 function resetRemoteMediaState(){
   var rv=$('remote-video');
   if(remoteStream)remoteStream.getTracks().forEach(function(t){t.onunmute=null;t.onmute=null;t.onended=null;});
+  remotePlayToken++;remotePlayPending=false;remoteUnmutedKey='';
   remoteStream=null;rv.srcObject=null;$('no-video-msg').style.display='';
-  remotePlayPending=false;remotePlayToken++;remoteUnmutedKey='';
 }
 
 // === WEBRTC ===
@@ -1184,8 +1189,8 @@ function startDeepgram(){
   if(!videoStream){log('dg_no_stream',{},'error');return}
   if(micMutedByUser){log('dg_skip_muted',{},'warn');return;}
   var langCode=DG_LANGS[room.myLang]||room.myLang||'en-US';
-  var langBase=(langCode||'en').toLowerCase().split('-')[0];
-  var model=langBase==='en'?'nova-3':'nova-2';
+  var langLower=String(langCode||'').toLowerCase();
+  var model=(langLower==='en'||langLower.indexOf('en-')===0)?'nova-3':'nova-2';
   var url='wss://api.deepgram.com/v1/listen?model='+encodeURIComponent(model)+'&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';
   var captureEpoch=sessionEpoch;
   dgWs=new WebSocket(url,['token',key]);


### PR DESCRIPTION
### Motivation
- Improve reliability of remote video autoplay to avoid stale promise callbacks unmuting the player or producing duplicate unmute logs. 
- Ensure inbound subtitles are normalized at the receive boundary to keep transcript/state consistent. 
- Choose Deepgram model more appropriately by language and reduce noisy logging level when skipping open connections. 

### Description
- Updated the transcript jump indicator glyph to an up-arrow (`↑`) while preserving the existing `scrollToBottom()` click behavior. 
- Hardened `refreshRemoteVideo()` with stream identity tracking and in-flight guards by adding token/epoch/stream checks and preventing stale `play()` callbacks from changing mute state or logging; deduped `rtc_unmuted` logs. 
- When remote tracks disappear, cancel any in-flight play state by incrementing the play token and clearing pending flags, while keeping existing `solo-banner`, no-video placeholder, and `srcObject` behavior. 
- Reset remote autoplay guard state early in `resetRemoteMediaState()` by incrementing the token, clearing pending, and clearing the unmuted key before nulling the stream. 
- Normalized inbound `subtitle` and `subtitle-update` messages in `handleRelay(d)` using `normalizeText(...,'speech')` and used normalized values for `showSub(...)`, `addTr(...)`, and `patchTr(...)` without changing role/routing. 
- Adjusted Deepgram model selection in `startDeepgram()` to compute `langLower` and pick `model = (langLower==='en' || langLower.indexOf('en-')===0) ? 'nova-3' : 'nova-2'` and used the `model` in the WebSocket URL; kept `dg_skip_open` logged at `info` and preserved other DG retry/flow logic. 

### Testing
- Inspected the resulting diff with a workspace diff command and confirmed the arrow glyph and functional changes to `refreshRemoteVideo()` and `resetRemoteMediaState()`. (`git -C /workspace/stuff diff -- bridge8.html | sed -n '1,220p'`).
- Printed relevant file regions to verify code placement and surrounding context. (`nl -ba /workspace/stuff/bridge8.html | sed -n '330,350p;924,1018p;1020,1035p;1180,1200p'`).
- Performed an automated commit into the working tree after verification (change recorded successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27a93ccec832d985304a81d3a01ea)