### PR TITLE
Move indexing panel to right pane, remove timeline, and harden indexing job handling

### DIFF
--- a/folder-v2.html
+++ b/folder-v2.html
@@ -99,11 +99,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .tn-sub{font-family:var(--mono);font-size:10px;color:var(--tm)}
 
 /* ── Right panel ── */
-/* Index drawer (left panel) */
-.lp-acq-wrap{flex-shrink:0;border-top:1px solid var(--border);background:var(--surface)}
-.lp-acq-toggle{width:100%;display:flex;align-items:center;justify-content:space-between;background:transparent;border:none;color:var(--tm);padding:8px 10px;cursor:pointer;font-size:11px}
-.lp-acq-wrap.open .lp-acq-toggle .chev{transform:rotate(90deg)}
-.lp-acq-wrap:not(.open) #rp-acq,.lp-acq-wrap:not(.open) #rp-enroll{display:none}
 #rp-acq{flex-shrink:0;background:var(--surface);border-top:1px solid var(--border);padding:10px}
 .acq-fname{font-family:var(--mono);font-size:11px;color:var(--acc);background:var(--raised);padding:7px 11px;border-radius:var(--rs);margin:8px 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .pb-wrap{height:4px;background:var(--raised);border-radius:2px;overflow:hidden;margin-bottom:6px}
@@ -119,7 +114,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 #rp-enroll .btn{flex-shrink:0}
 #btn-index-now{white-space:nowrap;word-break:keep-all}
 .enroll-txt{flex:1;font-size:13px;color:var(--blu)}
-.enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px}
+.enroll-sub{font-size:11px;color:#fff;margin-top:2px}
 
 /* OmniSearch */
 #rp-search{position:sticky;top:0;z-index:12;flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}
@@ -128,23 +123,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 #omni-input::placeholder{color:var(--tm)}
 .omni-clear{background:transparent;border:none;color:var(--tm);cursor:pointer;font-size:16px;line-height:1;padding:2px 4px;transition:color .15s}
 .omni-clear:hover{color:var(--ts)}
-
-/* Timeline strip */
-#rp-timeline{flex-shrink:0;background:var(--surface);border-bottom:1px solid var(--border);overflow:hidden;transition:max-height .2s}
-#rp-timeline.tl-open{max-height:180px}
-#rp-timeline.tl-closed{max-height:30px}
-.tl-toggle-bar{display:flex;align-items:center;gap:8px;padding:6px 12px;cursor:pointer;font-size:11px;font-weight:700;color:var(--tm);text-transform:uppercase;letter-spacing:.08em;user-select:none;border-bottom:1px solid transparent}
-.tl-toggle-bar:hover{color:var(--ts)}
-.tl-open .tl-toggle-bar{border-bottom-color:var(--border)}
-.tl-chev{transition:transform .15s;font-size:9px}
-.tl-open .tl-chev{transform:rotate(90deg)}
-.tl-active-seg{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--acc);text-transform:none;letter-spacing:0}
-#tl-chart-area{padding:8px 12px;height:140px;overflow:hidden}
-#tl-svg{width:100%;height:100%}
-.tl-legend{display:flex;gap:8px;flex-wrap:wrap;padding:0 12px 6px;font-size:10px;color:var(--ts)}
-.tl-leg{display:flex;align-items:center;gap:4px;cursor:pointer}
-.tl-leg-dot{width:7px;height:7px;border-radius:2px;flex-shrink:0}
-.tl-leg.muted{opacity:.3}
 
 /* Stats chips */
 #rp-stats{flex-shrink:0;background:var(--surface);border-bottom:1px solid var(--border);padding:6px 10px}
@@ -338,34 +316,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
         <button class="lp-tab active">Tree</button>
       </div>
       <div id="lp-tree"></div>
-      <div class="lp-acq-wrap" id="lp-acq-wrap">
-        <button class="lp-acq-toggle" id="btn-acq-toggle"><span><span class="chev">▶</span> Indexing</span><span id="acq-mini">Idle</span></button>
-        <div id="rp-enroll" class="hidden">
-          <div style="flex:1">
-            <div class="enroll-txt" id="enroll-txt">Select a folder to view indexing status.</div>
-            <div class="enroll-sub" id="enroll-sub">Index it once to enable search, filtering, and curation.</div>
-          </div>
-          <button class="btn btn-pri btn-sm" id="btn-index-now">Index Now</button>
-        </div>
-        <div id="rp-acq" class="hidden">
-          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
-            <span style="font-size:12px;font-weight:600;color:var(--tp)">Indexing Folder</span>
-            <div style="display:flex;gap:6px">
-              <button class="btn btn-ghost btn-sm" id="btn-acq-pause">Pause</button>
-              <button class="btn btn-pri btn-sm hidden" id="btn-acq-resume">Resume</button>
-              <button class="btn btn-danger btn-sm" id="btn-acq-cancel">Cancel</button>
-            </div>
-          </div>
-          <div class="acq-fname" id="acq-folder">Initializing…</div>
-          <div class="pb-wrap"><div class="pb-fill" id="acq-pb"></div></div>
-          <div class="acq-ctrs">
-            <div>Folders: <strong id="acq-fc">0</strong></div>
-            <div>Files: <strong id="acq-ic">0</strong></div>
-            <div>Time: <strong id="acq-el">0s</strong></div>
-          </div>
-          <div class="acq-log" id="acq-log"></div>
-        </div>
-      </div>
     </div>
 
     <div id="l-divider"></div>
@@ -377,6 +327,31 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
             <div id="rp-search">
         <input id="omni-input" placeholder="Search files in this folder…" type="text">
         <button class="omni-clear" id="omni-clear" title="Clear search">✕</button>
+      </div>
+      <div id="rp-enroll" class="hidden" style="margin:8px 10px 0">
+        <div style="flex:1">
+          <div class="enroll-txt" id="enroll-txt">Select a folder to view indexing status.</div>
+          <div class="enroll-sub" id="enroll-sub">Index it once to enable search, filtering, and curation.</div>
+        </div>
+        <button class="btn btn-pri btn-sm" id="btn-index-now">Index Now</button>
+      </div>
+      <div id="rp-acq" class="hidden" style="margin:8px 10px 0">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+          <span style="font-size:12px;font-weight:600;color:var(--tp)">Indexing Folder</span>
+          <div style="display:flex;gap:6px">
+            <button class="btn btn-ghost btn-sm" id="btn-acq-pause">Pause</button>
+            <button class="btn btn-pri btn-sm hidden" id="btn-acq-resume">Resume</button>
+            <button class="btn btn-danger btn-sm" id="btn-acq-cancel">Cancel</button>
+          </div>
+        </div>
+        <div class="acq-fname" id="acq-folder">Initializing…</div>
+        <div class="pb-wrap"><div class="pb-fill" id="acq-pb"></div></div>
+        <div class="acq-ctrs">
+          <div>Folders: <strong id="acq-fc">0</strong></div>
+          <div>Files: <strong id="acq-ic">0</strong></div>
+          <div>Time: <strong id="acq-el">0s</strong></div>
+        </div>
+        <div class="acq-log" id="acq-log"></div>
       </div>
 
       <!-- Stats chips -->
@@ -487,7 +462,7 @@ const st={
   newChildren:[],
   ui:{
     leftOpen:true,view:'list',
-    search:'',classFilter:null,stackFilter:null,tlSegment:null,tlOpen:false,tlHidden:new Set(),
+    search:'',classFilter:null,stackFilter:null,
     sortCol:'effectiveDate',sortDir:'desc',
     expandedItemId:null,fabItemId:null,
     selectedIds:new Set(),
@@ -924,23 +899,13 @@ const RightPane={
     if(st.ui.search){const t=st.ui.search.toLowerCase();files=files.filter(f=>f.name.toLowerCase().includes(t));}
     if(st.ui.classFilter)files=files.filter(f=>f.class===st.ui.classFilter);
     if(st.ui.stackFilter)files=files.filter(f=>f.stack===st.ui.stackFilter);
-    if(st.ui.tlSegment){
-      files=files.filter(f=>{
-        if(!f.effectiveDate)return false;
-        const d=new Date(f.effectiveDate);if(isNaN(d))return false;
-        const seg=st.ui.tlSegment;
-        if(seg.type==='year')return d.getFullYear()===seg.value;
-        if(seg.type==='quarter'){const q=Math.floor(d.getMonth()/3)+1;return d.getFullYear()===seg.year&&q===seg.value;}
-        return true;
-      });
-    }
     const col=st.ui.sortCol,dir=st.ui.sortDir==='asc'?1:-1;
     files.sort((a,b)=>{let va=a[col]??'',vb=b[col]??'';return(typeof va==='string'?va.localeCompare(vb):va-vb)*dir;});
     return files;
   },
 
   render(){
-    this.renderStats();this.renderTimeline();this.renderContent();this.renderFooter();
+    this.renderStats();this.renderContent();this.renderFooter();
     // Update sort buttons
     document.querySelectorAll('.sort-btn').forEach(b=>{b.classList.toggle('active',b.dataset.col===st.ui.sortCol);});
     const sortDirBtn=$id('sort-dir-btn');if(sortDirBtn)sortDirBtn.textContent=st.ui.sortDir==='asc'?'↑':'↓';
@@ -975,67 +940,6 @@ const RightPane={
     curEl.appendChild(summary);
   },
 
-  renderTimeline(){
-    const tl=$id('rp-timeline');if(!tl)return;
-    tl.classList.toggle('tl-open',st.ui.tlOpen);tl.classList.toggle('tl-closed',!st.ui.tlOpen);
-    const chev=tl.querySelector('.tl-chev');if(chev)chev.style.transform=st.ui.tlOpen?'rotate(90deg)':'';
-    if(!st.ui.tlOpen)return;
-    const seg=$id('tl-active-seg');if(seg)seg.textContent=st.ui.tlSegment?`${st.ui.tlSegment.type==='year'?st.ui.tlSegment.value:`Q${st.ui.tlSegment.value} ${st.ui.tlSegment.year}`} ✕`:'';
-    const files=Intel.getDescendantFiles(st.selFolderId||'').filter(f=>f.effectiveDate);
-    this.drawTimeline(files);this.renderTimelineLegend(files);
-  },
-
-  drawTimeline(files){
-    const svg=$id('tl-svg');if(!svg)return;svg.innerHTML='';
-    const area=$id('tl-chart-area');if(!area)return;
-    const W=area.clientWidth||400,H=110;
-    const pad={l:30,r:10,t:8,b:24};
-    const cW=W-pad.l-pad.r,cH=H-pad.t-pad.b;
-    // Group by year
-    const map=new Map();
-    files.forEach(f=>{
-      const d=new Date(f.effectiveDate);if(isNaN(d))return;
-      const yr=d.getFullYear();if(!map.has(yr))map.set(yr,Object.fromEntries(CLASS_KEYS.map(k=>[k,0])));
-      map.get(yr)[f.class]=(map.get(yr)[f.class]||0)+1;
-    });
-    const buckets=Array.from(map.entries()).sort((a,b)=>a[0]-b[0]);if(!buckets.length)return;
-    const activeClasses=CLASS_KEYS.filter(k=>!st.ui.tlHidden.has(k));
-    const maxTotal=Math.max(...buckets.map(([,c])=>activeClasses.reduce((s,k)=>s+(c[k]||0),0)),1);
-    const bw=Math.max(8,Math.min(40,Math.floor((cW/buckets.length)*0.7)));
-    const gap=cW/buckets.length;
-    svg.setAttribute('viewBox',`0 0 ${W} ${H}`);svg.setAttribute('width',W);svg.setAttribute('height',H);
-    // gridlines
-    [0.5,1].forEach(p=>{const y=pad.t+cH*(1-p);const line=document.createElementNS('http://www.w3.org/2000/svg','line');line.setAttribute('x1',pad.l);line.setAttribute('x2',pad.l+cW);line.setAttribute('y1',y);line.setAttribute('y2',y);line.setAttribute('stroke','rgba(255,255,255,0.04)');svg.appendChild(line);});
-    buckets.forEach(([yr,counts],i)=>{
-      const cx=pad.l+i*gap+gap/2;let yOff=0;
-      activeClasses.slice().reverse().forEach(cls=>{
-        const n=counts[cls]||0;if(!n)return;
-        const bH=(n/maxTotal)*cH;const y=pad.t+cH-yOff-bH;
-        const rect=document.createElementNS('http://www.w3.org/2000/svg','rect');
-        rect.setAttribute('x',cx-bw/2);rect.setAttribute('y',y);rect.setAttribute('width',bw);rect.setAttribute('height',bH);
-        rect.setAttribute('fill',CLASS_DEF[cls]?.color||'#888');rect.setAttribute('opacity','0.85');rect.style.cursor='pointer';
-        rect.addEventListener('click',()=>{st.ui.tlSegment={type:'year',value:yr};const segEl=$id('tl-active-seg');if(segEl)segEl.textContent=`${yr} ✕`;this.render();});
-        svg.appendChild(rect);yOff+=bH;
-      });
-      const txt=document.createElementNS('http://www.w3.org/2000/svg','text');
-      txt.setAttribute('x',cx);txt.setAttribute('y',pad.t+cH+14);txt.setAttribute('text-anchor','middle');
-      txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');
-      txt.textContent=String(yr).slice(2);txt.style.cursor='pointer';
-      txt.addEventListener('click',()=>{st.ui.tlSegment={type:'year',value:yr};this.render();});
-      svg.appendChild(txt);
-    });
-  },
-
-  renderTimelineLegend(files){
-    const el=$id('tl-legend');if(!el)return;el.innerHTML='';
-    CLASS_KEYS.forEach(cls=>{
-      if(!files.some(f=>f.class===cls))return;
-      const item=document.createElement('div');item.className='tl-leg'+(st.ui.tlHidden.has(cls)?' muted':'');
-      item.innerHTML=`<div class="tl-leg-dot" style="background:${CLASS_DEF[cls].color}"></div>${CLASS_DEF[cls].label}`;
-      item.addEventListener('click',()=>{if(st.ui.tlHidden.has(cls))st.ui.tlHidden.delete(cls);else st.ui.tlHidden.add(cls);this.renderTimeline();});
-      el.appendChild(item);
-    });
-  },
 
   renderContent(){
     const content=$id('rp-content');if(!content)return;
@@ -1227,8 +1131,7 @@ const App={
       st.levelOneFolders=await st.provider.getLevelOneFolders();
       st.selFolderId=null;st.selFolderEnrolled=false;
       $id('rp-enroll').classList.add('hidden');
-      $id('lp-acq-wrap')?.classList.remove('open');
-      Tree.render();
+            Tree.render();
       RightPane.render();
       // Defer intelligence hydration to keep first paint and initial interaction instant.
       setTimeout(()=>{Intel.load().then(()=>{Tree.render();}).catch(()=>{});},0);
@@ -1247,16 +1150,21 @@ const App={
   selectFolder(folderId,folderName,enrolled){
     // Clear context
     st.selFolderId=folderId;st.selFolderEnrolled=enrolled;
-    st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;st.ui.tlSegment=null;
+    st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;
     st.ui.expandedItemId=null;st.ui.fabItemId=null;st.ui.portalPage=1;st.ui.selectedIds=new Set();
     const omni=$id('omni-input');if(omni)omni.value='';
     // Update tree selection
     Tree.render();
     // Show/hide enrollment banner
-    const banner=$id('rp-enroll');if(banner)banner.classList.toggle('hidden',enrolled);
+    const banner=$id('rp-enroll');
+    const acqPanel=$id('rp-acq');
+    const job=st.acqJobs[folderId];
+    const hasIncompleteJob=!!(job&&!job.running&&!job.completed);
+    if(acqPanel&&job?.running)acqPanel.classList.remove('hidden');
+    if(banner)banner.classList.toggle('hidden',enrolled||job?.running);
     if(!enrolled){
       const txt=$id('enroll-txt');if(txt)txt.textContent=`"${folderName}" hasn't been indexed yet.`;
-      const sub=$id('enroll-sub');if(sub)sub.textContent='Index it once to enable search, filtering, and curation.';
+      const sub=$id('enroll-sub');if(sub)sub.textContent=hasIncompleteJob?'Indexing stalled. Resume from saved progress or cancel to restart.':'Index it once to enable search, filtering, and curation.';
     }
     // Render right pane
     RightPane.render();
@@ -1272,21 +1180,23 @@ const App={
 
   async startIndexing(folderId,folderName){
     const activeJob=st.acqJobs[folderId];
-    if(activeJob?.cancelled){
-      if(!confirm(`Resume indexing "${folderName}" from previous progress?`))return;
+    if(activeJob?.running){toast('Indexing already in progress for this folder','',2200);return;}
+    if(activeJob&&!activeJob.completed){
+      const resume=await confirm2(`"${folderName}" has incomplete indexing progress. Proceed to resume from checkpoint?`);
+      if(!resume)return;
     }
-    if(st.workerPool.active>=st.workerPool.max){toast('slot not available, try again later','',2200);return;}
+    if(st.workerPool.active>=5){toast('slot not available, try again later','',2200);return;}
     st.workerPool.active++;
+    let slotReleased=false;
+    const releaseSlot=()=>{if(slotReleased)return;slotReleased=true;st.workerPool.active=Math.max(0,st.workerPool.active-1);};
     $id('rp-enroll').classList.add('hidden');
-    $id('lp-acq-wrap')?.classList.add('open');
     $id('rp-acq').classList.remove('hidden');
-    st.acq={running:true,cancelled:false,paused:false,t0:Date.now(),tick:null};
-    st.acqJobs[folderId]={running:true,cancelled:false,paused:false,lastFolder:folderName};
+    st.acq={running:true,cancelled:false,paused:false,t0:Date.now(),tick:null,folderId};
+    st.acqJobs[folderId]={...(activeJob||{}),running:true,cancelled:false,paused:false,lastFolder:folderName};
     $id('acq-log').innerHTML='';$id('acq-pb').style.width='0%';
     st.acq.tick=setInterval(()=>{const el=$id('acq-el');if(el)el.textContent=Math.round((Date.now()-st.acq.t0)/1000)+'s';},1000);
     const onProg=({folder,fc,ic})=>{
       const fn=$id('acq-folder'),fc2=$id('acq-fc'),ic2=$id('acq-ic'),pb=$id('acq-pb');
-      const mini=$id('acq-mini');if(mini)mini.textContent='Indexing…';
       if(fn)fn.textContent=folder||'…';if(fc2)fc2.textContent=fc;if(ic2)ic2.textContent=ic;
       if(pb)pb.style.width=Math.min(99,Math.round(ic/Math.max(1,ic+1)*50+fc*2))+'%';
     };
@@ -1297,8 +1207,7 @@ const App={
       st.acq.running=false;
       st.acq.paused=false;
       st.acqJobs[folderId]={running:false,cancelled:false,paused:false,lastFolder:folderName,completed:true};
-      st.workerPool.active=Math.max(0,st.workerPool.active-1);
-      const mini=$id('acq-mini');if(mini)mini.textContent='Complete';
+      releaseSlot();
       await sleep(500);
       $id('rp-acq').classList.add('hidden');
       st.selFolderEnrolled=true;Tree.render();RightPane.render();
@@ -1306,9 +1215,8 @@ const App={
     }catch(e){
       clearInterval(st.acq.tick);logLine(`✖ ${e.message}`);st.acq.running=false;
       st.acq.paused=false;
-      st.acqJobs[folderId]={running:false,cancelled:true,paused:false,lastFolder:folderName};
-      st.workerPool.active=Math.max(0,st.workerPool.active-1);
-      const mini=$id('acq-mini');if(mini)mini.textContent='Error';
+      st.acqJobs[folderId]={...(st.acqJobs[folderId]||{}),running:false,cancelled:true,paused:false,lastFolder:folderName,completed:false};
+      releaseSlot();
       toast('Indexing failed: '+e.message,'t-err');
     }
   },
@@ -1424,27 +1332,24 @@ function initEvents(){
     if(!confirm(`Index "${folder.name||st.selFolderId}" now?`))return;
     App.startIndexing(st.selFolderId,folder.name||st.selFolderId);
   });
-  $id('btn-acq-toggle').addEventListener('click',()=>{$id('lp-acq-wrap')?.classList.toggle('open');});
   $id('btn-acq-cancel').addEventListener('click',()=>{
     st.acq.cancelled=true;clearInterval(st.acq.tick);
-    if(st.selFolderId&&st.acqJobs[st.selFolderId]){st.acqJobs[st.selFolderId].cancelled=true;st.acqJobs[st.selFolderId].running=false;}
-    st.workerPool.active=Math.max(0,st.workerPool.active-1);
-    const mini=$id('acq-mini');if(mini)mini.textContent='Paused';
-    setTimeout(()=>{$id('rp-acq').classList.add('hidden');},500);
+    const fid=st.acq.folderId||st.selFolderId;
+    if(fid&&st.acqJobs[fid]){st.acqJobs[fid].cancelled=true;st.acqJobs[fid].running=false;st.acqJobs[fid].completed=false;}
+    if(st.selFolderId===fid){const sub=$id('enroll-sub');if(sub)sub.textContent='Indexing stalled. Resume from saved progress or cancel to restart.';$id('rp-enroll')?.classList.remove('hidden');}
+    setTimeout(()=>{$id('rp-acq').classList.add('hidden');},300);
   });
   $id('btn-acq-pause').addEventListener('click',()=>{
     st.acq.paused=true;
     if(st.selFolderId&&st.acqJobs[st.selFolderId])st.acqJobs[st.selFolderId].paused=true;
     $id('btn-acq-pause')?.classList.add('hidden');
     $id('btn-acq-resume')?.classList.remove('hidden');
-    const mini=$id('acq-mini');if(mini)mini.textContent='Paused';
   });
   $id('btn-acq-resume').addEventListener('click',()=>{
     st.acq.paused=false;
     if(st.selFolderId&&st.acqJobs[st.selFolderId]){st.acqJobs[st.selFolderId].paused=false;st.acqJobs[st.selFolderId].cancelled=false;}
     $id('btn-acq-resume')?.classList.add('hidden');
     $id('btn-acq-pause')?.classList.remove('hidden');
-    const mini=$id('acq-mini');if(mini)mini.textContent='Indexing…';
   });
 
   // View tabs
@@ -1454,6 +1359,7 @@ function initEvents(){
       document.querySelectorAll('.vtab').forEach(b=>b.classList.toggle('active',b===btn));
       $id('sort-strip').classList.toggle('hidden',st.ui.view!=='list');
       $id('portal-strip').classList.toggle('hidden',st.ui.view!=='portal');
+      $id('density-slider')?.closest('.density-wrap')?.classList.toggle('hidden',st.ui.view!=='portal');
       RightPane.renderContent();
     });
   });
@@ -1471,8 +1377,6 @@ function initEvents(){
     const p=new URLSearchParams(window.location.search);const code=p.get('code'),error=p.get('error');
     if(window.opener){window.opener.postMessage(code?{type:'GOOGLE_AUTH_SUCCESS',code}:{type:'GOOGLE_AUTH_ERROR',error},window.location.origin);window.close();}
   }
-
-  // Resize: redraw timeline
 }
 
 // ── Boot ──────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Surface indexing/enrollment controls in the right panel for clearer context next to search and file lists.
- Simplify the UI by removing the timeline feature and related state to reduce complexity.
- Make indexing start/resume/cancel behavior and worker-slot accounting more robust across paused/incomplete jobs.

### Description
- Moved the enrollment and acquisition blocks (`#rp-enroll`, `#rp-acq`) out of the left `lp-acq-wrap` into the right panel after `#rp-search`, removed the left-panel toggle and its CSS, and adjusted styles (including `.enroll-sub` color).
- Removed timeline UI and logic including `#rp-timeline` CSS, `renderTimeline`, `drawTimeline`, `renderTimelineLegend`, and timeline-related state/filters (e.g. `tlSegment`, `tlHidden`) and references in `getFilteredFiles` and `render`.
- Reworked indexing job management by tracking per-folder jobs in `st.acqJobs`, adding `folderId` to `st.acq`, preserving incomplete job state, updating the resume confirmation flow, and improving cancel/pause/resume handlers and messages shown in the enrollment banner.
- Strengthened worker-slot handling by replacing direct decrements with a guarded `releaseSlot` helper to avoid double-release, capping concurrent slots, and merging existing job state when resuming.
- Updated event wiring and view toggles (removed `btn-acq-toggle`, adjusted portal density visibility) and cleaned up unused mini status element usage.

### Testing
- Ran the project linter with `npm run lint` and it completed without errors.
- Executed the unit test suite with `npm test` and all tests passed.
- Performed an automated build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc87d128cc832db77d7b64c3fe5a9a)