### PR TITLE
Improve incremental folder indexing and add draggable divider handle

### DIFF
--- a/folder-v1.html
+++ b/folder-v1.html
@@ -151,7 +151,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .new-notice button{background:var(--blu);color:#fff;border:none;border-radius:3px;padding:2px 8px;font-size:10px;font-weight:700;cursor:pointer;font-family:var(--sans)}
 
 /* ── Divider ── */
-#t-div{background:var(--border);cursor:col-resize;transition:background .15s}
+#t-div{background:var(--border);cursor:col-resize;transition:background .15s;position:relative}
+#t-div::after{content:'';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:10px;height:30px;border-radius:8px;background:rgba(245,158,11,.22);border:1px solid rgba(245,158,11,.35);pointer-events:none}
 #t-div:hover,#t-div.drag{background:var(--acc)}
 
 /* ── Right pane ── */
@@ -911,6 +912,10 @@ const Intel = {
       if(st.acq.cancelled){onLog('⊘ Cancelled');break;}
       const fid=queue.shift();if(visited.has(fid))continue;visited.add(fid);
 
+      const existingFolder=rec.folders[fid];
+      const prevHash=existingFolder?.hash||'';
+      const prevStats=existingFolder?.stats?{...existingFolder.stats,byClass:{...existingFolder.stats.byClass}}:null;
+      const prevCuration=existingFolder?.curation?{...existingFolder.curation}:null;
       if(!rec.folders[fid]){
         rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:folderIds.includes(fid),
           firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],
@@ -961,11 +966,31 @@ const Intel = {
       let allFiles=[];
       try{allFiles=await p.getAllFiles(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
       const folder=rec.folders[fid];const hp=[];
+      allFiles.forEach(f=>{
+        const sigHash=f.md5Checksum||f.file?.hashes?.sha1Hash||f.file?.hashes?.quickXorHash||'';
+        hp.push(`${f.id}:${f.modifiedTime||f.lastModifiedDateTime||''}:${sigHash}`);
+      });
+      const nextHash=simpleHash(hp.sort().join('|'));
+
+      if(prevHash&&prevHash===nextHash&&prevStats&&prevCuration){
+        folder.stats=prevStats;
+        folder.curation=prevCuration;
+        folder.hash=nextHash;
+        folder.status='current';
+        fScanned++;
+        onLog(`  ✓ unchanged — incremental skip`);
+        onProg({folder:fname,fc:fScanned,ic:iCount,total:totalEst});
+        await sleep(12);
+        continue;
+      }
+
+      const priorFileIds=new Set(Object.keys(rec.files).filter(k=>rec.files[k].folderId===fid));
+      const seenFileIds=new Set();
 
       allFiles.forEach(f=>{
         const fr=p.extractFileRecord(f);
         rec.files[fr.id]={...fr,folderId:fid};
-        hp.push(`${fr.id}:${fr.modifiedTime||''}`);
+        seenFileIds.add(fr.id);
         folder.stats.totalFiles++;
         folder.stats.byClass[fr.class]=(folder.stats.byClass[fr.class]||0)+1;
         folder.stats.totalSize+=fr.size;
@@ -980,8 +1005,10 @@ const Intel = {
         if(fr.favorite) folder.curation.favorited++;
         iCount++;
       });
+      priorFileIds.forEach(id=>{if(!seenFileIds.has(id)) delete rec.files[id];});
 
-      folder.hash=simpleHash(hp.sort().join('|'));
+      folder.hash=nextHash;
+      folder.status='current';
       fScanned++;
       onProg({folder:fname,fc:fScanned,ic:iCount,total:totalEst});
       await sleep(30);


### PR DESCRIPTION
### Motivation
- Reduce memory and CPU pressure during folder scans by detecting unchanged folders and avoiding expensive full rebuilds. 
- Improve UX discoverability of the split-pane divider so users can resize the left/right panes easily. 
- Prevent stale file records from accumulating in intelligence state across rescans to avoid state bloat. 

### Description
- Added a visible center handle to the pane divider via CSS (`#t-div::after`) so the divider is clearly draggable (`folder-v1.html`).
- Enhanced folder signature generation in `Intel.acquire` to include provider file-hash fields (`md5Checksum`, `sha1Hash`, `quickXorHash`) together with modified timestamps for more accurate delta detection (`folder-v1.html`).
- Implemented an incremental short-circuit in `Intel.acquire` that preserves previous `stats`/`curation` and skips per-file metadata rebuilding when the folder signature is unchanged (`folder-v1.html`).
- Cleaned up stale `rec.files` entries for files no longer present in a re-scanned folder so deleted files do not persist in the intelligence record (`folder-v1.html`).

### Testing
- Verified the updated file was written and inspected its size using `node -e "const fs=require('fs');const s=fs.readFileSync('folder-v1.html','utf8');console.log('bytes',s.length)"`, which succeeded. 
- Performed static verification with `rg`/`sed` to confirm the new CSS handle and indexing logic lines are present, which succeeded. 
- Performed a workspace status check to confirm no outstanding local changes, which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a42d5fb4832d8f77c064788008ff)