### PR TITLE
Add timeline diff summaries and exportable sequence model in repo view

### DIFF
--- a/repo.html
+++ b/repo.html
@@ -54,6 +54,7 @@
       </section>
 
       <section class="pane" id="results">
+        <div class="card"><button class="tab" id="exportModel">Export timeline JSON model</button></div>
         <div class="card" id="resultsList"></div>
       </section>
 
@@ -71,19 +72,53 @@
     </main>
   </div>
 <script>
-let all=[]; let shown=[]; let current=null;
+let all=[]; let shown=[]; let current=null; let timelineModel=[];
 const $=id=>document.getElementById(id);
 function esc(s){return String(s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
 function dt(x){return new Date(x||0).getTime()||0}
+function iso(x){const d=new Date(x||0); return Number.isNaN(d.getTime())?'1970-01-01T00:00:00.000Z':d.toISOString();}
 function inferFocus(tags){if(tags.includes('soft-delete')&&tags.includes('xml'))return 'Soft-delete + XML fix iteration.'; if(tags.includes('soft-delete'))return 'Soft-delete focused.'; if(tags.includes('xml'))return 'XML handling focused.'; if(tags.includes('patched'))return 'Patch stabilization attempt.'; if(tags.includes('restore'))return 'Rollback/restore exploration.'; return 'General iteration.';}
+async function loadBlobText(item){
+  if(item._blobText!==undefined) return item._blobText;
+  try{
+    const res=await fetch(item.blobUrl,{cache:'no-store'});
+    item._blobText=res.ok?await res.text():'';
+  }catch{ item._blobText=''; }
+  return item._blobText;
+}
+function summarizeDelta(prevText,nextText){
+  if(!prevText && nextText) return 'Initial version in timeline.';
+  if(prevText===nextText) return 'No textual delta from previous timeline item.';
+  const a=(prevText||'').split('\n'); const b=(nextText||'').split('\n');
+  let added=0, removed=0;
+  const prevSet=new Set(a); const nextSet=new Set(b);
+  for(const line of b){ if(!prevSet.has(line)) added++; }
+  for(const line of a){ if(!nextSet.has(line)) removed++; }
+  return `Changed from previous variant: +${added} / -${removed} unique lines.`;
+}
+async function buildTimelineModel(){
+  const sorted=[...shown].sort((a,b)=>dt(a.created)-dt(b.created)||dt(a.lastUpdated)-dt(b.lastUpdated));
+  const blobs=await Promise.all(sorted.map(loadBlobText));
+  timelineModel=sorted.map((item,idx)=>({
+    seq: idx+1,
+    timestamp: iso(item.lastUpdated||item.created),
+    commitid: item.commit,
+    filename: item.file,
+    description_delta_from_previous: summarizeDelta(blobs[idx-1]||'', blobs[idx]||''),
+    blob: item.blobUrl,
+    launch: item.launchUrl,
+    note: item.lineageNote||inferFocus(item.tags||[])
+  }));
+}
 function setCurrent(file){current=shown.find(x=>x.file===file)||shown[0]; if(!current)return; $('preview').src=current.launchUrl; $('activeMeta').innerHTML=`<strong>${esc(current.file)}</strong><br><span class='muted'>${esc(current.created)} | ${esc(current.commit.slice(0,10))}</span><div>${inferFocus(current.tags||[])}</div><div><a target='_blank' href='${esc(current.launchUrl)}'>Launch</a> · <a target='_blank' href='${esc(current.blobUrl)}'>Code blob</a></div>`; renderList();}
 function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.file===x.file?'active':''}' data-file='${esc(x.file)}'><strong>${esc(x.file)}</strong><div class='muted'>${esc((x.tags||[]).join(', '))}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrent(n.dataset.file)); }
-function renderResults(){ $('resultsList').innerHTML=shown.map((x,i)=>`<div class='card'><strong>${i+1}. ${esc(x.file)}</strong><div class='muted'>${esc(x.created)} → ${esc(x.lastUpdated)}</div><div>${esc(x.lineageNote||inferFocus(x.tags||[]))}</div></div>`).join(''); }
+function renderResults(){ $('resultsList').innerHTML=timelineModel.map(row=>`<div class='card'><strong>${row.seq}. ${esc(row.filename)}</strong><div class='muted'>${esc(row.timestamp)} · ${esc(row.commitid.slice(0,12))}</div><div>${esc(row.description_delta_from_previous)}</div><div class='muted'>${esc(row.note)}</div></div>`).join(''); }
 function renderAnalysis(){ $('analysisLog').innerHTML=`<ol>${shown.map(x=>`<li><code>${esc(x.file)}</code> — ${esc(inferFocus(x.tags||[]))}</li>`).join('')}</ol>`; $('progress').textContent=`Completed: ${shown.length} bridge variants ordered and indexed.`; }
 function renderCompare(){ const opts=shown.map(x=>`<option value='${esc(x.file)}'>${esc(x.file)}</option>`).join(''); $('leftPick').innerHTML=opts; $('rightPick').innerHTML=opts; if(shown[0]) $('leftFrame').src=shown[0].launchUrl; if(shown[1]) $('rightFrame').src=shown[1].launchUrl; $('leftPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('leftFrame').src=f.launchUrl;}; $('rightPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('rightFrame').src=f.launchUrl;}; }
-function rerender(){ renderList(); renderResults(); renderAnalysis(); renderCompare(); if(!current&&shown[0]) setCurrent(shown[0].file); }
+async function rerender(){ await buildTimelineModel(); renderList(); renderResults(); renderAnalysis(); renderCompare(); if(!current&&shown[0]) setCurrent(shown[0].file); }
 $('omni').oninput=e=>{ const q=e.target.value.toLowerCase().trim(); shown=all.filter(x=>[x.file,x.commit,(x.tags||[]).join(' ')].join(' ').toLowerCase().includes(q)); shown.sort((a,b)=>dt(a.created)-dt(b.created)); current=null; rerender(); };
 $('toggleNav').onclick=()=>$('app').classList.toggle('hidden-left');
+$('exportModel').onclick=()=>{ const out=JSON.stringify(timelineModel,null,2); const blob=new Blob([out],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='bridge-lineage-timeline-model.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url),1000); };
 document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active')); t.classList.add('active'); document.querySelectorAll('.pane').forEach(p=>p.classList.remove('active')); $(t.dataset.tab).classList.add('active');});
 fetch('bridge-lineage.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{all=data.sort((a,b)=>dt(a.created)-dt(b.created)); shown=[...all]; rerender();}).catch(e=>{$('progress').textContent='Load failed: '+e.message;});
 </script>


### PR DESCRIPTION
### Motivation
- Provide a date/time-driven lineage model that can compare commit-to-commit evolution even when filenames change across versions. 
- Make it possible to persist an ordered, summarized timeline for offline inspection and tooling via a JSON export.

### Description
- Added an export control in the Lineage Results pane (`Export timeline JSON model`) and an `exportModel` click handler to download the computed model as `bridge-lineage-timeline-model.json`.
- Introduced `timelineModel` and builder functions including `iso()`, `loadBlobText()`, `summarizeDelta()` and `buildTimelineModel()` to load blobs, compute a lightweight line-based delta against the previous timeline item, and produce rows with `seq`, `timestamp`, `commitid`, `filename`, `description_delta_from_previous`, `blob`, `launch`, and `note` fields.
- Switched `rerender()` to async and updated `renderResults()` to use `timelineModel` so result cards show ordered sequence numbers, timestamps, commit snippets, and delta summaries.
- Kept the existing UI scaffolding intact and used `created` with `lastUpdated` as a tiebreaker for timeline ordering so variants are ordered by date/time rather than filename.

### Testing
- Ran `git -C /workspace/stuff status --short` which completed successfully.
- Ran `git -C /workspace/stuff add repo.html && git -C /workspace/stuff commit -m "Add timeline diff summaries and exportable sequence model"` which completed successfully and recorded the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffaac2669c832d83f2de0c8f1f2d66)