### PR TITLE
Normalize subtitles before display and transcript updates

### DIFF
--- a/bridge8.html
+++ b/bridge8.html
@@ -929,13 +929,16 @@ function handleRelay(d){
   if(d.type==='webrtc-signal'){handleSig(d);return}
   if(d.type==='subtitle'){
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
-    addTr('partner',d.sourceText,d.text,d.sourceLang,d.targetLang,d.subtitleSeq);return;
+    var normText=normalizeText(d.text, 'speech');
+    var normSrc=normalizeText(d.sourceText, 'speech')||normText;
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    addTr('partner',normSrc,normText,d.sourceLang,d.targetLang,d.subtitleSeq);return;
   }
   if(d.type==='subtitle-update'){
     markPartnerTalking();
-    if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');
-    patchTr('partner',d.subtitleSeq,d.text,d.sourceLang,d.targetLang);return;
+    var normText=normalizeText(d.text, 'speech');
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    patchTr('partner',d.subtitleSeq,normText,d.sourceLang,d.targetLang);return;
   }
   if(d.type==='chat-msg'){handleChatMsg(d);return;}
   if(d.type==='cam-state'){var rco=$('remote-cam-off');if(rco){rco.classList.toggle('show',d.camOn===false);}var rcl=$('remote-cam-off-label');if(rcl)rcl.textContent=L('camera_off');return;}


### PR DESCRIPTION
### Motivation
- Ensure subtitle text and source text are normalized before display and transcript insertion so speech subtitles are cleaned/standardized and transcript entries use consistent text.

### Description
- Update `handleRelay` handling for `subtitle` and `subtitle-update` to call `normalizeText(...,'speech')` on `d.text` and on `d.sourceText` (with fallback to the normalized text) and use the normalized values in `showSub`, `addTr`, and `patchTr`.

### Testing
- Ran automated checks including `npm run lint` and `npm test`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f285074c8c832dacb9eb8a972f249a)