### PR TITLE
Deterministic RTC recovery ladder and signaling hardening

### DIFF
--- a/bridge8-patched.html
+++ b/bridge8-patched.html
@@ -424,6 +424,8 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null;
 var pendingCandidates=[];
 var savedOffer=null;
 var savedCandidates=[];
+var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_connectTimeoutTimer=null,_seenRemoteCand=new Set();
+var _remoteVideoWatchdogTimer=null,_remoteVideoLastTime=0,_remoteVideoStallCount=0;
 var PHRASE_KEY='tb_standard_phrasebook';
 var phrasebook=[];
 var DEFAULT_PHRASEBOOK=[{id:'seed-hello',source:'Hello',target:'Hola',tags:['greeting'],clarify:['General greeting'],verdict:'good'},{id:'seed-help',source:'Please help me',target:'Por favor ayúdame',tags:['urgent'],clarify:['Ask for help'],verdict:'none'}];
@@ -485,6 +487,7 @@ function teardownSession(mode,reason){
   clearTimeout(wsReconnectTimer);wsReconnectTimer=null;
   makingOffer=false;
   pendingCandidates=[];savedOffer=null;savedCandidates=[];
+  resetRecoveryState();
   saveTr();
   callHistoryPushed=false;
 }
@@ -988,9 +991,11 @@ function handleRelay(d){
       hidePartnerDisconnected();
       resetRemoteMediaState();
       pendingCandidates=[];savedOffer=null;savedCandidates=[];
+      resetRecoveryState();
       if(pc){try{pc.close();}catch(_){}pc=null;}
       $('solo-banner').style.display='';
       setCallPhase('call_connecting','partner_left');
+      armConnectTimeout();
       log('partner_left',{},'info');
     }
     return;
@@ -1012,6 +1017,8 @@ async function enterCall(){
   if(!callHistoryPushed){history.pushState({tbView:'call'},'',location.href);callHistoryPushed=true}
   $('call-screen').classList.add('active');lobbyState=LS.call;
   setCallPhase('call_connecting','enter_call');
+  resetRecoveryState();
+  armConnectTimeout();
   $('local-video').srcObject=videoStream;syncMic();syncCam();updateCallChip();
   var roomMsg='Entering'+(room.name?' '+room.name:'')+'\n'+gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
   toast(roomMsg);
@@ -1050,6 +1057,65 @@ function resetRemoteMediaState(){
   if(remoteStream)remoteStream.getTracks().forEach(function(t){t.onunmute=null;t.onmute=null;t.onended=null;});
   remoteStream=null;rv.srcObject=null;$('no-video-msg').style.display='';
 }
+function resetRecoveryState(){
+  _recoveryLock=false;_recoveryStep=0;_stableSince=null;_seenRemoteCand.clear();
+  clearTimeout(_recoveryTimer);_recoveryTimer=null;
+  clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+  clearInterval(_remoteVideoWatchdogTimer);_remoteVideoWatchdogTimer=null;
+  _remoteVideoLastTime=0;_remoteVideoStallCount=0;
+}
+function armConnectTimeout(){
+  clearTimeout(_connectTimeoutTimer);
+  _connectTimeoutTimer=setTimeout(function(){
+    if(callPhase==='call_connecting')runRecovery('connect_timeout');
+  },12000);
+}
+function startRemoteVideoWatchdog(){
+  clearInterval(_remoteVideoWatchdogTimer);
+  _remoteVideoWatchdogTimer=setInterval(function(){
+    if(callPhase!=='call_live')return;
+    var rv=$('remote-video');
+    if(!rv||!rv.srcObject)return;
+    var now=rv.currentTime||0;
+    if(now<=_remoteVideoLastTime+0.01)_remoteVideoStallCount++;
+    else _remoteVideoStallCount=0;
+    _remoteVideoLastTime=now;
+    if(_remoteVideoStallCount>=4){log('rtc_watchdog_stall',{t:now},'warn');runRecovery('video_stall');}
+  },1000);
+}
+async function runRecovery(reason){
+  if(_recoveryLock||!room.id||lobbyState!==LS.call)return;
+  _recoveryLock=true;
+  _recoveryStep=Math.min(_recoveryStep+1,3);
+  var step=_recoveryStep;
+  log('rtc_recovery_step',{step:step,why:reason},'warn');
+  try{
+    if(step===1){
+      refreshRemoteVideo();
+      startRemoteVideoWatchdog();
+      log('rtc_recovery_done',{step:step},'ok');
+    }else if(step===2){
+      if(pc&&pc.connectionState!=='closed'){
+        await pc.setLocalDescription(await pc.createOffer({iceRestart:true}));
+        var msg={type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}};
+        savedOffer=msg;relaySend(msg);log('rtc_recovery_ice_restart',{},'ok');
+      }
+    }else{
+      if(pc){try{pc.close();}catch(_){}pc=null;}
+      resetRemoteMediaState();
+      pendingCandidates=[];savedCandidates=[];savedOffer=null;
+      _seenRemoteCand.clear();
+      await setupPC();
+      connectRelay();
+      armConnectTimeout();
+      log('rtc_recovery_rebuild',{},'ok');
+    }
+  }catch(e){log('rtc_recovery_err',{step:step,e:String(e)},'error');}
+  finally{
+    clearTimeout(_recoveryTimer);
+    _recoveryTimer=setTimeout(function(){_recoveryLock=false;},800);
+  }
+}
 
 // === WEBRTC ===
 var _keepaliveChannel=null;var _keepaliveTimer=null;
@@ -1087,19 +1153,30 @@ async function setupPC(){
     log('rtc_conn',{s:s},s==='connected'?'ok':s==='failed'?'error':'info');
     if(s==='connected'){
       hidePartnerDisconnected();
-      setCallPhase('call_live','pc_connected');
-      reconcileDeepgramState('pc_connected');
+      clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+      _stableSince=Date.now();
+      clearTimeout(_recoveryTimer);
+      _recoveryTimer=setTimeout(function(){
+        if(!pc||pc.connectionState!=='connected')return;
+        if(_stableSince&&Date.now()-_stableSince>=2000){
+          setCallPhase('call_live','pc_connected_stable');
+          _recoveryStep=0;
+          reconcileDeepgramState('pc_connected_stable');
+          startRemoteVideoWatchdog();
+        }
+      },2000);
     }
     if(s==='disconnected'){
+      _stableSince=null;clearTimeout(_recoveryTimer);
       setCallPhase('call_degraded','pc_disconnected');
       showPartnerDisconnected(L('disconnected'));
+      runRecovery('pc_disconnected');
     }
     if(s==='failed'&&room.id&&lobbyState===LS.call){
+      _stableSince=null;clearTimeout(_recoveryTimer);
       log('rtc_restart',{},'warn');
       setCallPhase('call_degraded','pc_failed');
-      try{pc.close();}catch(_){}pc=null;remoteStream=null;pendingCandidates=[];savedCandidates=[];
-      var rv=document.getElementById('remote-video');if(rv)rv.srcObject=null;
-      setupPC().then(function(){connectRelay();});
+      runRecovery('pc_failed');
     }
   };
   pc.ontrack=function(e){
@@ -1147,11 +1224,15 @@ async function handleSig(d){
         log('rtc_got_answer',{},'ok');
       }
     }else if(d.signal.candidate){
+      var c=d.signal.candidate||{};
+      var cKey=[c.sdpMid||'',c.sdpMLineIndex==null?'':c.sdpMLineIndex,String(c.candidate||'')].join('|');
+      if(_seenRemoteCand.has(cKey)){log('rtc_ice_dupe_drop',{},'warn');return;}
+      _seenRemoteCand.add(cKey);
       if(!pc||!pc.remoteDescription){
-        pendingCandidates.push(d.signal.candidate);
+        pendingCandidates.push(c);
         log('rtc_ice_queued',{n:pendingCandidates.length});
       }else{
-        try{await pc.addIceCandidate(d.signal.candidate);log('rtc_ice_added',{type:d.signal.candidate.type||'?'});}catch(e){log('rtc_ice_add_err',{e:String(e)},'error');}
+        try{await pc.addIceCandidate(c);log('rtc_ice_added',{type:c.type||'?'});}catch(e){log('rtc_ice_add_err',{e:String(e)},'error');}
       }
     }
   }catch(e){log('rtc_sig_err',{e:String(e)},'error')}


### PR DESCRIPTION
### Motivation
- Reduce nondeterministic recovery behavior by replacing passive remote-video rebinding with a bounded, single-flight recovery controller for the RTC path.
- Prevent repeated ICE candidate churn from duplicate inbound signaling and provide a deterministic escalation ladder for connection failures and video stalls.
- Avoid flapping `call_live` transitions by requiring a short stability window before treating a connection as fully live.

### Description
- Added recovery state (`_recoveryLock`, `_recoveryStep`, `_recoveryTimer`, `_stableSince`, `_connectTimeoutTimer`, `_seenRemoteCand`, and watchdog counters) and initialized them in the top-level state in `bridge8-patched.html`.
- Implemented `resetRecoveryState()` and wired it into teardown/reset flows (`teardownSession`, partner-left handling and call entry) to clear locks, timers, and candidate dedupe state.
- Added `armConnectTimeout()` (12s) to escalate when stuck in `call_connecting` and started it on call entry and partner-left reconnect paths.
- Implemented `runRecovery(reason)` as a bounded, single-flight escalation ladder that increments `_recoveryStep` and performs: (1) targeted `refreshRemoteVideo()` and watchdog arm, (2) ICE restart via `createOffer({iceRestart:true})` and relay send, and (3) full peer rebuild (`pc.close()`, clear candidate state, `setupPC()`, `connectRelay()`), with logs and lock/timer management.
- Gated `call_live` in `pc.onconnectionstatechange` to require ~2s of stable `connected` before transitioning and reset stability when leaving `connected`.
- Hardened `handleSig(d)` candidate path by deduplicating inbound ICE candidates via a stable key and dropping duplicates while preserving existing queuing behavior.
- Reworked remote video watchdog to act as a secondary signal and call `runRecovery('video_stall')` on sustained stalls instead of endless rebind loops.
- Scope is strictly limited to `bridge8-patched.html` and changes are minimal and localized to the RTC/signaling/recovery logic.

### Testing
- Ran `git diff -- bridge8-patched.html` to inspect the unified diff of the change and confirm modifications, and the command completed successfully.
- Performed `git add bridge8-patched.html && git commit -m "Add deterministic WebRTC recovery controller"` to record the change, and the commit succeeded.
- No additional automated runtime tests were added in this patch; the edits are limited to `bridge8-patched.html` and existing runtime behavior outside recovery was preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46312231c832d824f16f024b1b6ad)