### PR TITLE
Remove blocking folder-list loading banner and surface indexing in left panel

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -115,11 +115,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .enroll-txt{flex:1;font-size:13px;color:var(--blu)}
 .enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px}
 
-/* Intelligence loading */
-#rp-loading{flex-shrink:0;background:var(--raised);border-bottom:1px solid var(--border);padding:10px 14px;display:flex;align-items:center;gap:10px}
-.load-step{font-size:12px;color:var(--ts);flex:1}
-.load-sub{font-size:11px;color:var(--tm);margin-top:2px}
-
 /* OmniSearch */
 #rp-search{position:sticky;top:0;z-index:12;flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}
 #omni-input{flex:1;padding:7px 12px;background:var(--raised);border:1px solid var(--border);border-radius:var(--rs);color:var(--tp);font-family:var(--sans);font-size:13px;outline:none;transition:border-color .15s}
@@ -338,8 +333,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
         <button class="lp-acq-toggle" id="btn-acq-toggle"><span><span class="chev">▶</span> Indexing</span><span id="acq-mini">Idle</span></button>
         <div id="rp-enroll" class="hidden">
           <div style="flex:1">
-            <div class="enroll-txt" id="enroll-txt">Fetching folder list…</div>
-            <div class="enroll-sub" id="enroll-sub">Index to enable search and filters.</div>
+            <div class="enroll-txt" id="enroll-txt">Select a folder to view indexing status.</div>
+            <div class="enroll-sub" id="enroll-sub">Index it once to enable search, filtering, and curation.</div>
           </div>
           <button class="btn btn-pri btn-sm" id="btn-index-now">Index Now</button>
         </div>
@@ -364,15 +359,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 
     <!-- Right panel -->
     <div id="right-panel">
-
-      <!-- Inline loading progress -->
-      <div id="rp-loading" class="hidden">
-        <div class="spin"></div>
-        <div>
-          <div class="load-step" id="load-step">Loading intelligence…</div>
-          <div class="load-sub" id="load-sub"></div>
-        </div>
-      </div>
 
       <!-- OmniSearch -->
       <div id="rp-search">
@@ -1235,23 +1221,15 @@ const App={
     this.setLeftOpen(leftOpen);
     try{
       // Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work.
-      this.showLoading(true,'Fetching folder list…','');
       st.levelOneFolders=await st.provider.getLevelOneFolders();
       st.selFolderId=null;st.selFolderEnrolled=false;
       $id('rp-enroll').classList.add('hidden');
       $id('lp-acq-wrap')?.classList.remove('open');
       Tree.render();
       RightPane.render();
-      this.showLoading(false);
       // Defer intelligence hydration to keep first paint and initial interaction instant.
       setTimeout(()=>{Intel.load().then(()=>{Tree.render();}).catch(()=>{});},0);
-    }catch(e){this.showLoading(false);toast('Load failed: '+e.message,'t-err');}
-  },
-
-  showLoading(show,step,sub){
-    const el=$id('rp-loading');if(!el)return;
-    el.classList.toggle('hidden',!show);
-    if(show){const s=$id('load-step');const sb=$id('load-sub');if(s)s.textContent=step||'';if(sb)sb.textContent=sub||'';}
+    }catch(e){toast('Load failed: '+e.message,'t-err');}
   },
 
   shouldQuickRefresh(folderId){
@@ -1275,7 +1253,7 @@ const App={
     const banner=$id('rp-enroll');if(banner)banner.classList.toggle('hidden',enrolled);
     if(!enrolled){
       const txt=$id('enroll-txt');if(txt)txt.textContent=`"${folderName}" hasn't been indexed yet.`;
-      const sub=$id('enroll-sub');if(sub)sub.textContent='Index to enable search and filters.';
+      const sub=$id('enroll-sub');if(sub)sub.textContent='Index it once to enable search, filtering, and curation.';
     }
     // Render right pane
     RightPane.render();


### PR DESCRIPTION
### Motivation
- The right-side, always-visible "Fetching folder list…" loading banner blocked the UI and caused confusion during startup.
- Indexing activity and progress should be shown in the left-hand Indexing area rather than as a persistent top-right overlay.
- Update explanatory copy to instruct the user to index a folder once to enable search, filtering, and curation.

### Description
- Removed the inline right-panel loading strip (`#rp-loading`) CSS and HTML markup from `folder.html` so the right pane no longer shows a persistent loading banner.
- Removed all startup calls to `showLoading(...)` and deleted the `showLoading` helper from the startup flow so initial folder bootstrap no longer depends on that UI.
- Updated the left-panel enrollment banner copy in `folder.html` to use the new messages: `Select a folder to view indexing status.` and `Index it once to enable search, filtering, and curation.`
- Left the existing left-panel indexing progress UI (`#rp-acq`) and acquisition flow unchanged so all indexing progress remains in the Indexing drawer.

### Testing
- Verified removal of `rp-loading` and `showLoading` references using `rg -n "rp-loading|showLoading\(|Fetching folder list" folder.html` which confirmed the loading strip and helper were removed.
- Confirmed the new left-panel enrollment copy appears in `folder.html` via a code search for the updated strings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f649f9dd0c832dae94c16d65997766)