### PR TITLE
Improve slash search trigger and phrase drawer dismissal in bridge8

### DIFF
--- a/bridge8-patched.html
+++ b/bridge8-patched.html
@@ -164,6 +164,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .phrase-drawer{position:fixed;left:0;right:0;bottom:-52dvh;height:48dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:12;transition:bottom .18s ease;padding:8px 10px;overflow-y:auto;}
 .phrase-drawer.open{bottom:0;}
 .phrase-mini{border:1px solid rgba(255,255,255,.12);border-radius:10px;padding:8px;margin:8px 0;background:rgba(255,255,255,.03);}
+.phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+.phrase-mini-side{border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:6px;}
+.phrase-mini-meta{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;}
 .phrase-mini-src{font-size:13px;color:var(--text-dim);}
 .phrase-mini-tgt{font-size:13px;color:var(--text);margin-top:2px;}
 .phrase-mini-actions{display:flex;gap:6px;margin-top:6px;}
@@ -347,13 +350,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <div class="transcript-more-indicator" id="transcript-more-indicator" onclick="scrollToBottom()">↓</div>
   </div>
   <div class="chat-compose-strip" id="chat-compose-strip">
-    <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-icon-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file" style="background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;">📎</button><textarea class="chat-compose-ta" id="chat-input" placeholder="Type a message…" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)"></textarea>
+    <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-icon-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file" style="background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;">📎</button><textarea class="chat-compose-ta" id="chat-input" placeholder="help? for commands or type to chat" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)"></textarea>
     <button class="chat-send-btn" id="chat-send-btn" onclick="sendChat()" disabled title="Send">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
     </button>
   </div>
 </div>
-<div class="phrase-drawer" id="phrase-drawer"><div id="phrase-results"></div></div>
+<div class="phrase-drawer" id="phrase-drawer"><div style="display:flex;justify-content:flex-end;"><button onclick="closePhraseDrawer()" style="background:none;border:none;color:var(--text-dim);font-size:18px;line-height:1;">×</button></div><div id="phrase-results"></div></div>
 <input id="phrase-import-file" type="file" accept=".json" style="display:none" onchange="importPhrasebook(event)">
 <div id="toast"></div>
 
@@ -580,7 +583,8 @@ async function sendChat(){
   var ta=$('chat-input');
   var text=normalizeText((ta&&ta.value||''),'chat');if(!text||!room.id)return;
   if(text.indexOf('//')===0){runPhraseCommand(text.slice(2).trim());ta.value='';chatInputEvt();return;}
-  if(text.indexOf('/')===0){runPhraseSearch(text.slice(1));return;}
+  if(text==='help?'){runPhraseCommand('help?');ta.value='';chatInputEvt();return;}
+  if(text.charAt(0)==='/'&&norm(text.slice(1))){runPhraseSearch(text.slice(1));return;}
   ta.value='';ta.style.height='';$('chat-send-btn').disabled=true;
   closePhraseDrawer();
   var src=room.myLang,tgt=room.theirLang;


### PR DESCRIPTION
### Motivation
- Make the integrated phrasebook drawer easier to dismiss and make slash-search behavior less noisy by only triggering on explicit search input and support a visible help command entry point.

### Description
- Add an explicit close (`×`) control to the bottom phrase search drawer and keep it consistent with existing drawer styling. 
- Update compose placeholder to `help? for commands or type to chat`.
- Prevent search from triggering for bare `/` input and require non-empty content after a leading `/` before running search, while routing `help?` through command handling.
- Add minimal CSS helper classes for left/right mini result layout to support upgraded bubble rendering.

### Testing
- Ran `git diff` to verify changes to `bridge8-patched.html` and committed the file; commit succeeded.
- No automated unit tests in repo for UI changes; manual smoke-checks via file diff and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4609aa528832d856f76c7dbc75008)