### PR TITLE
Touch wrapper: single-row control strip with tap-to-activate LED

### DIFF
--- a/nimbusflight-touch-wrapper.html
+++ b/nimbusflight-touch-wrapper.html
@@ -33,10 +33,17 @@
         border-top: 1px solid #1e293b;
         background: #0f172a;
         padding: 0.75rem;
-        display: grid;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         gap: 0.5rem;
+        flex-wrap: nowrap;
+        overflow-x: auto;
       }
-      .row { display: flex; justify-content: center; gap: 0.5rem; }
+      .status { display: inline-flex; align-items: center; gap: 0.4rem; margin-right: 0.5rem; color: #cbd5e1; font-size: 0.85rem; white-space: nowrap; }
+      .led { width: 0.7rem; height: 0.7rem; border-radius: 999px; background: #334155; box-shadow: inset 0 0 0 1px #475569; }
+      .led.active { background: #22c55e; box-shadow: 0 0 0.35rem #22c55e, inset 0 0 0 1px #14532d; }
+      .row { display: contents; }
       button {
         border: 1px solid #334155;
         background: #1e293b;
@@ -61,10 +68,12 @@
     <main>
       <iframe id="game" src="https://nimbusflight.vercel.app/" title="NimbusFlight" allow="fullscreen"></iframe>
 
-      <section class="controls" id="controls"></section>
+      <section class="controls" id="controls">
+        <div class="status"><span class="led" id="panel-led"></span><span id="panel-state">Panel inactive</span></div>
+      </section>
     </main>
 
-    <footer>Tip: tap inside the game once after load so it can capture input.</footer>
+    <footer>Tap the game surface once to activate controls, then use the single-row strip below.</footer>
 
     <script>
       const controlRows = [
@@ -92,7 +101,23 @@
 
       const game = document.getElementById('game');
       const controlsRoot = document.getElementById('controls');
+      const led = document.getElementById('panel-led');
+      const panelState = document.getElementById('panel-state');
       const active = new Set();
+      let panelActive = false;
+
+      
+      function setPanelActive(next) {
+        panelActive = next;
+        led.classList.toggle('active', panelActive);
+        panelState.textContent = panelActive ? 'Panel active: sending commands' : 'Panel inactive';
+      }
+
+      game.addEventListener('load', () => setPanelActive(false));
+      game.addEventListener('pointerdown', () => {
+        setPanelActive(true);
+        if (game.contentWindow) game.contentWindow.focus();
+      });
 
       function makeEvent(type, c) {
         return new KeyboardEvent(type, {
@@ -106,6 +131,7 @@
       }
 
       function fire(type, control) {
+        if (!panelActive) return;
         window.dispatchEvent(makeEvent(type, control));
         document.dispatchEvent(makeEvent(type, control));
         if (game && game.contentWindow) game.contentWindow.focus();


### PR DESCRIPTION
### Motivation
- The on-screen controls were stacked and did not present as a single control strip suitable for touch devices.\
- The control panel could send commands immediately which caused unreliable behavior when the game iframe had not captured input.\
- A lightweight UX-based activation and visual state (LED) was needed to make it clear when the wrapper will send key events without adding a heavyweight proxy solution.\

### Description
- Convert the controls container to a single horizontal strip with `flex` layout, nowrap behavior, and horizontal overflow to keep all controls on one row.\
- Add a status widget consisting of a small LED and text to the controls area to indicate panel state (`Panel inactive` / `Panel active: sending commands`).\
- Implement a tap-to-activate flow where the iframe is set to inactive on load and only begins sending `keydown`/`keyup` events after a `pointerdown` on the iframe, and update focus handling accordingly.\
- Gate `fire()` so key events are suppressed unless the panel is active, and update footer copy to instruct users to tap the game surface to enable controls.\

### Testing
- Performed static verification by printing the updated file (`nl -ba nimbusflight-touch-wrapper.html`) to confirm the new markup, styles, and script were added successfully.\
- No automated test suite was run for this static HTML/JS change; manual verification in a browser is recommended to validate focus/iframe interaction and the LED activation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff902f456c832d8b77fec3282ed35a)