### PR TITLE
Add NimbusFlight touch-control wrapper

### DIFF
--- a/nimbusflight-touch-wrapper.html
+++ b/nimbusflight-touch-wrapper.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>NimbusFlight Touch Wrapper</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+        background: #020617;
+        color: #fff;
+        min-height: 100vh;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+      }
+      header, footer {
+        padding: 0.75rem 1rem;
+        background: #0f172a;
+        border-color: #1e293b;
+      }
+      header { border-bottom: 1px solid #1e293b; }
+      footer { border-top: 1px solid #1e293b; font-size: 0.8rem; color: #94a3b8; }
+      h1 { margin: 0; font-size: 1rem; }
+      .sub { margin: 0.25rem 0 0; color: #cbd5e1; font-size: 0.875rem; }
+      main { display: grid; grid-template-rows: 1fr auto; min-height: 0; }
+      iframe { width: 100%; height: 100%; border: 0; background: #000; }
+      .controls {
+        border-top: 1px solid #1e293b;
+        background: #0f172a;
+        padding: 0.75rem;
+        display: grid;
+        gap: 0.5rem;
+      }
+      .row { display: flex; justify-content: center; gap: 0.5rem; }
+      button {
+        border: 1px solid #334155;
+        background: #1e293b;
+        color: #fff;
+        border-radius: 0.75rem;
+        font-weight: 700;
+        min-width: 4rem;
+        padding: 0.75rem 1rem;
+        touch-action: none;
+        user-select: none;
+      }
+      button.wide { min-width: 7rem; }
+      button.active { background: #22d3ee; color: #082f49; border-color: #67e8f9; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>NimbusFlight Touch Wrapper</h1>
+      <p class="sub">On-screen controls for play without a physical keyboard.</p>
+    </header>
+
+    <main>
+      <iframe id="game" src="https://nimbusflight.vercel.app/" title="NimbusFlight" allow="fullscreen"></iframe>
+
+      <section class="controls" id="controls"></section>
+    </main>
+
+    <footer>Tip: tap inside the game once after load so it can capture input.</footer>
+
+    <script>
+      const controlRows = [
+        [
+          { label: 'Esc', key: 'Escape', code: 'Escape', keyCode: 27 },
+          { label: 'Enter', key: 'Enter', code: 'Enter', keyCode: 13 }
+        ],
+        [
+          { label: '↑', key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+          { label: 'W', key: 'w', code: 'KeyW', keyCode: 87 },
+          { label: 'Space', key: ' ', code: 'Space', keyCode: 32, wide: true }
+        ],
+        [
+          { label: '←', key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+          { label: '↓', key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+          { label: '→', key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 }
+        ],
+        [
+          { label: 'A', key: 'a', code: 'KeyA', keyCode: 65 },
+          { label: 'S', key: 's', code: 'KeyS', keyCode: 83 },
+          { label: 'D', key: 'd', code: 'KeyD', keyCode: 68 },
+          { label: 'Shift', key: 'Shift', code: 'ShiftLeft', keyCode: 16 }
+        ]
+      ];
+
+      const game = document.getElementById('game');
+      const controlsRoot = document.getElementById('controls');
+      const active = new Set();
+
+      function makeEvent(type, c) {
+        return new KeyboardEvent(type, {
+          key: c.key,
+          code: c.code,
+          keyCode: c.keyCode,
+          which: c.keyCode,
+          bubbles: true,
+          cancelable: true
+        });
+      }
+
+      function fire(type, control) {
+        window.dispatchEvent(makeEvent(type, control));
+        document.dispatchEvent(makeEvent(type, control));
+        if (game && game.contentWindow) game.contentWindow.focus();
+      }
+
+      function release(control, button) {
+        if (!active.has(control.code)) return;
+        active.delete(control.code);
+        button.classList.remove('active');
+        fire('keyup', control);
+      }
+
+      function press(control, button) {
+        if (active.has(control.code)) return;
+        active.add(control.code);
+        button.classList.add('active');
+        fire('keydown', control);
+      }
+
+      controlRows.forEach((row) => {
+        const rowEl = document.createElement('div');
+        rowEl.className = 'row';
+
+        row.forEach((control) => {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.textContent = control.label;
+          if (control.wide) btn.classList.add('wide');
+
+          btn.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            btn.setPointerCapture(e.pointerId);
+            press(control, btn);
+          });
+          btn.addEventListener('pointerup', () => release(control, btn));
+          btn.addEventListener('pointercancel', () => release(control, btn));
+          btn.addEventListener('lostpointercapture', () => release(control, btn));
+
+          rowEl.appendChild(btn);
+        });
+
+        controlsRoot.appendChild(rowEl);
+      });
+    </script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,139 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
+
+type KeyControl = {
+  label: string;
+  key: string;
+  keyCode: number;
+  code: string;
+  wide?: boolean;
+};
+
+const controlRows: KeyControl[][] = [
+  [
+    { label: 'Esc', key: 'Escape', keyCode: 27, code: 'Escape' },
+    { label: 'Enter', key: 'Enter', keyCode: 13, code: 'Enter' },
+  ],
+  [
+    { label: '↑', key: 'ArrowUp', keyCode: 38, code: 'ArrowUp' },
+    { label: 'W', key: 'w', keyCode: 87, code: 'KeyW' },
+    { label: 'Space', key: ' ', keyCode: 32, code: 'Space', wide: true },
+  ],
+  [
+    { label: '←', key: 'ArrowLeft', keyCode: 37, code: 'ArrowLeft' },
+    { label: '↓', key: 'ArrowDown', keyCode: 40, code: 'ArrowDown' },
+    { label: '→', key: 'ArrowRight', keyCode: 39, code: 'ArrowRight' },
+  ],
+  [
+    { label: 'A', key: 'a', keyCode: 65, code: 'KeyA' },
+    { label: 'S', key: 's', keyCode: 83, code: 'KeyS' },
+    { label: 'D', key: 'd', keyCode: 68, code: 'KeyD' },
+    { label: 'Shift', key: 'Shift', keyCode: 16, code: 'ShiftLeft' },
+  ],
+];
 
 function App() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+
+  const buildKeyboardEvent = useCallback((type: 'keydown' | 'keyup', control: KeyControl) => {
+    return new KeyboardEvent(type, {
+      key: control.key,
+      code: control.code,
+      keyCode: control.keyCode,
+      which: control.keyCode,
+      bubbles: true,
+      cancelable: true,
+    });
+  }, []);
+
+  const fireKey = useCallback(
+    (type: 'keydown' | 'keyup', control: KeyControl) => {
+      window.dispatchEvent(buildKeyboardEvent(type, control));
+      document.dispatchEvent(buildKeyboardEvent(type, control));
+      const frameWindow = iframeRef.current?.contentWindow;
+      frameWindow?.focus();
+    },
+    [buildKeyboardEvent],
+  );
+
+  const press = useCallback(
+    (control: KeyControl) => {
+      setActiveKeys((prev) => new Set(prev).add(control.code));
+      fireKey('keydown', control);
+    },
+    [fireKey],
+  );
+
+  const release = useCallback(
+    (control: KeyControl) => {
+      setActiveKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(control.code);
+        return next;
+      });
+      fireKey('keyup', control);
+    },
+    [fireKey],
+  );
+
   return (
-    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-      <p>Start prompting (or editing) to see magic happen :)</p>
+    <div className="min-h-screen bg-slate-950 text-white flex flex-col">
+      <header className="px-4 py-3 bg-slate-900 border-b border-slate-800">
+        <h1 className="text-lg font-semibold">NimbusFlight Touch Wrapper</h1>
+        <p className="text-sm text-slate-300">Tap and hold buttons to emulate keyboard controls.</p>
+      </header>
+
+      <main className="flex-1 grid grid-rows-[1fr_auto]">
+        <iframe
+          ref={iframeRef}
+          title="NimbusFlight"
+          src="https://nimbusflight.vercel.app/"
+          className="w-full h-full border-0 bg-black"
+          allow="fullscreen"
+        />
+
+        <section className="p-4 bg-slate-900 border-t border-slate-800">
+          <div className="grid gap-2 max-w-2xl mx-auto">
+            {controlRows.map((row, rowIndex) => (
+              <div key={rowIndex} className="flex gap-2 justify-center">
+                {row.map((control) => {
+                  const isActive = activeKeys.has(control.code);
+                  return (
+                    <button
+                      key={control.code}
+                      type="button"
+                      className={`select-none rounded-xl border px-4 py-3 font-semibold transition ${
+                        control.wide ? 'min-w-28' : 'min-w-16'
+                      } ${
+                        isActive
+                          ? 'bg-cyan-500 border-cyan-300 text-slate-950'
+                          : 'bg-slate-800 border-slate-700 hover:bg-slate-700'
+                      }`}
+                      onMouseDown={() => press(control)}
+                      onMouseUp={() => release(control)}
+                      onMouseLeave={() => release(control)}
+                      onTouchStart={(event) => {
+                        event.preventDefault();
+                        press(control);
+                      }}
+                      onTouchEnd={(event) => {
+                        event.preventDefault();
+                        release(control);
+                      }}
+                    >
+                      {control.label}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="px-4 py-2 text-xs text-slate-400 bg-slate-900 border-t border-slate-800">
+        Tip: tap inside the game once after load so it can capture input.
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a mobile/touch-friendly wrapper for the NimbusFlight web game so it can be played without a physical keyboard.
- Replace the placeholder app skeleton with a focused UI that embeds the game and exposes on-screen controls for common gameplay keys.

### Description
- Replaced `src/App.tsx` content to render an iframe pointing to `https://nimbusflight.vercel.app/` and a mobile-styled header/footer.
- Added an on-screen control layout (`Esc`, `Enter`, arrow keys, `W/A/S/D`, `Space`, `Shift`) with touch and mouse handlers in `src/App.tsx`.
- Implemented synthetic `keydown`/`keyup` event dispatching and active-button visual states to emulate press-and-hold behavior.
- Focuses the iframe window when firing events and shows a short usage tip to tap the game once after load.

### Testing
- Performed repository verification and diff inspection via repo checks and confirmed the patched changes applied successfully.
- Printed and reviewed the modified file using `nl -ba src/App.tsx` to verify content and formatting, which succeeded.
- No unit or build tests were added; only static/inspection checks were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69febbdcf044832dae632fdedf233d1a)