### PR TITLE
Move indexing enrollment UI into left drawer; make search sticky and relax divider drag bounds

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .lp-acq-wrap{flex-shrink:0;border-top:1px solid var(--border);background:var(--surface)}
 .lp-acq-toggle{width:100%;display:flex;align-items:center;justify-content:space-between;background:transparent;border:none;color:var(--tm);padding:8px 10px;cursor:pointer;font-size:11px}
 .lp-acq-wrap.open .lp-acq-toggle .chev{transform:rotate(90deg)}
-.lp-acq-wrap:not(.open) #rp-acq{display:none}
+.lp-acq-wrap:not(.open) #rp-acq,.lp-acq-wrap:not(.open) #rp-enroll{display:none}
 #rp-acq{flex-shrink:0;background:var(--surface);border-top:1px solid var(--border);padding:10px}
 .acq-fname{font-family:var(--mono);font-size:11px;color:var(--acc);background:var(--raised);padding:7px 11px;border-radius:var(--rs);margin:8px 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .pb-wrap{height:4px;background:var(--raised);border-radius:2px;overflow:hidden;margin-bottom:6px}
@@ -109,7 +109,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .acq-ctrs strong{color:var(--acc)}
 
 /* Enrollment banner */
-#rp-enroll{flex-shrink:0;background:var(--blu-d);border-bottom:1px solid rgba(59,130,246,.2);padding:12px 16px;display:flex;align-items:center;gap:12px}
+#rp-enroll{flex-shrink:0;background:var(--blu-d);border:1px solid rgba(59,130,246,.2);border-radius:var(--rs);padding:10px;display:flex;align-items:center;gap:10px;margin-top:8px}
 #rp-enroll .btn{flex-shrink:0}
 #btn-index-now{white-space:nowrap;word-break:keep-all}
 .enroll-txt{flex:1;font-size:13px;color:var(--blu)}
@@ -121,7 +121,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .load-sub{font-size:11px;color:var(--tm);margin-top:2px}
 
 /* OmniSearch */
-#rp-search{flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}
+#rp-search{position:sticky;top:0;z-index:12;flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}
 #omni-input{flex:1;padding:7px 12px;background:var(--raised);border:1px solid var(--border);border-radius:var(--rs);color:var(--tp);font-family:var(--sans);font-size:13px;outline:none;transition:border-color .15s}
 #omni-input:focus{border-color:var(--bacc)}
 #omni-input::placeholder{color:var(--tm)}
@@ -336,6 +336,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
       <div id="lp-tree"></div>
       <div class="lp-acq-wrap" id="lp-acq-wrap">
         <button class="lp-acq-toggle" id="btn-acq-toggle"><span><span class="chev">▶</span> Indexing</span><span id="acq-mini">Idle</span></button>
+        <div id="rp-enroll" class="hidden">
+          <div style="flex:1">
+            <div class="enroll-txt" id="enroll-txt">Fetching folder list…</div>
+            <div class="enroll-sub" id="enroll-sub">Index to enable search and filters.</div>
+          </div>
+          <button class="btn btn-pri btn-sm" id="btn-index-now">Index Now</button>
+        </div>
         <div id="rp-acq" class="hidden">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
             <span style="font-size:12px;font-weight:600;color:var(--tp)">Indexing Folder</span>
@@ -365,15 +372,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
           <div class="load-step" id="load-step">Loading intelligence…</div>
           <div class="load-sub" id="load-sub"></div>
         </div>
-      </div>
-
-      <!-- Enrollment banner -->
-      <div id="rp-enroll" class="hidden">
-        <div style="flex:1">
-          <div class="enroll-txt" id="enroll-txt">This folder hasn't been indexed yet.</div>
-          <div class="enroll-sub" id="enroll-sub">Index to enable search and filters.</div>
-        </div>
-        <button class="btn btn-pri btn-sm" id="btn-index-now">Index Now</button>
       </div>
 
       <!-- OmniSearch -->
@@ -1417,7 +1415,7 @@ function initEvents(){
 
   const div=$id('l-divider');let dragging=false,sx=0,sw=0;
   div.addEventListener('pointerdown',e=>{dragging=true;div.classList.add('drag');sx=e.clientX;sw=parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--lpw'))||260;div.setPointerCapture(e.pointerId);});
-  div.addEventListener('pointermove',e=>{if(!dragging)return;const nw=Math.max(160,Math.min(480,sw+(e.clientX-sx)));document.documentElement.style.setProperty('--lpw',nw+'px');});
+  div.addEventListener('pointermove',e=>{if(!dragging)return;const minW=80,maxW=Math.max(minW,window.innerWidth-120);const nw=Math.max(minW,Math.min(maxW,sw+(e.clientX-sx)));document.documentElement.style.setProperty('--lpw',nw+'px');});
   div.addEventListener('pointerup',()=>{dragging=false;div.classList.remove('drag');localStorage.setItem(LS_LPW,getComputedStyle(document.documentElement).getPropertyValue('--lpw').trim());});
 
   // OmniSearch


### PR DESCRIPTION
### Motivation
- Consolidate folder indexing status and actions into the left-hand indexing drawer so the right pane is freed from a top banner and indexing state is colocated with folder controls. 
- Keep existing indexing wiring and `Index Now` behavior tied to the selected folder while improving layout ergonomics. 
- Allow users to place the left/right divider more freely while preventing invalid panel sizes.

### Description
- Moved the `#rp-enroll` markup out of the right panel and inserted it inside the left `lp-acq-wrap` under the indexing chevron so indexing copy and the `Index Now` button appear beneath the left drawer toggle and reuse the same IDs/handlers. 
- Updated CSS so closed `lp-acq-wrap` hides both `#rp-acq` and `#rp-enroll`, and adjusted `#rp-enroll` visual rules to fit the left drawer. 
- Removed the right-pane enrollment banner markup so it no longer occupies the top of `#right-panel`. 
- Made the omni search container `#rp-search` sticky with `position: sticky`, `top: 0`, and increased `z-index` to keep it visible while scrolling right-pane content. 
- Relaxed divider drag bounds in the `pointermove` handler to use `minW=80` and `maxW=Math.max(minW, window.innerWidth - 120)` so the divider can be placed broadly while still preventing extremely small/invalid widths; persisted the chosen width as before. 
- Preserved all existing event wiring and logic for `Index Now`, indexing progress UI (`#rp-acq`), and search interactions so no data-model, provider, or backend code was changed.

### Testing
- No automated tests were run for this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5926645b0832dad82ea32efd59aac)