### PR TITLE
Avoid background subfolder fetches and add L1 quick-refresh gating

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -913,17 +913,11 @@ const Tree={
     container.appendChild(node);
 
     // Expand/collapse
-    tog.addEventListener('click',async e=>{
+    tog.addEventListener('click',e=>{
       e.stopPropagation();
       if(!hasKidsActual&&!enrolled)return;
-      if(st.expandedNodes.has(fid)){st.expandedNodes.delete(fid);}
-      else{
-        st.expandedNodes.add(fid);
-        // Lazy load children if unenrolled and not cached
-        if(!enrolled&&!st.treeCache[fid]){
-          try{const subs=await st.provider.getSubfolders(fid);st.treeCache[fid]=subs;}catch(e){}
-        }
-      }
+      if(st.expandedNodes.has(fid))st.expandedNodes.delete(fid);
+      else st.expandedNodes.add(fid);
       this.render();
     });
 
@@ -1313,6 +1307,15 @@ const App={
     if(show){const s=$id('load-step');const sb=$id('load-sub');if(s)s.textContent=step||'';if(sb)sb.textContent=sub||'';}
   },
 
+  shouldQuickRefresh(folderId){
+    if(!st.intel||!st.intel.folders?.[folderId])return false;
+    const isLevelOne=st.levelOneFolders.some(f=>f.id===folderId);
+    if(!isLevelOne)return false;
+    const folderRec=st.intel.folders[folderId];
+    const lastCheck=folderRec.lastQuickRefreshCheck||0;
+    return(Date.now()-lastCheck)>120000;
+  },
+
   selectFolder(folderId,folderName,enrolled){
     // Clear context
     st.selFolderId=folderId;st.selFolderEnrolled=enrolled;
@@ -1329,11 +1332,13 @@ const App={
     }
     // Render right pane
     RightPane.render();
-    // Lazy delta check if enrolled
-    if(enrolled&&st.intel){
+    // Quick non-recursive refresh check only for selected level-1 folders
+    if(enrolled&&this.shouldQuickRefresh(folderId)){
+      const folderRec=st.intel?.folders?.[folderId];
+      if(folderRec)folderRec.lastQuickRefreshCheck=Date.now();
       setTimeout(async()=>{
         try{const changed=await Intel.checkDelta(folderId);if(changed){toast('Changes detected — refresh to re-index','',4000);Tree.render();}}catch(e){}
-      },800);
+      },250);
     }
   },
 


### PR DESCRIPTION
### Motivation
- Level-1 folder list must render near-instantly from the sidecar/index without triggering provider refresh calls or recursive checks until a user explicitly selects a folder.

### Description
- Removed the background async subfolder fetch from the tree expand/collapse handler so toggling nodes no longer triggers provider API calls.
- Added `shouldQuickRefresh(folderId)` to gate quick delta checks to enrolled level-1 folders and to throttle repeated checks with a per-folder timestamp window.
- Modified `selectFolder` to perform a non-recursive, just-in-time `Intel.checkDelta` only when the quick-refresh gate passes and to update the per-folder `lastQuickRefreshCheck` timestamp.
- Left full indexing and the existing acquire/index flow unchanged so comprehensive indexing still occurs when explicitly requested.

### Testing
- Used `rg` and `sed` to locate the relevant code paths and inspect the file before and after the patch, and the inspections completed successfully.
- Ran the Python patch script to apply the changes which printed `patched` indicating the edit was applied.
- Verified the modified file contents with `nl`/`sed` line inspections and a diff review to confirm the intended insertions and deletions were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f19906f8832d94b0e47d9100a581)