### PR TITLE
Switch repo timeline UI to generated lineage model

### DIFF
--- a/bridge-lineage-timeline-model.json
+++ b/bridge-lineage-timeline-model.json
@@ -1,0 +1,5218 @@
+[
+  {
+    "seq": 1,
+    "timestamp": "2026-05-09T15:27:36-07:00",
+    "commit_hash": "26f94230a996ff18655c420e489f272fa738421a",
+    "commit_short": "26f9423",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17"
+  },
+  {
+    "seq": 2,
+    "timestamp": "2026-05-09T15:27:15-07:00",
+    "commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17",
+    "commit_short": "65d16ac",
+    "code_fingerprint": "a0f72cde786551d68c4636458f992d96d638536db521176d7148fa540433f245",
+    "primary_filename": "resolve.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "resolve.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+184/-0); key paths: resolve.html.",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "65d16ac8128f601c40cdc528195175c487a34c17:resolve.html"
+    ],
+    "launch_ref": "resolve.html",
+    "note": "Inferred impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "7230e5c6f4e354727df4127ed2a8d96f2d53b6da"
+  },
+  {
+    "seq": 3,
+    "timestamp": "2026-05-09T15:10:11-07:00",
+    "commit_hash": "7230e5c6f4e354727df4127ed2a8d96f2d53b6da",
+    "commit_short": "7230e5c",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388"
+  },
+  {
+    "seq": 4,
+    "timestamp": "2026-05-09T15:10:01-07:00",
+    "commit_hash": "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388",
+    "commit_short": "67e83f3",
+    "code_fingerprint": "7e459c7c44ccd8be1e9a895b54899905bbc6f9dedb6f9d500dcaec6a61141047",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+209/-236); key paths: nimbus.html, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388:nimbus.html",
+      "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b0b152586b7ca0c88203b04b8c3f955900a52a27"
+  },
+  {
+    "seq": 5,
+    "timestamp": "2026-05-09T15:09:14-07:00",
+    "commit_hash": "b0b152586b7ca0c88203b04b8c3f955900a52a27",
+    "commit_short": "b0b1525",
+    "code_fingerprint": "529b27a383336333e9db9aef0e01dab117d3b97f6e73eceb813b66510a184cc1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+236/-209); key paths: nimbus.html, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b0b152586b7ca0c88203b04b8c3f955900a52a27:nimbus.html",
+      "b0b152586b7ca0c88203b04b8c3f955900a52a27:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637"
+  },
+  {
+    "seq": 6,
+    "timestamp": "2026-05-09T14:50:31-07:00",
+    "commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637",
+    "commit_short": "5a90f5d",
+    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbus.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+243/-0); key paths: nimbus.html.",
+    "functional_impacts": [
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5a90f5d9276733808541ffd6fc3ecd0635eb4637:nimbus.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Inferred impacts: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee"
+  },
+  {
+    "seq": 7,
+    "timestamp": "2026-05-09T14:50:05-07:00",
+    "commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee",
+    "commit_short": "5348f24",
+    "code_fingerprint": "978ee7934c61d8013cbf2e98802c7c5c9e3cc58d91ae8a9b469c6f2ee6b2cfe8",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+38/-246); key paths: nimbus.html, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5348f24c6b0b0b106375ee14add3cfc196c9adee:nimbus.html",
+      "5348f24c6b0b0b106375ee14add3cfc196c9adee:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4b1428fd105a6bede8b24459f061d04fe15ada71"
+  },
+  {
+    "seq": 8,
+    "timestamp": "2026-05-09T14:46:45-07:00",
+    "commit_hash": "4b1428fd105a6bede8b24459f061d04fe15ada71",
+    "commit_short": "4b1428f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6"
+  },
+  {
+    "seq": 9,
+    "timestamp": "2026-05-09T14:45:09-07:00",
+    "commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6",
+    "commit_short": "4f12657",
+    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbus.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+243/-0); key paths: nimbus.html.",
+    "functional_impacts": [
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "4f12657f7173ee95208e143fada0846fa9782ed6:nimbus.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Inferred impacts: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "552e1921349d60cfa8a5e1ee9805ab48134f278e"
+  },
+  {
+    "seq": 10,
+    "timestamp": "2026-05-09T14:16:01-07:00",
+    "commit_hash": "552e1921349d60cfa8a5e1ee9805ab48134f278e",
+    "commit_short": "552e192",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7"
+  },
+  {
+    "seq": 11,
+    "timestamp": "2026-05-09T14:15:52-07:00",
+    "commit_hash": "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7",
+    "commit_short": "7dfb07e",
+    "code_fingerprint": "e2d12c0a4a52763480e1cc149a1054ec5e6c78624c60dec8e828a85d4dd558d7",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 3 file(s) (+225/-238); key paths: bridge-lineage.json, nimbusflight-touch-wrapper.html, repo.html.",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:bridge-lineage.json",
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:nimbusflight-touch-wrapper.html",
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0a690a5aa30abfdc83e917f943508f584ebbd192"
+  },
+  {
+    "seq": 12,
+    "timestamp": "2026-05-09T14:14:03-07:00",
+    "commit_hash": "0a690a5aa30abfdc83e917f943508f584ebbd192",
+    "commit_short": "0a690a5",
+    "code_fingerprint": "38a05ea7111582abd44d527f30e6da85e1de2f2d1d6d35f6d87a04e15593ad28",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 3 file(s) (+238/-225); key paths: bridge-lineage.json, nimbusflight-touch-wrapper.html, repo.html.",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:bridge-lineage.json",
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:nimbusflight-touch-wrapper.html",
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181"
+  },
+  {
+    "seq": 13,
+    "timestamp": "2026-05-09T14:02:18-07:00",
+    "commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181",
+    "commit_short": "9e47705",
+    "code_fingerprint": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-4); key paths: nimbusflight-touch-wrapper.html.",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9e477053a08bb3c1d1fc512fd6d66310685ea181:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Inferred impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2d2b4d297266b1617865602303990dca5ef58557"
+  },
+  {
+    "seq": 14,
+    "timestamp": "2026-05-09T14:01:52-07:00",
+    "commit_hash": "2d2b4d297266b1617865602303990dca5ef58557",
+    "commit_short": "2d2b4d2",
+    "code_fingerprint": "d51e38ddecbaa7030810c3e86d2f7627246e11d0647a798b32d45050c2e41786",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 3 file(s) (+466/-198); key paths: bridge-lineage.json, nimbusflight-touch-wrapper.html, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2d2b4d297266b1617865602303990dca5ef58557:bridge-lineage.json",
+      "2d2b4d297266b1617865602303990dca5ef58557:nimbusflight-touch-wrapper.html",
+      "2d2b4d297266b1617865602303990dca5ef58557:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ed7187b3842c2c11ce708442ca41178827225b75"
+  },
+  {
+    "seq": 15,
+    "timestamp": "2026-05-09T14:01:18-07:00",
+    "commit_hash": "ed7187b3842c2c11ce708442ca41178827225b75",
+    "commit_short": "ed7187b",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a"
+  },
+  {
+    "seq": 16,
+    "timestamp": "2026-05-09T13:01:20-07:00",
+    "commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a",
+    "commit_short": "0a781ff",
+    "code_fingerprint": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-4); key paths: nimbusflight-touch-wrapper.html.",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0a781ffc74981891c79d98304dfe1a0509ca3d3a:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Inferred impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3032a77568937554bd8731ca600494a7311ddfd1"
+  },
+  {
+    "seq": 17,
+    "timestamp": "2026-05-09T12:43:20-07:00",
+    "commit_hash": "3032a77568937554bd8731ca600494a7311ddfd1",
+    "commit_short": "3032a77",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "d3126b3b2ecf41bb77a422905615d6cca1bf91e3"
+  },
+  {
+    "seq": 18,
+    "timestamp": "2026-05-08T22:20:27-07:00",
+    "commit_hash": "d3126b3b2ecf41bb77a422905615d6cca1bf91e3",
+    "commit_short": "d3126b3",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf"
+  },
+  {
+    "seq": 19,
+    "timestamp": "2026-05-08T22:20:04-07:00",
+    "commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf",
+    "commit_short": "e12a975",
+    "code_fingerprint": "d2040e6fba35fd9296b449aa117041debf1c3fd4eb88f07f8c8eb83ec45dbd04",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+154/-0); key paths: nimbusflight-touch-wrapper.html.",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "e12a9758445ead5f47ca4d2502b3cee824be2aaf:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Inferred impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279"
+  },
+  {
+    "seq": 20,
+    "timestamp": "2026-05-08T22:16:39-07:00",
+    "commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279",
+    "commit_short": "04d1fa0",
+    "code_fingerprint": "6f0f5ebd61640ac1c06d50690939561967e67f47f40cc96ff8ea25f42dc450c1",
+    "primary_filename": "src/App.tsx",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "src/App.tsx"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+133/-3); key paths: src/App.tsx.",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "04d1fa01bbdbe4045613e84151ef98bf5e4d4279:src/App.tsx"
+    ],
+    "launch_ref": "src/App.tsx",
+    "note": "Inferred impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d"
+  },
+  {
+    "seq": 21,
+    "timestamp": "2026-05-08T21:43:01-07:00",
+    "commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d",
+    "commit_short": "957d823",
+    "code_fingerprint": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-18); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "957d823fcf173239bcaf937deb2f5c67fb144f1d:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de"
+  },
+  {
+    "seq": 22,
+    "timestamp": "2026-05-07T23:41:40-07:00",
+    "commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de",
+    "commit_short": "116ce14",
+    "code_fingerprint": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053",
+    "primary_filename": "bridge-try.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-try.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+2778/-0); key paths: bridge-try.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "116ce1466570b35b822be41ef99ad9d2044784de:bridge-try.html"
+    ],
+    "launch_ref": "bridge-try.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd"
+  },
+  {
+    "seq": 23,
+    "timestamp": "2026-05-07T22:47:29-07:00",
+    "commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd",
+    "commit_short": "a0c2917",
+    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+197/-0); key paths: bridge-lineage.json, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a0c2917e740ed58bf537566e9333caf191eddbfd:bridge-lineage.json",
+      "a0c2917e740ed58bf537566e9333caf191eddbfd:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c"
+  },
+  {
+    "seq": 24,
+    "timestamp": "2026-05-07T22:46:50-07:00",
+    "commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c",
+    "commit_short": "7375fa6",
+    "code_fingerprint": "03fb4737a6e8fcf4008b10f97e1a47ee01fd809b59593722c5d4adf3a1b3fa6a",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore.html"
+      },
+      {
+        "status": "D",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 9 file(s) (+10811/-197); key paths: bridge-lineage.json, bridge-restore-minus-1.html, bridge-restore-minus-2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-lineage.json",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-1.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-2.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-3.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-1.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-2.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-3.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2ec79e932f0d4d650284dbb561b5ad57ed318437"
+  },
+  {
+    "seq": 25,
+    "timestamp": "2026-05-07T22:35:43-07:00",
+    "commit_hash": "2ec79e932f0d4d650284dbb561b5ad57ed318437",
+    "commit_short": "2ec79e9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2"
+  },
+  {
+    "seq": 26,
+    "timestamp": "2026-05-07T22:34:37-07:00",
+    "commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2",
+    "commit_short": "15aeb25",
+    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+197/-0); key paths: bridge-lineage.json, repo.html.",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "15aeb257bc1c9204f5d94a697cb776306491c9f2:bridge-lineage.json",
+      "15aeb257bc1c9204f5d94a697cb776306491c9f2:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Inferred impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae"
+  },
+  {
+    "seq": 27,
+    "timestamp": "2026-05-07T22:09:04-07:00",
+    "commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae",
+    "commit_short": "6109bca",
+    "code_fingerprint": "875c6d94825180e90a09a9d790e35471e1127e6540b433685b433711a95da7c7",
+    "primary_filename": "bridge-patched-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+134/-151); key paths: bridge-patched-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6109bca5ada37a1d39fa84ed47c608564e1b6dae:bridge-patched-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca"
+  },
+  {
+    "seq": 28,
+    "timestamp": "2026-05-07T22:08:30-07:00",
+    "commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca",
+    "commit_short": "feb3e3b",
+    "code_fingerprint": "499c88510bb69c38684b600515392b4dd85bae723dcce8c0a1ee31c9941aa482",
+    "primary_filename": "fastType/fastText.common.js",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "fastType/fastText.common.js"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+26/-35); key paths: fastType/fastText.common.js.",
+    "functional_impacts": [
+      "transcription",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "feb3e3beb6081d6e2ad75ae595113339885bcbca:fastType/fastText.common.js"
+    ],
+    "launch_ref": "fastType/fastText.common.js",
+    "note": "Inferred impacts: transcription, ui/ux flow changes.",
+    "previous_commit_hash": "25eb8809a933299895af51a6b723f2c5cb8e2e9f"
+  },
+  {
+    "seq": 29,
+    "timestamp": "2026-05-07T21:14:26-07:00",
+    "commit_hash": "25eb8809a933299895af51a6b723f2c5cb8e2e9f",
+    "commit_short": "25eb880",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284"
+  },
+  {
+    "seq": 30,
+    "timestamp": "2026-05-07T20:58:47-07:00",
+    "commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284",
+    "commit_short": "e87a36c",
+    "code_fingerprint": "1d3b3095ce26ec85ce95284a29621958f72e6b3e35743250d45bb364c328edd6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1/-1); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8f276b4265914eecab61413aa43aac42ec028517"
+  },
+  {
+    "seq": 31,
+    "timestamp": "2026-05-07T20:54:12-07:00",
+    "commit_hash": "8f276b4265914eecab61413aa43aac42ec028517",
+    "commit_short": "8f276b4",
+    "code_fingerprint": "e030129539f3c0e7b51aa471999f641a510b996f627da0b20a42e5b00ce45f81",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "fastType/fastText.common.js"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+8772/-18); key paths: bridge-patched-v1.html, fastType/fastText.common.js.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8f276b4265914eecab61413aa43aac42ec028517:bridge-patched-v1.html",
+      "8f276b4265914eecab61413aa43aac42ec028517:fastType/fastText.common.js"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b"
+  },
+  {
+    "seq": 32,
+    "timestamp": "2026-05-07T17:27:29-07:00",
+    "commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b",
+    "commit_short": "93446bd",
+    "code_fingerprint": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-18); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "93446bdabd881e40f5c5b709ea713c70af37068b:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71"
+  },
+  {
+    "seq": 33,
+    "timestamp": "2026-05-07T16:54:34-07:00",
+    "commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71",
+    "commit_short": "a31e6cb",
+    "code_fingerprint": "5c7f7f77b360cc453289f5a00c797da27ede361ebe2a2e83882ef0f732f54141",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1/-0); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a31e6cb586f30e974094da7fde554cc2863c2f71:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6"
+  },
+  {
+    "seq": 34,
+    "timestamp": "2026-05-07T16:36:40-07:00",
+    "commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6",
+    "commit_short": "d9c0759",
+    "code_fingerprint": "bb15faa67204cbdb2dd160d96a618975dcb502f7a04f5d675ec4fdb4a9bf5fa6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+20/-20); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d9c07596d0c39e42d23d86b4bc59525a97f467c6:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086"
+  },
+  {
+    "seq": 35,
+    "timestamp": "2026-05-07T05:59:35-07:00",
+    "commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086",
+    "commit_short": "c61dcf8",
+    "code_fingerprint": "63fac6b3d76eaa6e2e9987750d93fdc28a845570ce734e6f4b50233adfbb4cad",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+46/-148); key paths: folder-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Inferred impacts: normalization, translation, call termination behavior, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c"
+  },
+  {
+    "seq": 36,
+    "timestamp": "2026-05-07T05:59:21-07:00",
+    "commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c",
+    "commit_short": "f8eaade",
+    "code_fingerprint": "563982390bbcc280d087a2c365077162f3e75f12cdb0c33487004e447af2e7c6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+162/-48); key paths: bridge-patched-v1.html, folder-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:bridge-patched-v1.html",
+      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd"
+  },
+  {
+    "seq": 37,
+    "timestamp": "2026-05-07T05:50:32-07:00",
+    "commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd",
+    "commit_short": "d24f8c0",
+    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-6); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d24f8c0d2dab442b98ec0b2ef6346862eee042bd:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654"
+  },
+  {
+    "seq": 38,
+    "timestamp": "2026-05-07T05:50:19-07:00",
+    "commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654",
+    "commit_short": "8d959e5",
+    "code_fingerprint": "c9c12415b17de9b83d29421cad7800870e09c590b634524fdc97ec2b0086e965",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+52/-151); key paths: bridge-patched-v1.html, folder-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:bridge-patched-v1.html",
+      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a6885187e525a116f499c1bd909b9ff79a76f721"
+  },
+  {
+    "seq": 39,
+    "timestamp": "2026-05-07T05:41:09-07:00",
+    "commit_hash": "a6885187e525a116f499c1bd909b9ff79a76f721",
+    "commit_short": "a688518",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914"
+  },
+  {
+    "seq": 40,
+    "timestamp": "2026-05-07T05:39:32-07:00",
+    "commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914",
+    "commit_short": "91dc5b7",
+    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-6); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a"
+  },
+  {
+    "seq": 41,
+    "timestamp": "2026-05-07T04:54:29-07:00",
+    "commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a",
+    "commit_short": "87a480c",
+    "code_fingerprint": "a25f54cdb70ec936c40656a321c1fbace8b1c732ef9e7575c268ac2d4a2c5d83",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+10/-7); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "87a480cc2dbc1c46ff5029be551a40f335b7703a:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d"
+  },
+  {
+    "seq": 42,
+    "timestamp": "2026-05-07T04:27:03-07:00",
+    "commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d",
+    "commit_short": "42feeb2",
+    "code_fingerprint": "d4a4b91416b9f5a5ece980c6b7ca38b7b3a8c213e25271e1ac7175ea26431967",
+    "primary_filename": "talkbridge-northern-thai-bridge-plugin.js",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "talkbridge-northern-thai-bridge-plugin.js"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+646/-0); key paths: talkbridge-northern-thai-bridge-plugin.js.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "42feeb2dcb0aa771fd2fe82bb5191515dd95814d:talkbridge-northern-thai-bridge-plugin.js"
+    ],
+    "launch_ref": "talkbridge-northern-thai-bridge-plugin.js",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf"
+  },
+  {
+    "seq": 43,
+    "timestamp": "2026-05-07T04:07:07-07:00",
+    "commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf",
+    "commit_short": "5e99786",
+    "code_fingerprint": "bfb7ac1ec48eb7a4cc9d7d9511ae83bebaac1a38c0cf760420841a396c369ecb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+97/-13); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5e997868914a25463fb3e065cc5dcd7312e3ddaf:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b"
+  },
+  {
+    "seq": 44,
+    "timestamp": "2026-05-05T00:15:36-07:00",
+    "commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b",
+    "commit_short": "f1ae66b",
+    "code_fingerprint": "e0f432275c0f1700e86e4ee6b3636e322390043fd0a51dd9d63e878a217e3fcd",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+10/-126); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f1ae66bc58a4cb758b13ec589152c64a75b89d7b:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260"
+  },
+  {
+    "seq": 45,
+    "timestamp": "2026-05-04T23:59:08-07:00",
+    "commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260",
+    "commit_short": "95b15d6",
+    "code_fingerprint": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-1); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "95b15d65a00ed741cfd8b3820b38800635058260:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, translation, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8"
+  },
+  {
+    "seq": 46,
+    "timestamp": "2026-05-04T23:49:17-07:00",
+    "commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8",
+    "commit_short": "4d647b6",
+    "code_fingerprint": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+42/-23); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "4d647b6374df3fc15faae99330a71f6a5ef38ea8:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2ef14bfb581ecf85518691e8ac041943448a7425"
+  },
+  {
+    "seq": 47,
+    "timestamp": "2026-05-04T23:45:44-07:00",
+    "commit_hash": "2ef14bfb581ecf85518691e8ac041943448a7425",
+    "commit_short": "2ef14bf",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f"
+  },
+  {
+    "seq": 48,
+    "timestamp": "2026-05-04T23:43:57-07:00",
+    "commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f",
+    "commit_short": "21d7f60",
+    "code_fingerprint": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f",
+    "primary_filename": "bridge-patched-v2.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+2856/-0); key paths: bridge-patched-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "21d7f60ed8a12a9a47d6fa252c640220aab1021f:bridge-patched-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3"
+  },
+  {
+    "seq": 49,
+    "timestamp": "2026-05-04T22:28:46-07:00",
+    "commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3",
+    "commit_short": "7abbeea",
+    "code_fingerprint": "836b2203d55baa24b492baa594afa4dc8018ccfc8c5ea8b82e554e3a7a5686b1",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+67/-9); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7abbeea38ad2f527b6d154743de7b8c4a598d6b3:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672"
+  },
+  {
+    "seq": 50,
+    "timestamp": "2026-05-04T22:07:00-07:00",
+    "commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672",
+    "commit_short": "ef895c7",
+    "code_fingerprint": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+2/-1); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "ef895c75a7f8a2bf580efb5db957f0b6feec6672:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93"
+  },
+  {
+    "seq": 51,
+    "timestamp": "2026-05-04T21:19:27-07:00",
+    "commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93",
+    "commit_short": "6de44b0",
+    "code_fingerprint": "875fab43924ebc5cc33e13c7b9c67433b7837fddba825196ac7d553ad1ac37cb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+68/-37); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6de44b0e9f25115de07a8113d1c538c575ef1e93:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc"
+  },
+  {
+    "seq": 52,
+    "timestamp": "2026-05-04T20:02:14-07:00",
+    "commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc",
+    "commit_short": "8dc8a82",
+    "code_fingerprint": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+2747/-0); key paths: bridge-patched-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5"
+  },
+  {
+    "seq": 53,
+    "timestamp": "2026-05-04T13:56:09-07:00",
+    "commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5",
+    "commit_short": "41c63d3",
+    "code_fingerprint": "977cd9f260097e55f3ca7a597f7cce1a465668c71894270c0c5d05baf3ab8172",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+58/-21); key paths: bridge-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "41c63d354dfb4d2bb64311eed99e5acd6261d3f5:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e"
+  },
+  {
+    "seq": 54,
+    "timestamp": "2026-05-04T13:47:19-07:00",
+    "commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e",
+    "commit_short": "a80eaee",
+    "code_fingerprint": "849f6c3a6319721c447e1daa2aa8ef83606927c2809140f5382ade44ea5da0ca",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+122/-30); key paths: bridge-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a80eaee0241626ab570b35470651a92f8bde8c2e:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "913a20f91698c6317cb0a5d5f564e8027ca99fda"
+  },
+  {
+    "seq": 55,
+    "timestamp": "2026-05-04T12:55:58-07:00",
+    "commit_hash": "913a20f91698c6317cb0a5d5f564e8027ca99fda",
+    "commit_short": "913a20f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5007c65b6eb22c437ccca3b7f0df7d2cf32d74a1"
+  },
+  {
+    "seq": 56,
+    "timestamp": "2026-05-04T12:55:47-07:00",
+    "commit_hash": "5007c65b6eb22c437ccca3b7f0df7d2cf32d74a1",
+    "commit_short": "5007c65",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c"
+  },
+  {
+    "seq": 57,
+    "timestamp": "2026-05-04T11:00:46-07:00",
+    "commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c",
+    "commit_short": "6724b52",
+    "code_fingerprint": "d972281fe73fd7354e2b510ac1f10028fb085e9fbf0f8f838250fec48cf2c17d",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+96/-36); key paths: bridge-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6724b523bfd833fbea25db11abefdf7830d3c04c:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520"
+  },
+  {
+    "seq": 58,
+    "timestamp": "2026-05-04T10:26:21-07:00",
+    "commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520",
+    "commit_short": "f4dfad8",
+    "code_fingerprint": "94695e788b203d9d61cc3aba9fc3e9db10c767ca45de2a2b13b92ff8111c090a",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+22/-1); key paths: bridge-patched.html.",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f4dfad85040fdfe1d9137271cc466d27c65aa520:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3"
+  },
+  {
+    "seq": 59,
+    "timestamp": "2026-05-04T09:32:31-07:00",
+    "commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3",
+    "commit_short": "a4a043c",
+    "code_fingerprint": "0ec941fd4a5183a1f2615f02df4f09968cd017b6039791f39bd0de88d99871ff",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-19); key paths: bridge-patched.html.",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94"
+  },
+  {
+    "seq": 60,
+    "timestamp": "2026-05-03T23:09:22-07:00",
+    "commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94",
+    "commit_short": "b05216b",
+    "code_fingerprint": "a92ab0221ae9429ce10f716ac2a7cccc5139b8104ea98599aa35a9efabf8488a",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+359/-158); key paths: getit.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b05216b41efea4d90e62805b2edcf9890fdafd94:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Inferred impacts: normalization, translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "98560d0562826531e3fdb33f71735243dfa333f9"
+  },
+  {
+    "seq": 61,
+    "timestamp": "2026-05-03T21:46:19-07:00",
+    "commit_hash": "98560d0562826531e3fdb33f71735243dfa333f9",
+    "commit_short": "98560d0",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b"
+  },
+  {
+    "seq": 62,
+    "timestamp": "2026-05-03T21:46:07-07:00",
+    "commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b",
+    "commit_short": "ec23f33",
+    "code_fingerprint": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+22/-2); key paths: bridge-patched.html, bridge8-patched.html.",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge-patched.html",
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7185a930d74e3c02f120c88ea9b5725f1d339e03"
+  },
+  {
+    "seq": 63,
+    "timestamp": "2026-05-03T19:28:30-07:00",
+    "commit_hash": "7185a930d74e3c02f120c88ea9b5725f1d339e03",
+    "commit_short": "7185a93",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0aa34922277e9e143b2649ca95bb4f92540e4c84"
+  },
+  {
+    "seq": 64,
+    "timestamp": "2026-05-03T19:28:16-07:00",
+    "commit_hash": "0aa34922277e9e143b2649ca95bb4f92540e4c84",
+    "commit_short": "0aa3492",
+    "code_fingerprint": "3b9932d5f81417f7e0fb1ea2630da54d6dba8768e57279b30df3a9c735d16ed5",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+25/-71); key paths: folder-v2.html, recover.html.",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0aa34922277e9e143b2649ca95bb4f92540e4c84:folder-v2.html",
+      "0aa34922277e9e143b2649ca95bb4f92540e4c84:recover.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Inferred impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b89289127741c3e4823ab8b07368cd8f082d1e24"
+  },
+  {
+    "seq": 65,
+    "timestamp": "2026-05-03T19:25:24-07:00",
+    "commit_hash": "b89289127741c3e4823ab8b07368cd8f082d1e24",
+    "commit_short": "b892891",
+    "code_fingerprint": "0fb9d5de3ff747f378dc30884d2568c23e6d96ebbad1263215ad14df7b3a2d89",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+71/-25); key paths: folder-v2.html, recover.html.",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b89289127741c3e4823ab8b07368cd8f082d1e24:folder-v2.html",
+      "b89289127741c3e4823ab8b07368cd8f082d1e24:recover.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Inferred impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6ea2c1d409ec002c6c2d781bc66aded05d7721f5"
+  },
+  {
+    "seq": 66,
+    "timestamp": "2026-05-03T19:09:35-07:00",
+    "commit_hash": "6ea2c1d409ec002c6c2d781bc66aded05d7721f5",
+    "commit_short": "6ea2c1d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1"
+  },
+  {
+    "seq": 67,
+    "timestamp": "2026-05-03T19:09:25-07:00",
+    "commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1",
+    "commit_short": "ee75f51",
+    "code_fingerprint": "faf0959328f67a0b4d94eea87891d8907fc6ec7d6e01f05cca45066d2631f933",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+19/-10); key paths: folder-v2.html.",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "ee75f51efd1fdf5e8945775d120b15408d22c2c1:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Inferred impacts: compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "3f2437caf2785c101927215842d900e157c7ec75"
+  },
+  {
+    "seq": 68,
+    "timestamp": "2026-05-03T18:13:26-07:00",
+    "commit_hash": "3f2437caf2785c101927215842d900e157c7ec75",
+    "commit_short": "3f2437c",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed"
+  },
+  {
+    "seq": 69,
+    "timestamp": "2026-05-03T18:13:13-07:00",
+    "commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed",
+    "commit_short": "5946aea",
+    "code_fingerprint": "9c1a46bbde95e7a1b290173323a5cd066751fce43ce8ff0bf9e5c2bcb17a7cca",
+    "primary_filename": "recover.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+224/-0); key paths: recover.html.",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5946aea35f2a5fa282b878b9c05e76091107e8ed:recover.html"
+    ],
+    "launch_ref": "recover.html",
+    "note": "Inferred impacts: transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30"
+  },
+  {
+    "seq": 70,
+    "timestamp": "2026-05-03T17:20:24-07:00",
+    "commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30",
+    "commit_short": "98c907e",
+    "code_fingerprint": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 4 file(s) (+2531/-6); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-patched.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v1.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v2.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0"
+  },
+  {
+    "seq": 71,
+    "timestamp": "2026-05-03T17:20:12-07:00",
+    "commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0",
+    "commit_short": "3ff2166",
+    "code_fingerprint": "63a6e7aefe960781885fe16f5bfa6a55ef6a9a4b17df1f9880c2a507cc4ef4c0",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 5 file(s) (+33/-2558); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-patched.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v1.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v2.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge8-patched.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0d0e627a052bb8b78facd19226f22078ecd7e296"
+  },
+  {
+    "seq": 72,
+    "timestamp": "2026-05-03T17:19:51-07:00",
+    "commit_hash": "0d0e627a052bb8b78facd19226f22078ecd7e296",
+    "commit_short": "0d0e627",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c"
+  },
+  {
+    "seq": 73,
+    "timestamp": "2026-05-03T17:19:34-07:00",
+    "commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c",
+    "commit_short": "224cf53",
+    "code_fingerprint": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 4 file(s) (+2531/-6); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-patched.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v1.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v2.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "15b387ad945caa3f62832f4179a00d335f9caa8e"
+  },
+  {
+    "seq": 74,
+    "timestamp": "2026-05-03T15:56:12-07:00",
+    "commit_hash": "15b387ad945caa3f62832f4179a00d335f9caa8e",
+    "commit_short": "15b387a",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2"
+  },
+  {
+    "seq": 75,
+    "timestamp": "2026-05-03T15:55:49-07:00",
+    "commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2",
+    "commit_short": "2544c6f",
+    "code_fingerprint": "563535e56879f8e89329d09a78a6810702d4bad217c7b300b04f41b8fc41bb29",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1476/-0); key paths: folder-v2.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2544c6fe6660ffa86d63b4982be6d71b234575f2:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e6b99a6c03513ab98a37279e321264ef63268f2b"
+  },
+  {
+    "seq": 76,
+    "timestamp": "2026-05-03T14:48:35-07:00",
+    "commit_hash": "e6b99a6c03513ab98a37279e321264ef63268f2b",
+    "commit_short": "e6b99a6",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b"
+  },
+  {
+    "seq": 77,
+    "timestamp": "2026-05-03T14:43:39-07:00",
+    "commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b",
+    "commit_short": "f9decf2",
+    "code_fingerprint": "67fc30d2e5b0d8ba249cfdd386991060e96d8aeed84f0081ba4ed5736772bbf4",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+178/-39); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f9decf22f5d1994d4434a8c24f873d5b628b3a2b:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87"
+  },
+  {
+    "seq": 78,
+    "timestamp": "2026-05-03T00:42:36-07:00",
+    "commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87",
+    "commit_short": "2c5fa2d",
+    "code_fingerprint": "f231ae3379df4226b0def2f9763a648c3a59e0caefbaf5db997174c424ed3dea",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+20/-15); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2c5fa2def30b9629989e35cc5aaa3effb1750d87:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e"
+  },
+  {
+    "seq": 79,
+    "timestamp": "2026-05-03T00:21:52-07:00",
+    "commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e",
+    "commit_short": "f961596",
+    "code_fingerprint": "06a2cf14f0c350e0f90df52df32f339a67baced7a9c19f27cbc8bf928b04bf7f",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+707/-66); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f961596e94dc0f16e26732f86e50841b4db0db6e:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c"
+  },
+  {
+    "seq": 80,
+    "timestamp": "2026-05-02T17:04:00-07:00",
+    "commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c",
+    "commit_short": "3ce547b",
+    "code_fingerprint": "8fc2bc008fdfc875c04617b33c12d26c419e49f0e45e12ea52974720c69f2178",
+    "primary_filename": "bridge8-v1.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ce547b137b09576fa3d234229474df5bc92691c:bridge8-v1.html"
+    ],
+    "launch_ref": "bridge8-v1.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "602d9f942ef11936fcbff10a8bc262e3afd71f1f"
+  },
+  {
+    "seq": 81,
+    "timestamp": "2026-05-02T12:44:58-07:00",
+    "commit_hash": "602d9f942ef11936fcbff10a8bc262e3afd71f1f",
+    "commit_short": "602d9f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572"
+  },
+  {
+    "seq": 82,
+    "timestamp": "2026-05-02T12:44:43-07:00",
+    "commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572",
+    "commit_short": "4495e0c",
+    "code_fingerprint": "cae85d27080805ae33ec0b37d8e15521db3d3cdf13228749aae57839bba63e96",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-26); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "4495e0c7e62d4542847618ca264e396097ba5572:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404"
+  },
+  {
+    "seq": 83,
+    "timestamp": "2026-05-02T00:10:47-07:00",
+    "commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404",
+    "commit_short": "de27f93",
+    "code_fingerprint": "40bb83a982f2a7c1cd57aa6bddadc4904198f1e5cb508a19c9ab8f44d565b890",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+345/-250); key paths: getit.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "de27f935331846f56c5e0c1a1291bd236e44a404:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d"
+  },
+  {
+    "seq": 84,
+    "timestamp": "2026-05-01T23:49:39-07:00",
+    "commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d",
+    "commit_short": "fdb1c11",
+    "code_fingerprint": "25dda0eabe82792ced706a675b517b2bdf01bfbcbd15138dd5dc64ee98815548",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+245/-500); key paths: getit.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "fdb1c11f37574daa2b6c7427215a746eca88949d:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e6a5078b18106cc92e131b41e305c8d61bc5e150"
+  },
+  {
+    "seq": 85,
+    "timestamp": "2026-05-01T23:15:47-07:00",
+    "commit_hash": "e6a5078b18106cc92e131b41e305c8d61bc5e150",
+    "commit_short": "e6a5078",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2c54df1402f657652073de165d75e94185d0291c"
+  },
+  {
+    "seq": 86,
+    "timestamp": "2026-05-01T23:15:36-07:00",
+    "commit_hash": "2c54df1402f657652073de165d75e94185d0291c",
+    "commit_short": "2c54df1",
+    "code_fingerprint": "e916fec539cf0083ec8fb03adce6e37fb2e3339dbbea1b795c683bc5533cfaf9",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-13); key paths: folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "2c54df1402f657652073de165d75e94185d0291c:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e"
+  },
+  {
+    "seq": 87,
+    "timestamp": "2026-05-01T22:47:50-07:00",
+    "commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e",
+    "commit_short": "921ae43",
+    "code_fingerprint": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-46); key paths: folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "921ae437c597745ecc3e4ae697c897dd7b133c2e:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d"
+  },
+  {
+    "seq": 88,
+    "timestamp": "2026-05-01T22:47:35-07:00",
+    "commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d",
+    "commit_short": "8df99b4",
+    "code_fingerprint": "1e34bb0a21e864dca0e60e349bc5d1fd706d33ab1ef482038923165654bceb3b",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+83/-21); key paths: bridge8-patched.html, folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:bridge8-patched.html",
+      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:folder.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "343fdb2d97b5fc6831726d9120aa7589007784d7"
+  },
+  {
+    "seq": 89,
+    "timestamp": "2026-05-01T22:41:26-07:00",
+    "commit_hash": "343fdb2d97b5fc6831726d9120aa7589007784d7",
+    "commit_short": "343fdb2",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886"
+  },
+  {
+    "seq": 90,
+    "timestamp": "2026-05-01T22:40:42-07:00",
+    "commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886",
+    "commit_short": "efcf3c8",
+    "code_fingerprint": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-46); key paths: folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "bcf34643e9413fc5ccaf7e7cae5debf4a2718a5a"
+  },
+  {
+    "seq": 91,
+    "timestamp": "2026-05-01T19:23:44-07:00",
+    "commit_hash": "bcf34643e9413fc5ccaf7e7cae5debf4a2718a5a",
+    "commit_short": "bcf3464",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5"
+  },
+  {
+    "seq": 92,
+    "timestamp": "2026-05-01T19:23:30-07:00",
+    "commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5",
+    "commit_short": "b453763",
+    "code_fingerprint": "14a2df72aa2e8a5670f355dee74579274156d687e4c8874401da80b6ec2f69a3",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-60); key paths: folder.html.",
+    "functional_impacts": [
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b453763041c6ec72f7dc19520862e29470d5a5e5:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2cb633012cb1eb5c0b1540bb6fce57ceaf6d7e4e"
+  },
+  {
+    "seq": 93,
+    "timestamp": "2026-05-01T18:37:00-07:00",
+    "commit_hash": "2cb633012cb1eb5c0b1540bb6fce57ceaf6d7e4e",
+    "commit_short": "2cb6330",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703"
+  },
+  {
+    "seq": 94,
+    "timestamp": "2026-05-01T18:36:44-07:00",
+    "commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703",
+    "commit_short": "a3e213d",
+    "code_fingerprint": "651aaf0548d7d49d0bafad77c1396096bbe087d2195019aef407ae0471c4c0fd",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+8/-5); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a3e213d2f427f2275569c7ba94c9aea0f7f12703:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a04804657c51e98899bb7879ed97b0bab625d7c6"
+  },
+  {
+    "seq": 95,
+    "timestamp": "2026-05-01T17:24:35-07:00",
+    "commit_hash": "a04804657c51e98899bb7879ed97b0bab625d7c6",
+    "commit_short": "a048046",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95"
+  },
+  {
+    "seq": 96,
+    "timestamp": "2026-05-01T17:24:22-07:00",
+    "commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95",
+    "commit_short": "d36c711",
+    "code_fingerprint": "0f1847158621c0e146ac985bc6ce98fb76cdd02c461cbb113baab35d10446280",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+43/-31); key paths: folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "d36c711b38df63cf4750882c9a197d7928569a95:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: normalization, call termination behavior, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "9adca585152a92e48b14a887efacd989810e423d"
+  },
+  {
+    "seq": 97,
+    "timestamp": "2026-05-01T11:27:08-07:00",
+    "commit_hash": "9adca585152a92e48b14a887efacd989810e423d",
+    "commit_short": "9adca58",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2"
+  },
+  {
+    "seq": 98,
+    "timestamp": "2026-05-01T11:26:39-07:00",
+    "commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2",
+    "commit_short": "af1e316",
+    "code_fingerprint": "c631145b59d616d990ae151581b6257e387b82e3bc1814fce766878438fe967e",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+14/-9); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "af1e316ba52ea02575df8877ed4c49b1cccbb3e2:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6"
+  },
+  {
+    "seq": 99,
+    "timestamp": "2026-05-01T01:28:59-07:00",
+    "commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6",
+    "commit_short": "c62a620",
+    "code_fingerprint": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-3); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "c62a620eb345d738a7c6876a2653d68715735bf6:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8"
+  },
+  {
+    "seq": 100,
+    "timestamp": "2026-05-01T01:28:17-07:00",
+    "commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8",
+    "commit_short": "babd6c5",
+    "code_fingerprint": "abbe658ae982eec5b287e147fa9f7811f59bb7fbe1addf95dd1b20928ab7f094",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+91/-11); key paths: bridge8-patched.html, folder.html.",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:bridge8-patched.html",
+      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:folder.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b0cd4f9c894917c16853b3ff054241dc438c46ef"
+  },
+  {
+    "seq": 101,
+    "timestamp": "2026-05-01T01:27:12-07:00",
+    "commit_hash": "b0cd4f9c894917c16853b3ff054241dc438c46ef",
+    "commit_short": "b0cd4f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66"
+  },
+  {
+    "seq": 102,
+    "timestamp": "2026-05-01T01:26:55-07:00",
+    "commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66",
+    "commit_short": "0bbe3bb",
+    "code_fingerprint": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-3); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "908c1f9770aa768dd54eb87e4ac26f2a34dbce82"
+  },
+  {
+    "seq": 103,
+    "timestamp": "2026-05-01T01:18:52-07:00",
+    "commit_hash": "908c1f9770aa768dd54eb87e4ac26f2a34dbce82",
+    "commit_short": "908c1f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2661a802963c02b840d9be6107d00391063aae84"
+  },
+  {
+    "seq": 104,
+    "timestamp": "2026-05-01T01:16:11-07:00",
+    "commit_hash": "2661a802963c02b840d9be6107d00391063aae84",
+    "commit_short": "2661a80",
+    "code_fingerprint": "9ea95cf5e3c9dd21ced1f0755d7d0fef3b34856652696116b30bcb1bdbc9d740",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+7/-3); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2661a802963c02b840d9be6107d00391063aae84:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0fad6e1e1cb3ce88413ca54212807f9ebb11dc50"
+  },
+  {
+    "seq": 105,
+    "timestamp": "2026-05-01T00:40:28-07:00",
+    "commit_hash": "0fad6e1e1cb3ce88413ca54212807f9ebb11dc50",
+    "commit_short": "0fad6e1",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2"
+  },
+  {
+    "seq": 106,
+    "timestamp": "2026-05-01T00:38:52-07:00",
+    "commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2",
+    "commit_short": "6074eb1",
+    "code_fingerprint": "45131bbfbc34c700f37c7a2ccb80ea73c6b319ecf2e5cf20ccee70332a2eb2f9",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "combine.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+28/-89); key paths: bridge8-patched.html, combine.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6074eb1be207e02c35ef43fceda38081481019a2:bridge8-patched.html",
+      "6074eb1be207e02c35ef43fceda38081481019a2:combine.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc"
+  },
+  {
+    "seq": 107,
+    "timestamp": "2026-04-30T19:12:48-07:00",
+    "commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc",
+    "commit_short": "1ca55a4",
+    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-21); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "1ca55a4db797027a611be068345f5d002e5ba7dc:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269"
+  },
+  {
+    "seq": 108,
+    "timestamp": "2026-04-30T19:12:32-07:00",
+    "commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269",
+    "commit_short": "75f8049",
+    "code_fingerprint": "b076bf56fdca9239433888816749094ffa315e8beebf7ab1669dacd4b77a13fa",
+    "primary_filename": "combine.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "combine.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+110/-11); key paths: combine.html, folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "75f804905813803e1af5c50c2872a79b1c5d9269:combine.html",
+      "75f804905813803e1af5c50c2872a79b1c5d9269:folder.html"
+    ],
+    "launch_ref": "combine.html",
+    "note": "Inferred impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4cdceee325361d42c14d254d65338e6cdc417ea3"
+  },
+  {
+    "seq": 109,
+    "timestamp": "2026-04-30T19:11:41-07:00",
+    "commit_hash": "4cdceee325361d42c14d254d65338e6cdc417ea3",
+    "commit_short": "4cdceee",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a"
+  },
+  {
+    "seq": 110,
+    "timestamp": "2026-04-30T19:11:29-07:00",
+    "commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a",
+    "commit_short": "9807fc9",
+    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-21); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "9807fc9d9ee78265619f56573090a33dd8fae85a:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "934bea854b4d8131b28eab028e0dde85f53cb70c"
+  },
+  {
+    "seq": 111,
+    "timestamp": "2026-04-30T17:29:57-07:00",
+    "commit_hash": "934bea854b4d8131b28eab028e0dde85f53cb70c",
+    "commit_short": "934bea8",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287"
+  },
+  {
+    "seq": 112,
+    "timestamp": "2026-04-30T17:29:42-07:00",
+    "commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287",
+    "commit_short": "505ee36",
+    "code_fingerprint": "cc0985e2c4b673cf467e69ed79f4e6a0a37a092ced406d9586fdbd2999e92a5d",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+17/-12); key paths: folder.html.",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "505ee3639da7242f762ffc75f6426ad242cfb287:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: ui/ux flow changes.",
+    "previous_commit_hash": "b488a29cb1efbc9ac9494b6d3c3c144a8c0d904f"
+  },
+  {
+    "seq": 113,
+    "timestamp": "2026-04-30T15:37:38-07:00",
+    "commit_hash": "b488a29cb1efbc9ac9494b6d3c3c144a8c0d904f",
+    "commit_short": "b488a29",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a"
+  },
+  {
+    "seq": 114,
+    "timestamp": "2026-04-30T15:37:26-07:00",
+    "commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a",
+    "commit_short": "0109ef7",
+    "code_fingerprint": "4b13eb54734afbb3d2bcd65274c2642a682768150b90f078d3bdab86af06f28d",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+9/-9); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0109ef79bf0d709dcf6db76489132abdfda1b83a:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "afa2e7d25bb456cbe054c40ee32a6ef4dabea51a"
+  },
+  {
+    "seq": 115,
+    "timestamp": "2026-04-30T15:26:28-07:00",
+    "commit_hash": "afa2e7d25bb456cbe054c40ee32a6ef4dabea51a",
+    "commit_short": "afa2e7d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a"
+  },
+  {
+    "seq": 116,
+    "timestamp": "2026-04-30T15:25:02-07:00",
+    "commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a",
+    "commit_short": "47d49d4",
+    "code_fingerprint": "97f96f03041ba26112366f457f65ed57557094751c9d13e6b1615db7f13290fa",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1425/-1286); key paths: folder.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f"
+  },
+  {
+    "seq": 117,
+    "timestamp": "2026-04-30T09:52:39-07:00",
+    "commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f",
+    "commit_short": "f5ca35c",
+    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39"
+  },
+  {
+    "seq": 118,
+    "timestamp": "2026-04-30T09:52:21-07:00",
+    "commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39",
+    "commit_short": "000d821",
+    "code_fingerprint": "c66a4f6033dd6d9befd2ec40c624a24b4a46b33e451fdb698c19902eb66e7b50",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+17/-1574); key paths: bridge8-patched.html, folder-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:bridge8-patched.html",
+      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:folder-v1.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "569a703dae03c627ee7f04bcbb1bfa2074566da5"
+  },
+  {
+    "seq": 119,
+    "timestamp": "2026-04-30T09:43:21-07:00",
+    "commit_hash": "569a703dae03c627ee7f04bcbb1bfa2074566da5",
+    "commit_short": "569a703",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4"
+  },
+  {
+    "seq": 120,
+    "timestamp": "2026-04-30T09:43:05-07:00",
+    "commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4",
+    "commit_short": "5fbfd05",
+    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-patched.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5fbfd050889202865fd1d369a9f9f46835347cf4:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ee01d9435c3948ae0af40ab48a9e202c43868f33"
+  },
+  {
+    "seq": 121,
+    "timestamp": "2026-04-30T05:58:19-07:00",
+    "commit_hash": "ee01d9435c3948ae0af40ab48a9e202c43868f33",
+    "commit_short": "ee01d94",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b"
+  },
+  {
+    "seq": 122,
+    "timestamp": "2026-04-30T05:58:04-07:00",
+    "commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b",
+    "commit_short": "612ed7c",
+    "code_fingerprint": "e5bbdcc50e5d4154fbf9fa89ce596b893f6c558a89db083b32ab0a2956391286",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-10); key paths: folder-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "612ed7c646da2e6fe69bd82c2f57013ebdecc65b:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Inferred impacts: normalization, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2f474239b8c20296fb4ee6bdd95e705f84605792"
+  },
+  {
+    "seq": 123,
+    "timestamp": "2026-04-29T20:48:29-07:00",
+    "commit_hash": "2f474239b8c20296fb4ee6bdd95e705f84605792",
+    "commit_short": "2f47423",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826"
+  },
+  {
+    "seq": 124,
+    "timestamp": "2026-04-29T20:48:12-07:00",
+    "commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826",
+    "commit_short": "47dcdfe",
+    "code_fingerprint": "d997591f10449d2ba31886b8dbd9f66d6f6f414a8c73fe3f95ab1a891207d3c4",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-3); key paths: folder-v1.html.",
+    "functional_impacts": [
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "47dcdfe54ff286772521ccc0992d4506c8807826:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Inferred impacts: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "fa2c2c7885a9db8c35c398946f6cb6ef55b72339"
+  },
+  {
+    "seq": 125,
+    "timestamp": "2026-04-29T15:30:02-07:00",
+    "commit_hash": "fa2c2c7885a9db8c35c398946f6cb6ef55b72339",
+    "commit_short": "fa2c2c7",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a"
+  },
+  {
+    "seq": 126,
+    "timestamp": "2026-04-29T15:28:50-07:00",
+    "commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a",
+    "commit_short": "51fdf0b",
+    "code_fingerprint": "73e06a56193f04241aa2e76bab7109e2a8e5f5acc78069e4e1e43645b68947b0",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+7/-4); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "51fdf0baf671eca52961f8ae50683f2257f4860a:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, joining/rejoining flow, remediation/repair/fix behavior.",
+    "previous_commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8"
+  },
+  {
+    "seq": 127,
+    "timestamp": "2026-04-29T15:13:46-07:00",
+    "commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8",
+    "commit_short": "9f9f905",
+    "code_fingerprint": "72b442e36cbd488b720d9d9f07b61444a73393c29d10b400abbd9a946d4cf3d8",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+13/-46); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9f9f905d5e81a12101a8175e9ede5772bc0276a8:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8"
+  },
+  {
+    "seq": 128,
+    "timestamp": "2026-04-29T14:53:22-07:00",
+    "commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8",
+    "commit_short": "78b712f",
+    "code_fingerprint": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-26); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "78b712f6f394afc43c81e0edb6236379401c21d8:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee"
+  },
+  {
+    "seq": 129,
+    "timestamp": "2026-04-29T14:53:05-07:00",
+    "commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee",
+    "commit_short": "8e48d01",
+    "code_fingerprint": "792526c369bf80bc46f7299d4befb81d6621f20a6d8c537ad79dcbf4e5c7c78d",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 2 file(s) (+81/-59); key paths: bridge8.html, folder-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:bridge8.html",
+      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:folder-v1.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f103ade44d16f1e40c5ba545352ea1be0b45deaf"
+  },
+  {
+    "seq": 130,
+    "timestamp": "2026-04-29T14:52:42-07:00",
+    "commit_hash": "f103ade44d16f1e40c5ba545352ea1be0b45deaf",
+    "commit_short": "f103ade",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354"
+  },
+  {
+    "seq": 131,
+    "timestamp": "2026-04-29T14:52:28-07:00",
+    "commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354",
+    "commit_short": "9a517b6",
+    "code_fingerprint": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-26); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9a517b6654ac77afe65153ff64e781d02f25a354:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7542365931a6ebcb792f375d2384b062343ff818"
+  },
+  {
+    "seq": 132,
+    "timestamp": "2026-04-29T14:26:11-07:00",
+    "commit_hash": "7542365931a6ebcb792f375d2384b062343ff818",
+    "commit_short": "7542365",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11"
+  },
+  {
+    "seq": 133,
+    "timestamp": "2026-04-29T14:25:57-07:00",
+    "commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11",
+    "commit_short": "f92b1a8",
+    "code_fingerprint": "864f0eeff516258423dd51c23108c3a60954188271104480c8c6a5f5a86b29cd",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+37/-9); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f92b1a8823d53cfdb012e2acfe3081f5ea12de11:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f"
+  },
+  {
+    "seq": 134,
+    "timestamp": "2026-04-29T13:37:59-07:00",
+    "commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f",
+    "commit_short": "a8459ec",
+    "code_fingerprint": "8f0dca3def9c684d12ba3efafb6f05eda1e3c64e1c78ef9a6892fa45e5fefe0c",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+22/-9); key paths: bridge8.html.",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a8459ec1dcc0b081f970b53b341167e8e5cd829f:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029"
+  },
+  {
+    "seq": 135,
+    "timestamp": "2026-04-29T12:57:43-07:00",
+    "commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029",
+    "commit_short": "70905ee",
+    "code_fingerprint": "735cdce0dccea703583b3fd33ceb72a4b957f86c333196d395b27703688c8db1",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+350/-209); key paths: bridge8.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "70905ee5ad416786a2cfefa64f619d0ed4eb2029:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e4ebf4d1058ed4efbb0d30e4da68005d801eec44"
+  },
+  {
+    "seq": 136,
+    "timestamp": "2026-04-29T11:50:00-07:00",
+    "commit_hash": "e4ebf4d1058ed4efbb0d30e4da68005d801eec44",
+    "commit_short": "e4ebf4d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007"
+  },
+  {
+    "seq": 137,
+    "timestamp": "2026-04-29T11:49:48-07:00",
+    "commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007",
+    "commit_short": "5498e01",
+    "code_fingerprint": "6efe9dd0cbc45aa93c722855ec9c01bb3370730cc985c978ee617f8bb649870f",
+    "primary_filename": "bridge5-reliability-implementation-guide.md",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge5-reliability-implementation-guide.md"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+411/-0); key paths: bridge5-reliability-implementation-guide.md.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5498e012fcbea3d98b08ac8f8719f3483ef9c007:bridge5-reliability-implementation-guide.md"
+    ],
+    "launch_ref": "bridge5-reliability-implementation-guide.md",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "cb7f4a5fb2166bd9ec3b9287eb1a1d35d6fc77ba"
+  },
+  {
+    "seq": 138,
+    "timestamp": "2026-04-29T10:51:56-07:00",
+    "commit_hash": "cb7f4a5fb2166bd9ec3b9287eb1a1d35d6fc77ba",
+    "commit_short": "cb7f4a5",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded"
+  },
+  {
+    "seq": 139,
+    "timestamp": "2026-04-29T10:36:35-07:00",
+    "commit_hash": "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded",
+    "commit_short": "9f6ea5b",
+    "code_fingerprint": "93ec0a491c353f0872762d5267b6aea8d6b377f72e20f5379db04c4a670127cb",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1/-1); key paths: bridge5.html.",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "call termination behavior"
+    ],
+    "blob_refs": [
+      "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Inferred impacts: joining/rejoining flow, call termination behavior.",
+    "previous_commit_hash": "4cb828fb96b0d7102a17f345aa8cf96684fb6ed1"
+  },
+  {
+    "seq": 140,
+    "timestamp": "2026-04-29T10:20:29-07:00",
+    "commit_hash": "4cb828fb96b0d7102a17f345aa8cf96684fb6ed1",
+    "commit_short": "4cb828f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5"
+  },
+  {
+    "seq": 141,
+    "timestamp": "2026-04-29T10:20:03-07:00",
+    "commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5",
+    "commit_short": "a91df5c",
+    "code_fingerprint": "f1786ef0b28fbb6e56b257e956aef6c9e6886e4465b8df0479468c06532e012e",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+79/-20); key paths: folder-v1.html.",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a91df5c90b90d2debc24f01d5f627ec973ad05e5:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Inferred impacts: normalization, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3771cba07ddd8d7bc9dc1b5bf93141e7f9d184a7"
+  },
+  {
+    "seq": 142,
+    "timestamp": "2026-04-29T10:13:39-07:00",
+    "commit_hash": "3771cba07ddd8d7bc9dc1b5bf93141e7f9d184a7",
+    "commit_short": "3771cba",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f"
+  },
+  {
+    "seq": 143,
+    "timestamp": "2026-04-29T10:09:14-07:00",
+    "commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f",
+    "commit_short": "da34712",
+    "code_fingerprint": "1e06043cd0030a497fc58aad99c67809600395c9ea1d55fa985ff54cb2af3104",
+    "primary_filename": "mvp.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "mvp.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+1200/-0); key paths: mvp.html.",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "da3471207c91bbb0eab4c89b80cb7d0e8896375f:mvp.html"
+    ],
+    "launch_ref": "mvp.html",
+    "note": "Inferred impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2"
+  },
+  {
+    "seq": 144,
+    "timestamp": "2026-04-29T04:02:01-07:00",
+    "commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2",
+    "commit_short": "334bb37",
+    "code_fingerprint": "597f08ccd96f53d0613bdf40db730ac48ca002fdb94a65801088dbb819520b7f",
+    "primary_filename": "bridge4.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge4.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+257/-212); key paths: bridge4.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "334bb3779a443984362ae932b2d77b7d7449eca2:bridge4.html"
+    ],
+    "launch_ref": "bridge4.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c5dcad79008fa3bab84889ea0282052e4039a7cd"
+  },
+  {
+    "seq": 145,
+    "timestamp": "2026-04-29T03:47:24-07:00",
+    "commit_hash": "c5dcad79008fa3bab84889ea0282052e4039a7cd",
+    "commit_short": "c5dcad7",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b"
+  },
+  {
+    "seq": 146,
+    "timestamp": "2026-04-29T03:43:03-07:00",
+    "commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b",
+    "commit_short": "edb2b14",
+    "code_fingerprint": "adcaa871588b0cf77fca60db45f67dc10ca76d052c26cfae57b7011525be85c6",
+    "primary_filename": "bridge3.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge3.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+33/-10); key paths: bridge3.html.",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "edb2b1455cbbe3e5b0a15b998acc68931606ae9b:bridge3.html"
+    ],
+    "launch_ref": "bridge3.html",
+    "note": "Inferred impacts: transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e5cc4459d6810f99e3905e7e1a754c162a8e7d80"
+  },
+  {
+    "seq": 147,
+    "timestamp": "2026-04-29T02:48:36-07:00",
+    "commit_hash": "e5cc4459d6810f99e3905e7e1a754c162a8e7d80",
+    "commit_short": "e5cc445",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6"
+  },
+  {
+    "seq": 148,
+    "timestamp": "2026-04-29T02:43:41-07:00",
+    "commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6",
+    "commit_short": "5de44ec",
+    "code_fingerprint": "b59df86da5495be79f711042396670871c56ea2a87a0a82e01a3f40f55545e6b",
+    "primary_filename": "bridge3.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge3.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+301/-86); key paths: bridge3.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5de44ec461db4973f9253be2f1224da1bc802af6:bridge3.html"
+    ],
+    "launch_ref": "bridge3.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579"
+  },
+  {
+    "seq": 149,
+    "timestamp": "2026-04-29T02:02:52-07:00",
+    "commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579",
+    "commit_short": "d226e42",
+    "code_fingerprint": "c04e237dc345efd5272f3d6c99e7eea2e50daa2f1b7105b2661239b839f92c63",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+117/-76); key paths: bridge5.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d226e42a50e87bcca0724c882cfffe7870b16579:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad"
+  },
+  {
+    "seq": 150,
+    "timestamp": "2026-04-29T01:59:17-07:00",
+    "commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad",
+    "commit_short": "075ddc1",
+    "code_fingerprint": "9a4155d76e21298008ce53d9776cf0478aa876eb0495dd9beabc87118e4fc321",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+34/-19); key paths: bridge5.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "80f7e99160da6d88863758680feec842cde59544"
+  },
+  {
+    "seq": 151,
+    "timestamp": "2026-04-29T01:03:40-07:00",
+    "commit_hash": "80f7e99160da6d88863758680feec842cde59544",
+    "commit_short": "80f7e99",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "74b6cc2ccd14140b8ff3c6334c82a0441e030788"
+  },
+  {
+    "seq": 152,
+    "timestamp": "2026-04-29T00:59:58-07:00",
+    "commit_hash": "74b6cc2ccd14140b8ff3c6334c82a0441e030788",
+    "commit_short": "74b6cc2",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a99c5f67c13ad33e75e4b984167778c985c100ef"
+  },
+  {
+    "seq": 153,
+    "timestamp": "2026-04-29T00:59:32-07:00",
+    "commit_hash": "a99c5f67c13ad33e75e4b984167778c985c100ef",
+    "commit_short": "a99c5f6",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388"
+  },
+  {
+    "seq": 154,
+    "timestamp": "2026-04-29T00:16:16-07:00",
+    "commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388",
+    "commit_short": "b940a35",
+    "code_fingerprint": "fdb02fb6d97abec8dd5d7433b022cc956430f63f5bbbf80ea33da467701d48eb",
+    "primary_filename": "bridge4.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge4.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+297/-112); key paths: bridge4.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b940a35c57c2249a1556ec296ab98ce1c4ab8388:bridge4.html"
+    ],
+    "launch_ref": "bridge4.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "fda8ffabef024f45583ed863e8583d8382b84b71"
+  },
+  {
+    "seq": 155,
+    "timestamp": "2026-04-28T23:49:17-07:00",
+    "commit_hash": "fda8ffabef024f45583ed863e8583d8382b84b71",
+    "commit_short": "fda8ffa",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "425d9040a45366684ce38b4d6e1046ffffda1578"
+  },
+  {
+    "seq": 156,
+    "timestamp": "2026-04-28T23:20:20-07:00",
+    "commit_hash": "425d9040a45366684ce38b4d6e1046ffffda1578",
+    "commit_short": "425d904",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous timeline entry.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18"
+  },
+  {
+    "seq": 157,
+    "timestamp": "2026-04-28T23:16:44-07:00",
+    "commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18",
+    "commit_short": "9562b49",
+    "code_fingerprint": "a3aed8ccb9a777a0c4a266a828ee6e10a86e40a27af83d9bb7c4cb4364d58ddc",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-22); key paths: bridge5.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9562b493dc73cbcf7078ce1158ccce866241ac18:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b"
+  },
+  {
+    "seq": 158,
+    "timestamp": "2026-04-28T22:46:25-07:00",
+    "commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b",
+    "commit_short": "76a9c93",
+    "code_fingerprint": "4207d74943cc176f1fe5563c6f4859a2356d680e43096672e22e9b076f081889",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 1 file(s) (+242/-290); key paths: bridge5.html.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "76a9c93a783e1ac0b80d939a3062007dd82e609b:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960"
+  },
+  {
+    "seq": 159,
+    "timestamp": "2026-04-28T22:28:50-07:00",
+    "commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960",
+    "commit_short": "3ecf332",
+    "code_fingerprint": "e48c2780ab268b54f65b1b6d276c8cc93bcb4e945469791aaf5c07250458d211",
+    "primary_filename": ".bolt/config.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": ".bolt/config.json"
+      },
+      {
+        "status": "A",
+        "path": ".bolt/prompt"
+      },
+      {
+        "status": "A",
+        "path": ".github/workflows/static.yml"
+      },
+      {
+        "status": "A",
+        "path": ".gitignore"
+      },
+      {
+        "status": "A",
+        "path": "2vid.html"
+      },
+      {
+        "status": "A",
+        "path": "Boid-fun.html"
+      },
+      {
+        "status": "A",
+        "path": "FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md"
+      },
+      {
+        "status": "A",
+        "path": "GET_WELL_PATCH_PROMPT.md"
+      },
+      {
+        "status": "A",
+        "path": "Instructions.txt"
+      },
+      {
+        "status": "A",
+        "path": "MyPlaceToChill.html"
+      },
+      {
+        "status": "A",
+        "path": "QA_LIFECYCLE_SCRIPT.md"
+      },
+      {
+        "status": "A",
+        "path": "README.md"
+      },
+      {
+        "status": "A",
+        "path": "SECRETS.md"
+      },
+      {
+        "status": "A",
+        "path": "SESSION_INSTRUCTION_SET.md"
+      },
+      {
+        "status": "A",
+        "path": "TALK-SAY-PRD-v1.md"
+      },
+      {
+        "status": "A",
+        "path": "TALK-SAY-PRD.md"
+      },
+      {
+        "status": "A",
+        "path": "Talk-Say-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "UI-v2.html.html"
+      },
+      {
+        "status": "A",
+        "path": "Visual MAD v3.html"
+      },
+      {
+        "status": "A",
+        "path": "ai-jobs-kanban (3).html"
+      },
+      {
+        "status": "A",
+        "path": "ai-jobs-kanban.json"
+      },
+      {
+        "status": "A",
+        "path": "app.html"
+      },
+      {
+        "status": "A",
+        "path": "battle.html"
+      },
+      {
+        "status": "A",
+        "path": "biord.html"
+      },
+      {
+        "status": "A",
+        "path": "block.html"
+      },
+      {
+        "status": "A",
+        "path": "blue.html"
+      },
+      {
+        "status": "A",
+        "path": "boid perp-plus.html"
+      },
+      {
+        "status": "A",
+        "path": "boid-perp.html"
+      },
+      {
+        "status": "A",
+        "path": "boidfloid wb.html"
+      },
+      {
+        "status": "A",
+        "path": "boidfloid-pro.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (20).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (5).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (6).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (7).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-c.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-dcr.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-transcript-analysis.md"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge1-test-matrix.md"
+      },
+      {
+        "status": "A",
+        "path": "bridge1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge4.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5a.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5b.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5c.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge6.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge8.html"
+      },
+      {
+        "status": "A",
+        "path": "buildit.html"
+      },
+      {
+        "status": "A",
+        "path": "casa.html"
+      },
+      {
+        "status": "A",
+        "path": "chat.html"
+      },
+      {
+        "status": "A",
+        "path": "clock.html"
+      },
+      {
+        "status": "A",
+        "path": "combined_oauth_server_for_repo.js"
+      },
+      {
+        "status": "A",
+        "path": "compound.html"
+      },
+      {
+        "status": "A",
+        "path": "convo.html"
+      },
+      {
+        "status": "A",
+        "path": "core.html"
+      },
+      {
+        "status": "A",
+        "path": "currency.html"
+      },
+      {
+        "status": "A",
+        "path": "dash.html"
+      },
+      {
+        "status": "A",
+        "path": "dev.html"
+      },
+      {
+        "status": "A",
+        "path": "dg.html"
+      },
+      {
+        "status": "A",
+        "path": "diag.html"
+      },
+      {
+        "status": "A",
+        "path": "do.html"
+      },
+      {
+        "status": "A",
+        "path": "dualtime.html"
+      },
+      {
+        "status": "A",
+        "path": "enhanced-fixed.js"
+      },
+      {
+        "status": "A",
+        "path": "enhanced-hitomezashi.html"
+      },
+      {
+        "status": "A",
+        "path": "enhanced.js"
+      },
+      {
+        "status": "A",
+        "path": "eslint.config.js"
+      },
+      {
+        "status": "A",
+        "path": "fastType/deleteme"
+      },
+      {
+        "status": "A",
+        "path": "fastType/fastText.common.wasm"
+      },
+      {
+        "status": "A",
+        "path": "fastType/lid.176.ftz"
+      },
+      {
+        "status": "A",
+        "path": "fetch-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "fetch.html"
+      },
+      {
+        "status": "A",
+        "path": "finapp.html"
+      },
+      {
+        "status": "A",
+        "path": "flags.png"
+      },
+      {
+        "status": "A",
+        "path": "fly.html"
+      },
+      {
+        "status": "A",
+        "path": "flyv1.html"
+      },
+      {
+        "status": "A",
+        "path": "flyv2.html"
+      },
+      {
+        "status": "A",
+        "path": "folder-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "folder.html"
+      },
+      {
+        "status": "A",
+        "path": "g.html"
+      },
+      {
+        "status": "A",
+        "path": "ga.html"
+      },
+      {
+        "status": "A",
+        "path": "game.html"
+      },
+      {
+        "status": "A",
+        "path": "gdrive-metadata-extraction.html"
+      },
+      {
+        "status": "A",
+        "path": "getit.html"
+      },
+      {
+        "status": "A",
+        "path": "gg.html"
+      },
+      {
+        "status": "A",
+        "path": "ggg.html"
+      },
+      {
+        "status": "A",
+        "path": "gggg.html"
+      },
+      {
+        "status": "A",
+        "path": "gh.html"
+      },
+      {
+        "status": "A",
+        "path": "gh.html.html"
+      },
+      {
+        "status": "A",
+        "path": "git.html"
+      },
+      {
+        "status": "A",
+        "path": "github.html"
+      },
+      {
+        "status": "A",
+        "path": "glate.html"
+      },
+      {
+        "status": "A",
+        "path": "goji.html"
+      },
+      {
+        "status": "A",
+        "path": "groove.html"
+      },
+      {
+        "status": "A",
+        "path": "groovy.html"
+      },
+      {
+        "status": "A",
+        "path": "gt.html"
+      },
+      {
+        "status": "A",
+        "path": "gtg.html"
+      },
+      {
+        "status": "A",
+        "path": "hexi.html"
+      },
+      {
+        "status": "A",
+        "path": "home.html"
+      },
+      {
+        "status": "A",
+        "path": "index copy.html"
+      },
+      {
+        "status": "A",
+        "path": "index.html"
+      },
+      {
+        "status": "A",
+        "path": "ithub.html"
+      },
+      {
+        "status": "A",
+        "path": "join.html"
+      },
+      {
+        "status": "A",
+        "path": "joy.html"
+      },
+      {
+        "status": "A",
+        "path": "kaleidoscope_visualizer_advanced.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban.json"
+      },
+      {
+        "status": "A",
+        "path": "kanban2.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban3.html"
+      },
+      {
+        "status": "A",
+        "path": "landmark-bridge.html"
+      },
+      {
+        "status": "A",
+        "path": "layout.html"
+      },
+      {
+        "status": "A",
+        "path": "lim.html"
+      },
+      {
+        "status": "A",
+        "path": "liminal_breach_stable_classic_graphics.html"
+      },
+      {
+        "status": "A",
+        "path": "love.html"
+      },
+      {
+        "status": "A",
+        "path": "love2.html"
+      },
+      {
+        "status": "A",
+        "path": "loveit.html"
+      },
+      {
+        "status": "A",
+        "path": "magic+.html"
+      },
+      {
+        "status": "A",
+        "path": "magic.html"
+      },
+      {
+        "status": "A",
+        "path": "menu.html"
+      },
+      {
+        "status": "A",
+        "path": "metadata-sync-worker.js"
+      },
+      {
+        "status": "A",
+        "path": "metadata_extractor_lib.js"
+      },
+      {
+        "status": "A",
+        "path": "metric.html"
+      },
+      {
+        "status": "A",
+        "path": "mic.html"
+      },
+      {
+        "status": "A",
+        "path": "milkyway.html"
+      },
+      {
+        "status": "A",
+        "path": "mob.html"
+      },
+      {
+        "status": "A",
+        "path": "mobapp.html"
+      },
+      {
+        "status": "A",
+        "path": "mobweb (1) (2).html"
+      },
+      {
+        "status": "A",
+        "path": "mobweb.html"
+      },
+      {
+        "status": "A",
+        "path": "noon-dear.html"
+      },
+      {
+        "status": "A",
+        "path": "noon.html"
+      },
+      {
+        "status": "A",
+        "path": "notify.html"
+      },
+      {
+        "status": "A",
+        "path": "onedrive.html"
+      },
+      {
+        "status": "A",
+        "path": "orb.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-dev-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-hold.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-v0.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-login.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-metadata-worker.js"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-sw.js"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v10.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v11.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v12.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v13.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14 copy.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14.html.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14b.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v15.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v3a.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v5-old.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v5.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8.html"
+      },
+      {
+        "status": "A",
+        "path": "p.html"
+      },
+      {
+        "status": "A",
+        "path": "package-lock.json"
+      },
+      {
+        "status": "A",
+        "path": "package.json"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/logging.json"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/script-old.js"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/script.js"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/download.jpeg"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/msg.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/sound.mp3"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/joy/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/love/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "partial.html"
+      },
+      {
+        "status": "A",
+        "path": "peace.html"
+      },
+      {
+        "status": "A",
+        "path": "pend.html"
+      },
+      {
+        "status": "A",
+        "path": "plan.html"
+      },
+      {
+        "status": "A",
+        "path": "playdoh.html"
+      },
+      {
+        "status": "A",
+        "path": "portal-create.html"
+      },
+      {
+        "status": "A",
+        "path": "portal.html"
+      },
+      {
+        "status": "A",
+        "path": "postcss.config.js"
+      },
+      {
+        "status": "A",
+        "path": "quilt.html"
+      },
+      {
+        "status": "A",
+        "path": "rec08.html"
+      },
+      {
+        "status": "A",
+        "path": "reco01.html"
+      },
+      {
+        "status": "A",
+        "path": "reco02.html"
+      },
+      {
+        "status": "A",
+        "path": "reco03.html"
+      },
+      {
+        "status": "A",
+        "path": "reco04.html"
+      },
+      {
+        "status": "A",
+        "path": "reco05.html"
+      },
+      {
+        "status": "A",
+        "path": "reco06.html"
+      },
+      {
+        "status": "A",
+        "path": "reco07.html"
+      },
+      {
+        "status": "A",
+        "path": "repoblast.html"
+      },
+      {
+        "status": "A",
+        "path": "repolist.html"
+      },
+      {
+        "status": "A",
+        "path": "restructure.txt"
+      },
+      {
+        "status": "A",
+        "path": "roll.html"
+      },
+      {
+        "status": "A",
+        "path": "rss.html"
+      },
+      {
+        "status": "A",
+        "path": "sacred.html"
+      },
+      {
+        "status": "A",
+        "path": "say-alpha.html"
+      },
+      {
+        "status": "A",
+        "path": "say.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v2.html.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit.html"
+      },
+      {
+        "status": "A",
+        "path": "scribe.html"
+      },
+      {
+        "status": "A",
+        "path": "scrub.html"
+      },
+      {
+        "status": "A",
+        "path": "shad.html"
+      },
+      {
+        "status": "A",
+        "path": "shader.html"
+      },
+      {
+        "status": "A",
+        "path": "sigma.html"
+      },
+      {
+        "status": "A",
+        "path": "slideswipe.html"
+      },
+      {
+        "status": "A",
+        "path": "solar.html"
+      },
+      {
+        "status": "A",
+        "path": "spin.html"
+      },
+      {
+        "status": "A",
+        "path": "src/App.tsx"
+      },
+      {
+        "status": "A",
+        "path": "src/index.css"
+      },
+      {
+        "status": "A",
+        "path": "src/main.tsx"
+      },
+      {
+        "status": "A",
+        "path": "src/vite-env.d.ts"
+      },
+      {
+        "status": "A",
+        "path": "stars.html"
+      },
+      {
+        "status": "A",
+        "path": "stt-test.html"
+      },
+      {
+        "status": "A",
+        "path": "supabase/functions/venice-ai/index.ts"
+      },
+      {
+        "status": "A",
+        "path": "sw-enhanced.js"
+      },
+      {
+        "status": "A",
+        "path": "sy.html"
+      },
+      {
+        "status": "A",
+        "path": "synesthetic_experience_updated.html"
+      },
+      {
+        "status": "A",
+        "path": "tab.html"
+      },
+      {
+        "status": "A",
+        "path": "tag-example.html"
+      },
+      {
+        "status": "A",
+        "path": "tailwind.config.js"
+      },
+      {
+        "status": "A",
+        "path": "talk-notifications-sw.js"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-claude.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-gemini.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-prd-v1.7.pdf"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.5 (1).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.5 (2).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.6.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v3.2 (3).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v3.2 (5).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-venice.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say.html"
+      },
+      {
+        "status": "A",
+        "path": "talk.html"
+      },
+      {
+        "status": "A",
+        "path": "talk.webmanifest"
+      },
+      {
+        "status": "A",
+        "path": "talk01.html"
+      },
+      {
+        "status": "A",
+        "path": "talkv2.html"
+      },
+      {
+        "status": "A",
+        "path": "tb-app.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-media.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-transcribe.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-translate.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-transport.js"
+      },
+      {
+        "status": "A",
+        "path": "test-outline.md"
+      },
+      {
+        "status": "A",
+        "path": "test-pam (2).html"
+      },
+      {
+        "status": "A",
+        "path": "test-pam-objective-analysis-plan.md"
+      },
+      {
+        "status": "A",
+        "path": "test-pam.html"
+      },
+      {
+        "status": "A",
+        "path": "test-rollback.html"
+      },
+      {
+        "status": "A",
+        "path": "test.html"
+      },
+      {
+        "status": "A",
+        "path": "test01.html"
+      },
+      {
+        "status": "A",
+        "path": "test02.html"
+      },
+      {
+        "status": "A",
+        "path": "test03.html"
+      },
+      {
+        "status": "A",
+        "path": "testplan.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v7 (3).html"
+      },
+      {
+        "status": "A",
+        "path": "tilt-balance-mobile-fixed-v3-1.html"
+      },
+      {
+        "status": "A",
+        "path": "time.html"
+      },
+      {
+        "status": "A",
+        "path": "tk.html"
+      },
+      {
+        "status": "A",
+        "path": "tksy.html"
+      },
+      {
+        "status": "A",
+        "path": "tracker.html"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.app.json"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.json"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.node.json"
+      },
+      {
+        "status": "A",
+        "path": "ugh.html"
+      },
+      {
+        "status": "A",
+        "path": "update_test_html_patch_prompt.txt"
+      },
+      {
+        "status": "A",
+        "path": "uri.html"
+      },
+      {
+        "status": "A",
+        "path": "v.html"
+      },
+      {
+        "status": "A",
+        "path": "venice.html"
+      },
+      {
+        "status": "A",
+        "path": "vite.config.ts"
+      },
+      {
+        "status": "A",
+        "path": "voice-c.html"
+      },
+      {
+        "status": "A",
+        "path": "voice.html"
+      },
+      {
+        "status": "A",
+        "path": "voicehelper.html"
+      },
+      {
+        "status": "A",
+        "path": "vsay.html"
+      },
+      {
+        "status": "A",
+        "path": "vvv.html"
+      },
+      {
+        "status": "A",
+        "path": "vvvv.html"
+      },
+      {
+        "status": "A",
+        "path": "week.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend.html"
+      },
+      {
+        "status": "A",
+        "path": "x.html"
+      },
+      {
+        "status": "A",
+        "path": "xlate.html"
+      },
+      {
+        "status": "A",
+        "path": "xml.html"
+      },
+      {
+        "status": "A",
+        "path": "zoom.html"
+      }
+    ],
+    "description_delta_from_previous": "Patch touched 287 file(s) (+343512/-0); key paths: .bolt/config.json, .bolt/prompt, .github/workflows/static.yml.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/config.json",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/prompt",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.github/workflows/static.yml",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.gitignore",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:2vid.html",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:Boid-fun.html",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:GET_WELL_PATCH_PROMPT.md"
+    ],
+    "launch_ref": ".bolt/config.json",
+    "note": "Inferred impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": null
+  }
+]

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "axios": "^0.27.2",
     "express": "^4.18.1"
+  },
+  "scripts": {
+    "build:lineage": "node scripts/build-lineage-model.mjs"
   }
 }

--- a/repo.html
+++ b/repo.html
@@ -3,124 +3,49 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Bridge Timeline + Lineage Workbench</title>
+  <title>Bridge Timeline Explorer</title>
   <style>
     :root { --bg:#0f172a; --panel:#111827; --line:#334155; --text:#e2e8f0; --muted:#94a3b8; --brand:#38bdf8; }
     * { box-sizing:border-box; }
     body { margin:0; font-family:Inter,system-ui,sans-serif; background:var(--bg); color:var(--text); }
-    .app { display:grid; grid-template-columns:320px 1fr; height:100vh; }
+    .app { display:grid; grid-template-columns:380px 1fr; height:100vh; }
     .left { background:#020617; border-right:1px solid var(--line); overflow:auto; }
     .right { overflow:auto; }
     .top { padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:#020617; z-index:10; }
-    .hamburger { background:transparent; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:6px 10px; cursor:pointer; }
-    .search { width:100%; margin-top:8px; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
+    .search { width:100%; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
     .list { padding:10px; display:flex; flex-direction:column; gap:6px; }
     .item { padding:8px; border:1px solid var(--line); border-radius:8px; cursor:pointer; background:#0b1220; }
     .item.active { border-color:var(--brand); }
-    .tabs { display:flex; gap:8px; padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--bg); z-index:5; }
-    .tab { background:#1e293b; color:var(--text); border:1px solid var(--line); border-radius:999px; padding:7px 12px; cursor:pointer; }
-    .tab.active { background:var(--brand); color:#001018; border-color:var(--brand); }
-    .pane { display:none; padding:10px; }
-    .pane.active { display:block; }
-    iframe { width:100%; height:70vh; border:1px solid var(--line); border-radius:10px; background:white; }
-    .grid2 { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+    .pane { padding:10px; }
     .card { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:10px; margin-bottom:10px; }
     .muted{ color:var(--muted); font-size:.9rem; }
-    .hidden-left .left { display:none; }
-    .hidden-left.app { grid-template-columns:1fr; }
-    a{ color:var(--brand); }
+    code { color:#bae6fd; }
   </style>
 </head>
 <body>
   <div class="app" id="app">
     <aside class="left">
       <div class="top">
-        <button class="hamburger" id="toggleNav">☰</button>
-        <input class="search" id="omni" placeholder="Omni search: file, tag, hash" />
+        <input class="search" id="omni" placeholder="Search hash, path, impact, summary" />
       </div>
       <div class="list" id="variantList"></div>
     </aside>
     <main class="right">
-      <div class="tabs">
-        <button class="tab active" data-tab="analysis">Analysis Run</button>
-        <button class="tab" data-tab="results">Lineage Results</button>
-        <button class="tab" data-tab="explorer">Manual Explorer</button>
-        <button class="tab" data-tab="compare">Side-by-Side</button>
-      </div>
-
-      <section class="pane active" id="analysis">
-        <div class="card"><strong>Production + Progress</strong><div class="muted" id="progress">Loading bridge timeline…</div></div>
-        <div class="card" id="analysisLog"></div>
-      </section>
-
-      <section class="pane" id="results">
-        <div class="card"><button class="tab" id="exportModel">Export timeline JSON model</button></div>
-        <div class="card" id="resultsList"></div>
-      </section>
-
       <section class="pane" id="explorer">
         <div class="card" id="activeMeta"></div>
-        <iframe id="preview"></iframe>
-      </section>
-
-      <section class="pane" id="compare">
-        <div class="card grid2">
-          <div><select id="leftPick"></select><iframe id="leftFrame"></iframe></div>
-          <div><select id="rightPick"></select><iframe id="rightFrame"></iframe></div>
-        </div>
       </section>
     </main>
   </div>
 <script>
-let all=[]; let shown=[]; let current=null; let timelineModel=[];
+let all=[]; let shown=[]; let current=null;
 const $=id=>document.getElementById(id);
 function esc(s){return String(s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
-function dt(x){return new Date(x||0).getTime()||0}
-function iso(x){const d=new Date(x||0); return Number.isNaN(d.getTime())?'1970-01-01T00:00:00.000Z':d.toISOString();}
-function inferFocus(tags){if(tags.includes('soft-delete')&&tags.includes('xml'))return 'Soft-delete + XML fix iteration.'; if(tags.includes('soft-delete'))return 'Soft-delete focused.'; if(tags.includes('xml'))return 'XML handling focused.'; if(tags.includes('patched'))return 'Patch stabilization attempt.'; if(tags.includes('restore'))return 'Rollback/restore exploration.'; return 'General iteration.';}
-async function loadBlobText(item){
-  if(item._blobText!==undefined) return item._blobText;
-  try{
-    const res=await fetch(item.blobUrl,{cache:'no-store'});
-    item._blobText=res.ok?await res.text():'';
-  }catch{ item._blobText=''; }
-  return item._blobText;
-}
-function summarizeDelta(prevText,nextText){
-  if(!prevText && nextText) return 'Initial version in timeline.';
-  if(prevText===nextText) return 'No textual delta from previous timeline item.';
-  const a=(prevText||'').split('\n'); const b=(nextText||'').split('\n');
-  let added=0, removed=0;
-  const prevSet=new Set(a); const nextSet=new Set(b);
-  for(const line of b){ if(!prevSet.has(line)) added++; }
-  for(const line of a){ if(!nextSet.has(line)) removed++; }
-  return `Changed from previous variant: +${added} / -${removed} unique lines.`;
-}
-async function buildTimelineModel(){
-  const sorted=[...shown].sort((a,b)=>dt(a.created)-dt(b.created)||dt(a.lastUpdated)-dt(b.lastUpdated));
-  const blobs=await Promise.all(sorted.map(loadBlobText));
-  timelineModel=sorted.map((item,idx)=>({
-    seq: idx+1,
-    timestamp: iso(item.lastUpdated||item.created),
-    commitid: item.commit,
-    filename: item.file,
-    description_delta_from_previous: summarizeDelta(blobs[idx-1]||'', blobs[idx]||''),
-    blob: item.blobUrl,
-    launch: item.launchUrl,
-    note: item.lineageNote||inferFocus(item.tags||[])
-  }));
-}
-function setCurrent(file){current=shown.find(x=>x.file===file)||shown[0]; if(!current)return; $('preview').src=current.launchUrl; $('activeMeta').innerHTML=`<strong>${esc(current.file)}</strong><br><span class='muted'>${esc(current.created)} | ${esc(current.commit.slice(0,10))}</span><div>${inferFocus(current.tags||[])}</div><div><a target='_blank' href='${esc(current.launchUrl)}'>Launch</a> · <a target='_blank' href='${esc(current.blobUrl)}'>Code blob</a></div>`; renderList();}
-function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.file===x.file?'active':''}' data-file='${esc(x.file)}'><strong>${esc(x.file)}</strong><div class='muted'>${esc((x.tags||[]).join(', '))}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrent(n.dataset.file)); }
-function renderResults(){ $('resultsList').innerHTML=timelineModel.map(row=>`<div class='card'><strong>${row.seq}. ${esc(row.filename)}</strong><div class='muted'>${esc(row.timestamp)} · ${esc(row.commitid.slice(0,12))}</div><div>${esc(row.description_delta_from_previous)}</div><div class='muted'>${esc(row.note)}</div></div>`).join(''); }
-function renderAnalysis(){ $('analysisLog').innerHTML=`<ol>${shown.map(x=>`<li><code>${esc(x.file)}</code> — ${esc(inferFocus(x.tags||[]))}</li>`).join('')}</ol>`; $('progress').textContent=`Completed: ${shown.length} bridge variants ordered and indexed.`; }
-function renderCompare(){ const opts=shown.map(x=>`<option value='${esc(x.file)}'>${esc(x.file)}</option>`).join(''); $('leftPick').innerHTML=opts; $('rightPick').innerHTML=opts; if(shown[0]) $('leftFrame').src=shown[0].launchUrl; if(shown[1]) $('rightFrame').src=shown[1].launchUrl; $('leftPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('leftFrame').src=f.launchUrl;}; $('rightPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('rightFrame').src=f.launchUrl;}; }
-async function rerender(){ await buildTimelineModel(); renderList(); renderResults(); renderAnalysis(); renderCompare(); if(!current&&shown[0]) setCurrent(shown[0].file); }
-$('omni').oninput=e=>{ const q=e.target.value.toLowerCase().trim(); shown=all.filter(x=>[x.file,x.commit,(x.tags||[]).join(' ')].join(' ').toLowerCase().includes(q)); shown.sort((a,b)=>dt(a.created)-dt(b.created)); current=null; rerender(); };
-$('toggleNav').onclick=()=>$('app').classList.toggle('hidden-left');
-$('exportModel').onclick=()=>{ const out=JSON.stringify(timelineModel,null,2); const blob=new Blob([out],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='bridge-lineage-timeline-model.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url),1000); };
-document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active')); t.classList.add('active'); document.querySelectorAll('.pane').forEach(p=>p.classList.remove('active')); $(t.dataset.tab).classList.add('active');});
-fetch('bridge-lineage.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{all=data.sort((a,b)=>dt(a.created)-dt(b.created)); shown=[...all]; rerender();}).catch(e=>{$('progress').textContent='Load failed: '+e.message;});
+function setCurrentBySeq(seq){current=shown.find(x=>x.seq===seq)||shown[0]; renderList(); renderCurrent();}
+function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.seq===x.seq?'active':''}' data-seq='${x.seq}'><strong>#${x.seq} ${esc(x.commit_short)}</strong><div class='muted'>${esc(x.timestamp)} · ${esc(x.primary_filename||'')}</div><div class='muted'>${esc((x.functional_impacts||[]).join(', ')||'no impact tags')}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrentBySeq(Number(n.dataset.seq))); }
+function renderCurrent(){ if(!current) return; $('activeMeta').innerHTML=`<strong>Timeline Entry #${current.seq}</strong><div class='muted'>${esc(current.timestamp)}</div><div><code title='${esc(current.commit_hash)}'>${esc(current.commit_short)}</code> · <span class='muted'>full: ${esc(current.commit_hash)}</span></div><div><strong>code_fingerprint</strong>: <code>${esc(current.code_fingerprint)}</code></div><div><strong>description_delta_from_previous</strong>: ${esc(current.description_delta_from_previous)}</div><div><strong>functional_impacts</strong>: ${esc((current.functional_impacts||[]).join(', ')||'none')}</div><div><strong>primary_filename</strong>: ${esc(current.primary_filename||'N/A')}</div><div><strong>changed_paths</strong><pre>${esc(JSON.stringify(current.changed_paths||[], null, 2))}</pre></div>`; }
+function applyFilter(q){ const n=q.toLowerCase().trim(); shown=all.filter(x=>[x.commit_hash,x.commit_short,x.primary_filename,x.description_delta_from_previous,(x.functional_impacts||[]).join(' '),JSON.stringify(x.changed_paths||[])].join(' ').toLowerCase().includes(n)); current=null; if(shown[0]) setCurrentBySeq(shown[0].seq); else {renderList(); $('activeMeta').innerHTML='<div class="muted">No matching entries.</div>';} }
+$('omni').oninput=e=>applyFilter(e.target.value);
+fetch('bridge-lineage-timeline-model.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{ all=[...data].sort((a,b)=>a.seq-b.seq); shown=[...all]; if(shown[0]) setCurrentBySeq(shown[0].seq); else $('activeMeta').textContent='Timeline model is empty.'; }).catch(e=>{$('activeMeta').textContent='Load failed: '+e.message;});
 </script>
 </body>
 </html>

--- a/scripts/build-lineage-model.mjs
+++ b/scripts/build-lineage-model.mjs
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const MODEL_PATH = 'bridge-lineage-timeline-model.json';
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 256 }).trimEnd();
+}
+
+function hashText(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function normalizePatch(text) {
+  return text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((line) => !line.startsWith('index '))
+    .join('\n')
+    .trim();
+}
+
+function classifyImpacts(diffText) {
+  const t = diffText.toLowerCase();
+  const hits = [];
+  const categories = [
+    ['normalization', /(normalize|normalization|canonical|trim\(|lowercase|uppercase|sanitize)/],
+    ['transcription', /(transcrib|speech|stt|recognition|utterance|transcript)/],
+    ['translation', /(translat|locale|language|i18n|thai|english|xlate)/],
+    ['joining/rejoining flow', /(rejoin|join\b|reconnect|session|handshake|room|participant)/],
+    ['call termination behavior', /(hangup|terminate|end call|disconnect|teardown|close\()/],
+    ['compose strip focus behavior', /(compose|focus|cursor|caret|textarea|input field)/],
+    ['ui/ux flow changes', /(button|modal|panel|tab|layout|render|view|screen|ux|ui)/],
+    ['remediation/repair/fix behavior', /(fix|bug|repair|rollback|guard|fallback|recover|hotfix|patch)/],
+  ];
+  for (const [name, re] of categories) {
+    if (re.test(t)) hits.push(name);
+  }
+  return hits;
+}
+
+function summarizePatch(patch) {
+  if (!patch.trim()) return 'No code diff from previous timeline entry.';
+  const fileSet = new Set();
+  let added = 0;
+  let removed = 0;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      const m = line.match(/ b\/(.+)$/);
+      if (m) fileSet.add(m[1]);
+      continue;
+    }
+    if (line.startsWith('+++ ') || line.startsWith('--- ') || line.startsWith('@@')) continue;
+    if (line.startsWith('+')) added += 1;
+    if (line.startsWith('-')) removed += 1;
+  }
+  const files = [...fileSet].slice(0, 3).join(', ');
+  return `Patch touched ${fileSet.size} file(s) (+${added}/-${removed})${files ? `; key paths: ${files}` : ''}.`;
+}
+
+const commitLines = git(['log', '--date=iso-strict', '--pretty=format:%H%x09%h%x09%cI']).split('\n').filter(Boolean);
+const commits = commitLines.map((line, idx) => {
+  const [full, short, timestamp] = line.split('\t');
+  return { seq: idx + 1, full, short, timestamp };
+});
+
+const rows = commits.map((commit, idx) => {
+  const previous = commits[idx + 1]?.full ?? null;
+  const patch = previous ? git(['diff', `${previous}..${commit.full}`, '--', '.']) : git(['show', commit.full, '--pretty=format:', '--', '.']);
+  const nameStatusRaw = previous ? git(['diff', '--name-status', `${previous}..${commit.full}`, '--', '.']) : git(['show', '--name-status', '--pretty=format:', commit.full, '--', '.']);
+  const changed_paths = nameStatusRaw
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      const status = parts[0];
+      if (status.startsWith('R')) {
+        return { status, from: parts[1], to: parts[2] };
+      }
+      return { status, path: parts[1] };
+    });
+  const code_fingerprint = hashText(normalizePatch(patch));
+  const blob_refs = changed_paths.slice(0, 8).map((entry) => (entry.to ? `${commit.full}:${entry.to}` : `${commit.full}:${entry.path}`));
+  const primary_filename = changed_paths[0]?.to || changed_paths[0]?.path || 'N/A';
+  const impacts = classifyImpacts(patch);
+
+  return {
+    seq: commit.seq,
+    timestamp: commit.timestamp,
+    commit_hash: commit.full,
+    commit_short: commit.short,
+    code_fingerprint,
+    primary_filename,
+    changed_paths,
+    description_delta_from_previous: summarizePatch(patch),
+    functional_impacts: impacts,
+    blob_refs,
+    launch_ref: primary_filename,
+    note: impacts.length ? `Inferred impacts: ${impacts.join(', ')}.` : 'No prioritized behavior category detected from diff hunks.',
+    previous_commit_hash: previous,
+  };
+});
+
+writeFileSync(MODEL_PATH, `${JSON.stringify(rows, null, 2)}\n`);
+console.log(`Wrote ${rows.length} entries to ${MODEL_PATH}`);


### PR DESCRIPTION
### Motivation
- Simplify the UI to a single timeline/explorer that consumes a precomputed model instead of the previous multi-tab Analysis/Results flow. 
- Stop relying on a wildcard/file-list as the source of truth and instead derive lineage from authoritative git history so the timeline is deterministic and complete. 
- Provide diff-based, behavior-oriented summaries and impact categories so the timeline exposes concrete, repo-relevant change intent.

### Description
- Simplified `repo.html` to remove the "Analysis Run" and "Lineage Results" tabs and panes and replaced the client-side source with a single loader for `bridge-lineage-timeline-model.json`, while preserving search/filter over commit hash, file paths, impacts, and summary text. 
- Added `scripts/build-lineage-model.mjs` which reads git history in descending (newest-first) order, computes adjacent-commit diffs, and emits a stable JSON model with the required fields: `seq`, `timestamp`, `commit_hash`, `commit_short`, `code_fingerprint`, `primary_filename`, `changed_paths` (including rename handling), `description_delta_from_previous` (from real patch hunks), `functional_impacts` (classified from diffs), `blob_refs`, `launch_ref`, `note`, and `previous_commit_hash`. 
- Implemented deterministic normalization and fingerprinting of patch text with SHA-256 and diff-based summarization logic that counts added/removed lines and lists key paths. 
- Built lightweight heuristic classification for prioritized impact categories relevant to this repo (`normalization`, `transcription`, `translation`, `joining/rejoining flow`, `call termination behavior`, `compose strip focus behavior`, `ui/ux flow changes`, `remediation/repair/fix behavior`) derived from diff evidence. 
- Added a `build:lineage` npm script in `package.json` and committed the generated artifact `bridge-lineage-timeline-model.json` so the UI can immediately consume the precomputed timeline.

### Testing
- Ran `node scripts/build-lineage-model.mjs` which completed successfully and wrote the model file `bridge-lineage-timeline-model.json` (the run produced a full-history timeline with entries). 
- Verified the modified `repo.html` fetches `bridge-lineage-timeline-model.json` and renders entries (filter/search behavior implemented); the generator is exposed via the `build:lineage` script for repeatable runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb8e639c0832d9d4c39de7d1ca8cc)