### PR TITLE
Attachments: open links in new tab and add inline delete

### DIFF
--- a/bridge-patched.html
+++ b/bridge-patched.html
@@ -2206,6 +2206,16 @@ function renderMd(txt){
   s=s.replace(/\n/g,'<br>');
   return s;
 }
+function delAttachment(trId){
+  for(var i=0;i<transcript.length;i++){
+    if((transcript[i].id||(transcript[i].ts+'_'+transcript[i].who))===trId){
+      transcript[i].attachment=null;
+      saveTr();
+      renderTr();
+      return;
+    }
+  }
+}
 function trHtml(e){
   var srcLang=e.srcLang||(e.who==='me'?room.myLang:room.theirLang)||'en';
   var tgtLang=e.tgtLang||(e.who==='me'?room.theirLang:room.myLang)||'en';
@@ -2217,7 +2227,7 @@ function trHtml(e){
   var leftText,rightText,leftLang,rightLang;
   if(isMine){leftText=srcText;rightText=tgtText;leftLang=srcLang;rightLang=tgtLang;}
   else{leftText=tgtText;rightText=srcText;leftLang=tgtLang;rightLang=srcLang;}
-  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style="margin-top:6px;"><a href="#" onclick="attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">[view]</span> '+esc(att.name||'file')+'</a></div>';}
+  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style="margin-top:6px;display:flex;align-items:center;gap:8px;"><a href="'+esc(att.dataUrl)+'" target="_blank" rel="noopener" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg> <span style="text-decoration:underline;">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type="button" onclick="delAttachment('+JSON.stringify(trId)+')" style="background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;">✕</button>':'')+'</div>';}
   var chatClass=e.type==='chat'?' is-chat':'';
   return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
     +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'

--- a/bridge8-patched.html
+++ b/bridge8-patched.html
@@ -2206,6 +2206,16 @@ function renderMd(txt){
   s=s.replace(/\n/g,'<br>');
   return s;
 }
+function delAttachment(trId){
+  for(var i=0;i<transcript.length;i++){
+    if((transcript[i].id||(transcript[i].ts+'_'+transcript[i].who))===trId){
+      transcript[i].attachment=null;
+      saveTr();
+      renderTr();
+      return;
+    }
+  }
+}
 function trHtml(e){
   var srcLang=e.srcLang||(e.who==='me'?room.myLang:room.theirLang)||'en';
   var tgtLang=e.tgtLang||(e.who==='me'?room.theirLang:room.myLang)||'en';
@@ -2217,7 +2227,7 @@ function trHtml(e){
   var leftText,rightText,leftLang,rightLang;
   if(isMine){leftText=srcText;rightText=tgtText;leftLang=srcLang;rightLang=tgtLang;}
   else{leftText=tgtText;rightText=srcText;leftLang=tgtLang;rightLang=srcLang;}
-  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style="margin-top:6px;"><a href="#" onclick="attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">[view]</span> '+esc(att.name||'file')+'</a></div>';}
+  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style="margin-top:6px;display:flex;align-items:center;gap:8px;"><a href="'+esc(att.dataUrl)+'" target="_blank" rel="noopener" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg> <span style="text-decoration:underline;">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type="button" onclick="delAttachment('+JSON.stringify(trId)+')" style="background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;">✕</button>':'')+'</div>';}
   var chatClass=e.type==='chat'?' is-chat':'';
   return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
     +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'


### PR DESCRIPTION
### Motivation
- Fix chat transcript attachments so they open as real clickable links in a new tab and provide a way for the sender to remove their attachment inline.

### Description
- Render attachments as direct anchors using the attachment `dataUrl` with `target="_blank" rel="noopener"` in `bridge-patched.html` and `bridge8-patched.html`.
- Add an inline `✕` delete button displayed for messages from the local user that calls a new `delAttachment(trId)` function to clear the attachment, persist state (`saveTr()`), and re-render (`renderTr()`).
- Changes are limited to `bridge-patched.html` and `bridge8-patched.html`; `bridge-v1.html` and `bridge-v2.html` were inspected and left unchanged.

### Testing
- Searched the codebase for attachment-related occurrences with `rg` to confirm update locations, which succeeded.
- Inspected the updated files with `sed`/`nl` to verify the new `delAttachment` function and updated `attachHtml` markup are present, which succeeded.
- Performed a local review of the generated diff to confirm only the intended small changes were applied, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8232b4510832dba7cbdee8cd31ba2)