### PR TITLE
Add timeline model + build script and update repo UI to consume it

### DIFF
--- a/bridge-lineage-timeline-model.json
+++ b/bridge-lineage-timeline-model.json
@@ -1,0 +1,9660 @@
+[
+  {
+    "seq": 1,
+    "timestamp": "2026-05-10T00:14:22+00:00",
+    "commit_hash": "1e72b295b61a214dfc2800472731a480a912c6d0",
+    "commit_short": "1e72b29",
+    "code_fingerprint": "23bef3715abbf55ff3994df5b74f5cfb3f7b64c136ab27eaa268e484320860c7",
+    "primary_filename": "bridge-lineage-timeline-model.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-lineage-timeline-model.json"
+      },
+      {
+        "status": "M",
+        "path": "package.json"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      },
+      {
+        "status": "A",
+        "path": "scripts/build-lineage-model.mjs"
+      }
+    ],
+    "description_delta_from_previous": "Changed 4 file(s), 4 hunk(s), +5340/-88. bridge-lineage-timeline-model.json @@ -0,0 +1,5218 @@ | + [ | - no removed line sample || package.json @@ -6,5 +6,8 @@ | + }, | - no removed line sample || repo.html @@ -3,124 +3,49 @@ | + <title>Bridge Timeline Explorer</title> | - <title>Bridge Timeline + Lineage Workbench</title>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "1e72b295b61a214dfc2800472731a480a912c6d0:bridge-lineage-timeline-model.json",
+      "1e72b295b61a214dfc2800472731a480a912c6d0:package.json",
+      "1e72b295b61a214dfc2800472731a480a912c6d0:repo.html",
+      "1e72b295b61a214dfc2800472731a480a912c6d0:scripts/build-lineage-model.mjs"
+    ],
+    "launch_ref": "bridge-lineage-timeline-model.json",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "26f94230a996ff18655c420e489f272fa738421a",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage-timeline-model.json",
+        "hunk": "@@ -0,0 +1,5218 @@",
+        "add": "[",
+        "remove": ""
+      },
+      {
+        "file": "package.json",
+        "hunk": "@@ -6,5 +6,8 @@",
+        "add": "},",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -3,124 +3,49 @@",
+        "add": "<title>Bridge Timeline Explorer</title>",
+        "remove": "<title>Bridge Timeline + Lineage Workbench</title>"
+      },
+      {
+        "file": "scripts/build-lineage-model.mjs",
+        "hunk": "@@ -0,0 +1,106 @@",
+        "add": "import { createHash } from 'node:crypto';",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "23bef3715abbf55ff3994df5b74f5cfb3f7b64c136ab27eaa268e484320860c7"
+  },
+  {
+    "seq": 2,
+    "timestamp": "2026-05-09T15:27:36-07:00",
+    "commit_hash": "26f94230a996ff18655c420e489f272fa738421a",
+    "commit_short": "26f9423",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 3,
+    "timestamp": "2026-05-09T15:27:15-07:00",
+    "commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17",
+    "commit_short": "65d16ac",
+    "code_fingerprint": "a0f72cde786551d68c4636458f992d96d638536db521176d7148fa540433f245",
+    "primary_filename": "resolve.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "resolve.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +184/-0. resolve.html @@ -0,0 +1,184 @@ | + <!doctype html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "65d16ac8128f601c40cdc528195175c487a34c17:resolve.html"
+    ],
+    "launch_ref": "resolve.html",
+    "note": "Diff-evidenced impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "7230e5c6f4e354727df4127ed2a8d96f2d53b6da",
+    "diff_evidence": [
+      {
+        "file": "resolve.html",
+        "hunk": "@@ -0,0 +1,184 @@",
+        "add": "<!doctype html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "a0f72cde786551d68c4636458f992d96d638536db521176d7148fa540433f245"
+  },
+  {
+    "seq": 4,
+    "timestamp": "2026-05-09T15:10:11-07:00",
+    "commit_hash": "7230e5c6f4e354727df4127ed2a8d96f2d53b6da",
+    "commit_short": "7230e5c",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 5,
+    "timestamp": "2026-05-09T15:10:01-07:00",
+    "commit_hash": "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388",
+    "commit_short": "67e83f3",
+    "code_fingerprint": "7e459c7c44ccd8be1e9a895b54899905bbc6f9dedb6f9d500dcaec6a61141047",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 3 hunk(s), +209/-236. nimbus.html @@ -1,305 +1,243 @@ | + <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, viewport-fit=cover\" /> | - <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> || repo.html @@ -54,6 +54,7 @@ | + <div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div> | - no removed line sample || repo.html @@ -71,19 +72,53 @@ | + let all=[]; let shown=[]; let current=null; let timelineModel=[]; | - let all=[]; let shown=[]; let current=null;",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388:nimbus.html",
+      "67e83f36bdb4dc62b9703ded1e8274a7e5b4d388:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b0b152586b7ca0c88203b04b8c3f955900a52a27",
+    "diff_evidence": [
+      {
+        "file": "nimbus.html",
+        "hunk": "@@ -1,305 +1,243 @@",
+        "add": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, viewport-fit=cover\" />",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -54,6 +54,7 @@",
+        "add": "<div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div>",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -71,19 +72,53 @@",
+        "add": "let all=[]; let shown=[]; let current=null; let timelineModel=[];",
+        "remove": "let all=[]; let shown=[]; let current=null;"
+      }
+    ],
+    "patch_hash": "7e459c7c44ccd8be1e9a895b54899905bbc6f9dedb6f9d500dcaec6a61141047"
+  },
+  {
+    "seq": 6,
+    "timestamp": "2026-05-09T15:09:14-07:00",
+    "commit_hash": "b0b152586b7ca0c88203b04b8c3f955900a52a27",
+    "commit_short": "b0b1525",
+    "code_fingerprint": "529b27a383336333e9db9aef0e01dab117d3b97f6e73eceb813b66510a184cc1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 3 hunk(s), +236/-209. nimbus.html @@ -1,243 +1,305 @@ | + <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> | - <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, viewport-fit=cover\" /> || repo.html @@ -54,7 +54,6 @@ | + no added line sample | - <div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div> || repo.html @@ -72,53 +71,19 @@ | + let all=[]; let shown=[]; let current=null; | - let all=[]; let shown=[]; let current=null; let timelineModel=[];",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b0b152586b7ca0c88203b04b8c3f955900a52a27:nimbus.html",
+      "b0b152586b7ca0c88203b04b8c3f955900a52a27:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637",
+    "diff_evidence": [
+      {
+        "file": "nimbus.html",
+        "hunk": "@@ -1,243 +1,305 @@",
+        "add": "",
+        "remove": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, viewport-fit=cover\" />"
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -54,7 +54,6 @@",
+        "add": "",
+        "remove": "<div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div>"
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -72,53 +71,19 @@",
+        "add": "let all=[]; let shown=[]; let current=null;",
+        "remove": "let all=[]; let shown=[]; let current=null; let timelineModel=[];"
+      }
+    ],
+    "patch_hash": "529b27a383336333e9db9aef0e01dab117d3b97f6e73eceb813b66510a184cc1"
+  },
+  {
+    "seq": 7,
+    "timestamp": "2026-05-09T14:50:31-07:00",
+    "commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637",
+    "commit_short": "5a90f5d",
+    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbus.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +243/-0. nimbus.html @@ -0,0 +1,243 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5a90f5d9276733808541ffd6fc3ecd0635eb4637:nimbus.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Diff-evidenced impacts: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee",
+    "diff_evidence": [
+      {
+        "file": "nimbus.html",
+        "hunk": "@@ -0,0 +1,243 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1"
+  },
+  {
+    "seq": 8,
+    "timestamp": "2026-05-09T14:50:05-07:00",
+    "commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee",
+    "commit_short": "5348f24",
+    "code_fingerprint": "978ee7934c61d8013cbf2e98802c7c5c9e3cc58d91ae8a9b469c6f2ee6b2cfe8",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "nimbus.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 3 hunk(s), +38/-246. nimbus.html @@ -1,243 +0,0 @@ | + no added line sample | - <!DOCTYPE html> || repo.html @@ -54,6 +54,7 @@ | + <div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div> | - no removed line sample || repo.html @@ -71,19 +72,53 @@ | + let all=[]; let shown=[]; let current=null; let timelineModel=[]; | - let all=[]; let shown=[]; let current=null;",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5348f24c6b0b0b106375ee14add3cfc196c9adee:nimbus.html",
+      "5348f24c6b0b0b106375ee14add3cfc196c9adee:repo.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4b1428fd105a6bede8b24459f061d04fe15ada71",
+    "diff_evidence": [
+      {
+        "file": "nimbus.html",
+        "hunk": "@@ -1,243 +0,0 @@",
+        "add": "",
+        "remove": "<!DOCTYPE html>"
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -54,6 +54,7 @@",
+        "add": "<div class=\"card\"><button class=\"tab\" id=\"exportModel\">Export timeline JSON model</button></div>",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -71,19 +72,53 @@",
+        "add": "let all=[]; let shown=[]; let current=null; let timelineModel=[];",
+        "remove": "let all=[]; let shown=[]; let current=null;"
+      }
+    ],
+    "patch_hash": "978ee7934c61d8013cbf2e98802c7c5c9e3cc58d91ae8a9b469c6f2ee6b2cfe8"
+  },
+  {
+    "seq": 9,
+    "timestamp": "2026-05-09T14:46:45-07:00",
+    "commit_hash": "4b1428fd105a6bede8b24459f061d04fe15ada71",
+    "commit_short": "4b1428f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 10,
+    "timestamp": "2026-05-09T14:45:09-07:00",
+    "commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6",
+    "commit_short": "4f12657",
+    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
+    "primary_filename": "nimbus.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbus.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +243/-0. nimbus.html @@ -0,0 +1,243 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "4f12657f7173ee95208e143fada0846fa9782ed6:nimbus.html"
+    ],
+    "launch_ref": "nimbus.html",
+    "note": "Diff-evidenced impacts: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "552e1921349d60cfa8a5e1ee9805ab48134f278e",
+    "diff_evidence": [
+      {
+        "file": "nimbus.html",
+        "hunk": "@@ -0,0 +1,243 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1"
+  },
+  {
+    "seq": 11,
+    "timestamp": "2026-05-09T14:16:01-07:00",
+    "commit_hash": "552e1921349d60cfa8a5e1ee9805ab48134f278e",
+    "commit_short": "552e192",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 12,
+    "timestamp": "2026-05-09T14:15:52-07:00",
+    "commit_hash": "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7",
+    "commit_short": "7dfb07e",
+    "code_fingerprint": "e2d12c0a4a52763480e1cc149a1054ec5e6c78624c60dec8e828a85d4dd558d7",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 3 file(s), 13 hunk(s), +225/-238. bridge-lineage.json @@ -9,8 +9,7 @@ | + \"lineageNote\": \"General iteration and testing variant.\" | - \"lineageNote\": \"General iteration and testing variant.\", || bridge-lineage.json @@ -22,8 +21,7 @@ | + \"lineageNote\": \"General iteration and testing variant.\" | - \"lineageNote\": \"General iteration and testing variant.\", || bridge-lineage.json @@ -35,8 +33,7 @@ | + \"lineageNote\": \"General iteration and testing variant.\" | - \"lineageNote\": \"General iteration and testing variant.\",",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:bridge-lineage.json",
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:nimbusflight-touch-wrapper.html",
+      "7dfb07eef4e1585d107168ad6bc6b4d05083a4e7:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0a690a5aa30abfdc83e917f943508f584ebbd192",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -9,8 +9,7 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -22,8 +21,7 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -35,8 +33,7 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -48,8 +45,7 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -61,8 +57,7 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -74,177 +69,141 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -254,11 +213,9 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"soft-delete\","
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -268,172 +225,176 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\"",
+        "remove": "\"soft-delete\","
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -33,10 +33,17 @@",
+        "add": "display: flex;",
+        "remove": "display: grid;"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -61,10 +68,12 @@",
+        "add": "<section class=\"controls\" id=\"controls\">",
+        "remove": "<section class=\"controls\" id=\"controls\"></section>"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -92,7 +101,23 @@",
+        "add": "const led = document.getElementById('panel-led');",
+        "remove": ""
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -106,6 +131,7 @@",
+        "add": "if (!panelActive) return;",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "e2d12c0a4a52763480e1cc149a1054ec5e6c78624c60dec8e828a85d4dd558d7"
+  },
+  {
+    "seq": 13,
+    "timestamp": "2026-05-09T14:14:03-07:00",
+    "commit_hash": "0a690a5aa30abfdc83e917f943508f584ebbd192",
+    "commit_short": "0a690a5",
+    "code_fingerprint": "38a05ea7111582abd44d527f30e6da85e1de2f2d1d6d35f6d87a04e15593ad28",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 3 file(s), 11 hunk(s), +238/-225. bridge-lineage.json @@ -9,7 +9,8 @@ | + \"lineageNote\": \"General iteration and testing variant.\", | - \"lineageNote\": \"General iteration and testing variant.\" || bridge-lineage.json @@ -21,7 +22,8 @@ | + \"lineageNote\": \"General iteration and testing variant.\", | - \"lineageNote\": \"General iteration and testing variant.\" || bridge-lineage.json @@ -33,7 +35,8 @@ | + \"lineageNote\": \"General iteration and testing variant.\", | - \"lineageNote\": \"General iteration and testing variant.\"",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:bridge-lineage.json",
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:nimbusflight-touch-wrapper.html",
+      "0a690a5aa30abfdc83e917f943508f584ebbd192:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -9,7 +9,8 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -21,7 +22,8 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -33,7 +35,8 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -45,7 +48,8 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -57,7 +61,8 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -69,332 +74,366 @@",
+        "add": "\"lineageNote\": \"General iteration and testing variant.\",",
+        "remove": "\"lineageNote\": \"General iteration and testing variant.\""
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -33,17 +33,10 @@",
+        "add": "display: grid;",
+        "remove": "display: flex;"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -68,12 +61,10 @@",
+        "add": "<section class=\"controls\" id=\"controls\"></section>",
+        "remove": "<section class=\"controls\" id=\"controls\">"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -101,23 +92,7 @@",
+        "add": "",
+        "remove": "const led = document.getElementById('panel-led');"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -131,7 +106,6 @@",
+        "add": "",
+        "remove": "if (!panelActive) return;"
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -76,9 +76,9 @@ const $=id=>document.getElementById(id);",
+        "add": "function setCurrent(file){current=shown.find(x=>x.file===file)||shown[0]; if(!current)return; $('preview').src=current.launchUrl; const same=current.created===current.lastUpdated; const when=same?`Snapshot: ${esc(current.lastUpdated)}`:`${esc(current.created)} → ${esc(current.lastUpdated)}`; $('activeMeta').innerHTML=`<strong>${esc(current.file)}</strong><br><span class='muted'>#${shown.findIndex(v=>v.file===current.file)+1} in timeline · ${when} · ${esc((current.commit||'').slice(0,10))}</span><div>${inferFocus(current.tags||[])}</div><div><a target='_blank' href='${esc(current.launchUrl)}'>Launch</a> · <a target='_blank' href='${esc(current.blobUrl)}'>Code blob</a></div>`; renderList();}",
+        "remove": "function setCurrent(file){current=shown.find(x=>x.file===file)||shown[0]; if(!current)return; $('preview').src=current.launchUrl; $('activeMeta').innerHTML=`<strong>${esc(current.file)}</strong><br><span class='muted'>${esc(current.created)} | ${esc(current.commit.slice(0,10))}</span><div>${inferFocus(current.tags||[])}</div><div><a target='_blank' href='${esc(current.launchUrl)}'>Launch</a> · <a target='_blank' href='${esc(current.blobUrl)}'>Code blob</a></div>`; renderList();}"
+      }
+    ],
+    "patch_hash": "38a05ea7111582abd44d527f30e6da85e1de2f2d1d6d35f6d87a04e15593ad28"
+  },
+  {
+    "seq": 14,
+    "timestamp": "2026-05-09T14:02:18-07:00",
+    "commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181",
+    "commit_short": "9e47705",
+    "code_fingerprint": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +30/-4. nimbusflight-touch-wrapper.html @@ -33,10 +33,17 @@ | + display: flex; | - display: grid; || nimbusflight-touch-wrapper.html @@ -61,10 +68,12 @@ | + <section class=\"controls\" id=\"controls\"> | - <section class=\"controls\" id=\"controls\"></section> || nimbusflight-touch-wrapper.html @@ -92,7 +101,23 @@ | + const led = document.getElementById('panel-led'); | - no removed line sample",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9e477053a08bb3c1d1fc512fd6d66310685ea181:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2d2b4d297266b1617865602303990dca5ef58557",
+    "diff_evidence": [
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -33,10 +33,17 @@",
+        "add": "display: flex;",
+        "remove": "display: grid;"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -61,10 +68,12 @@",
+        "add": "<section class=\"controls\" id=\"controls\">",
+        "remove": "<section class=\"controls\" id=\"controls\"></section>"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -92,7 +101,23 @@",
+        "add": "const led = document.getElementById('panel-led');",
+        "remove": ""
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -106,6 +131,7 @@",
+        "add": "if (!panelActive) return;",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094"
+  },
+  {
+    "seq": 15,
+    "timestamp": "2026-05-09T14:01:52-07:00",
+    "commit_hash": "2d2b4d297266b1617865602303990dca5ef58557",
+    "commit_short": "2d2b4d2",
+    "code_fingerprint": "d51e38ddecbaa7030810c3e86d2f7627246e11d0647a798b32d45050c2e41786",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      },
+      {
+        "status": "M",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 3 file(s), 6 hunk(s), +466/-198. bridge-lineage.json @@ -1,35 +1,400 @@ | + \"file\": \"bridge (20).html\", | - \"family\": \"bridge\", || nimbusflight-touch-wrapper.html @@ -33,17 +33,10 @@ | + display: grid; | - display: flex; || nimbusflight-touch-wrapper.html @@ -68,12 +61,10 @@ | + <section class=\"controls\" id=\"controls\"></section> | - <section class=\"controls\" id=\"controls\">",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2d2b4d297266b1617865602303990dca5ef58557:bridge-lineage.json",
+      "2d2b4d297266b1617865602303990dca5ef58557:nimbusflight-touch-wrapper.html",
+      "2d2b4d297266b1617865602303990dca5ef58557:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ed7187b3842c2c11ce708442ca41178827225b75",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -1,35 +1,400 @@",
+        "add": "\"file\": \"bridge (20).html\",",
+        "remove": "\"family\": \"bridge\","
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -33,17 +33,10 @@",
+        "add": "display: grid;",
+        "remove": "display: flex;"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -68,12 +61,10 @@",
+        "add": "<section class=\"controls\" id=\"controls\"></section>",
+        "remove": "<section class=\"controls\" id=\"controls\">"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -101,23 +92,7 @@",
+        "add": "",
+        "remove": "const led = document.getElementById('panel-led');"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -131,7 +106,6 @@",
+        "add": "",
+        "remove": "if (!panelActive) return;"
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -3,160 +3,89 @@",
+        "add": "<title>Bridge Timeline + Lineage Workbench</title>",
+        "remove": "<title>Lineage Explorer</title>"
+      }
+    ],
+    "patch_hash": "d51e38ddecbaa7030810c3e86d2f7627246e11d0647a798b32d45050c2e41786"
+  },
+  {
+    "seq": 16,
+    "timestamp": "2026-05-09T14:01:18-07:00",
+    "commit_hash": "ed7187b3842c2c11ce708442ca41178827225b75",
+    "commit_short": "ed7187b",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 17,
+    "timestamp": "2026-05-09T13:01:20-07:00",
+    "commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a",
+    "commit_short": "0a781ff",
+    "code_fingerprint": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +30/-4. nimbusflight-touch-wrapper.html @@ -33,10 +33,17 @@ | + display: flex; | - display: grid; || nimbusflight-touch-wrapper.html @@ -61,10 +68,12 @@ | + <section class=\"controls\" id=\"controls\"> | - <section class=\"controls\" id=\"controls\"></section> || nimbusflight-touch-wrapper.html @@ -92,7 +101,23 @@ | + const led = document.getElementById('panel-led'); | - no removed line sample",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0a781ffc74981891c79d98304dfe1a0509ca3d3a:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3032a77568937554bd8731ca600494a7311ddfd1",
+    "diff_evidence": [
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -33,10 +33,17 @@",
+        "add": "display: flex;",
+        "remove": "display: grid;"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -61,10 +68,12 @@",
+        "add": "<section class=\"controls\" id=\"controls\">",
+        "remove": "<section class=\"controls\" id=\"controls\"></section>"
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -92,7 +101,23 @@",
+        "add": "const led = document.getElementById('panel-led');",
+        "remove": ""
+      },
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -106,6 +131,7 @@",
+        "add": "if (!panelActive) return;",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "be227180b61159ccfc3326d5c203861cb4925cded381edcbb3ce8e6ce038a094"
+  },
+  {
+    "seq": 18,
+    "timestamp": "2026-05-09T12:43:20-07:00",
+    "commit_hash": "3032a77568937554bd8731ca600494a7311ddfd1",
+    "commit_short": "3032a77",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "d3126b3b2ecf41bb77a422905615d6cca1bf91e3",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 19,
+    "timestamp": "2026-05-08T22:20:27-07:00",
+    "commit_hash": "d3126b3b2ecf41bb77a422905615d6cca1bf91e3",
+    "commit_short": "d3126b3",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 20,
+    "timestamp": "2026-05-08T22:20:04-07:00",
+    "commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf",
+    "commit_short": "e12a975",
+    "code_fingerprint": "d2040e6fba35fd9296b449aa117041debf1c3fd4eb88f07f8c8eb83ec45dbd04",
+    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "nimbusflight-touch-wrapper.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +154/-0. nimbusflight-touch-wrapper.html @@ -0,0 +1,154 @@ | + <!doctype html> | - no removed line sample",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "e12a9758445ead5f47ca4d2502b3cee824be2aaf:nimbusflight-touch-wrapper.html"
+    ],
+    "launch_ref": "nimbusflight-touch-wrapper.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279",
+    "diff_evidence": [
+      {
+        "file": "nimbusflight-touch-wrapper.html",
+        "hunk": "@@ -0,0 +1,154 @@",
+        "add": "<!doctype html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "d2040e6fba35fd9296b449aa117041debf1c3fd4eb88f07f8c8eb83ec45dbd04"
+  },
+  {
+    "seq": 21,
+    "timestamp": "2026-05-08T22:16:39-07:00",
+    "commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279",
+    "commit_short": "04d1fa0",
+    "code_fingerprint": "6f0f5ebd61640ac1c06d50690939561967e67f47f40cc96ff8ea25f42dc450c1",
+    "primary_filename": "src/App.tsx",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "src/App.tsx"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +133/-3. src/App.tsx @@ -1,9 +1,139 @@ | + import React, { useCallback, useRef, useState } from 'react'; | - import React from 'react';",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "04d1fa01bbdbe4045613e84151ef98bf5e4d4279:src/App.tsx"
+    ],
+    "launch_ref": "src/App.tsx",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d",
+    "diff_evidence": [
+      {
+        "file": "src/App.tsx",
+        "hunk": "@@ -1,9 +1,139 @@",
+        "add": "import React, { useCallback, useRef, useState } from 'react';",
+        "remove": "import React from 'react';"
+      }
+    ],
+    "patch_hash": "6f0f5ebd61640ac1c06d50690939561967e67f47f40cc96ff8ea25f42dc450c1"
+  },
+  {
+    "seq": 22,
+    "timestamp": "2026-05-08T21:43:01-07:00",
+    "commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d",
+    "commit_short": "957d823",
+    "code_fingerprint": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 7 hunk(s), +18/-18. bridge-patched-v1.html @@ -750,8 +750,9 @@ function getMicConstraints(){ | + if(s.normalize)s=s.normalize('NFC'); | - s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,''); || bridge-patched-v1.html @@ -926,7 +927,7 @@ async function sendChat(){ | + try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){} | - try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){} || bridge-patched-v1.html @@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis) | + function cleanTranslationText(t){ | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "957d823fcf173239bcaf937deb2f5c67fb144f1d:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,8 +750,9 @@ function getMicConstraints(){",
+        "add": "if(s.normalize)s=s.normalize('NFC');",
+        "remove": "s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -926,7 +927,7 @@ async function sendChat(){",
+        "add": "try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}",
+        "remove": "try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+        "add": "function cleanTranslationText(t){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1732,7 +1738,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);",
+        "remove": "if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1742,7 +1748,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});",
+        "remove": "return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1759,6 +1765,7 @@ function translate(text,from,to){",
+        "add": "t=cleanTranslationText(t);",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2320,20 +2327,13 @@ function onDGFinal(text){",
+        "add": "var srcText=normalizeText(text,'speech')||text;",
+        "remove": "Promise.race(["
+      }
+    ],
+    "patch_hash": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d"
+  },
+  {
+    "seq": 23,
+    "timestamp": "2026-05-07T23:41:40-07:00",
+    "commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de",
+    "commit_short": "116ce14",
+    "code_fingerprint": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053",
+    "primary_filename": "bridge-try.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-try.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +2778/-0. bridge-try.html @@ -0,0 +1,2778 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "116ce1466570b35b822be41ef99ad9d2044784de:bridge-try.html"
+    ],
+    "launch_ref": "bridge-try.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd",
+    "diff_evidence": [
+      {
+        "file": "bridge-try.html",
+        "hunk": "@@ -0,0 +1,2778 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053"
+  },
+  {
+    "seq": 24,
+    "timestamp": "2026-05-07T22:47:29-07:00",
+    "commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd",
+    "commit_short": "a0c2917",
+    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 2 hunk(s), +197/-0. bridge-lineage.json @@ -0,0 +1,35 @@ | + [ | - no removed line sample || repo.html @@ -0,0 +1,162 @@ | + <!doctype html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a0c2917e740ed58bf537566e9333caf191eddbfd:bridge-lineage.json",
+      "a0c2917e740ed58bf537566e9333caf191eddbfd:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -0,0 +1,35 @@",
+        "add": "[",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -0,0 +1,162 @@",
+        "add": "<!doctype html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67"
+  },
+  {
+    "seq": 25,
+    "timestamp": "2026-05-07T22:46:50-07:00",
+    "commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c",
+    "commit_short": "7375fa6",
+    "code_fingerprint": "03fb4737a6e8fcf4008b10f97e1a47ee01fd809b59593722c5d4adf3a1b3fa6a",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-minus-3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore-plus-3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-restore.html"
+      },
+      {
+        "status": "D",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 9 file(s), 9 hunk(s), +10811/-197. bridge-lineage.json @@ -1,35 +0,0 @@ | + no added line sample | - [ || bridge-restore-minus-1.html @@ -0,0 +1,1508 @@ | + <!DOCTYPE html> | - no removed line sample || bridge-restore-minus-2.html @@ -0,0 +1,1541 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-lineage.json",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-1.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-2.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-3.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-1.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-2.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-3.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore.html",
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2ec79e932f0d4d650284dbb561b5ad57ed318437",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -1,35 +0,0 @@",
+        "add": "",
+        "remove": "["
+      },
+      {
+        "file": "bridge-restore-minus-1.html",
+        "hunk": "@@ -0,0 +1,1508 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore-minus-2.html",
+        "hunk": "@@ -0,0 +1,1541 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore-minus-3.html",
+        "hunk": "@@ -0,0 +1,1536 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore-plus-1.html",
+        "hunk": "@@ -0,0 +1,1563 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore-plus-2.html",
+        "hunk": "@@ -0,0 +1,1563 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore-plus-3.html",
+        "hunk": "@@ -0,0 +1,1589 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-restore.html",
+        "hunk": "@@ -0,0 +1,1511 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -1,162 +0,0 @@",
+        "add": "",
+        "remove": "<!doctype html>"
+      }
+    ],
+    "patch_hash": "03fb4737a6e8fcf4008b10f97e1a47ee01fd809b59593722c5d4adf3a1b3fa6a"
+  },
+  {
+    "seq": 26,
+    "timestamp": "2026-05-07T22:35:43-07:00",
+    "commit_hash": "2ec79e932f0d4d650284dbb561b5ad57ed318437",
+    "commit_short": "2ec79e9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 27,
+    "timestamp": "2026-05-07T22:34:37-07:00",
+    "commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2",
+    "commit_short": "15aeb25",
+    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
+    "primary_filename": "bridge-lineage.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-lineage.json"
+      },
+      {
+        "status": "A",
+        "path": "repo.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 2 hunk(s), +197/-0. bridge-lineage.json @@ -0,0 +1,35 @@ | + [ | - no removed line sample || repo.html @@ -0,0 +1,162 @@ | + <!doctype html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "15aeb257bc1c9204f5d94a697cb776306491c9f2:bridge-lineage.json",
+      "15aeb257bc1c9204f5d94a697cb776306491c9f2:repo.html"
+    ],
+    "launch_ref": "bridge-lineage.json",
+    "note": "Diff-evidenced impacts: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae",
+    "diff_evidence": [
+      {
+        "file": "bridge-lineage.json",
+        "hunk": "@@ -0,0 +1,35 @@",
+        "add": "[",
+        "remove": ""
+      },
+      {
+        "file": "repo.html",
+        "hunk": "@@ -0,0 +1,162 @@",
+        "add": "<!doctype html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67"
+  },
+  {
+    "seq": 28,
+    "timestamp": "2026-05-07T22:09:04-07:00",
+    "commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae",
+    "commit_short": "6109bca",
+    "code_fingerprint": "875c6d94825180e90a09a9d790e35471e1127e6540b433685b433711a95da7c7",
+    "primary_filename": "bridge-patched-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 24 hunk(s), +134/-151. bridge-patched-v2.html @@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} | - .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} || bridge-patched-v2.html @@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - .pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);} || bridge-patched-v2.html @@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - <button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6109bca5ada37a1d39fa84ed47c608564e1b6dae:bridge-patched-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ".pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);}"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button>"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -579,21 +575,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -664,6 +645,56 @@ var LANGS=[",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -697,7 +728,7 @@ var pc=null,videoStream=null,remoteStream=null;",
+        "add": "var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;",
+        "remove": "var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -721,6 +752,12 @@ function normalizeText(raw,mode){",
+        "add": "if(mode==='speech'){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -793,13 +830,13 @@ var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];",
+        "add": "var _ftBase=location.href.replace(/\\/[^\\/]*$/,'/');var s=document.createElement('script');s.src=_ftBase+'fastType/fastText.common.js';",
+        "remove": "var s=document.createElement('script');s.src='/fastText/fasttext.js';"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -834,10 +871,8 @@ function _detectLangAsync(text){",
+        "add": "if(micOn&&!micMutedByUser){toggleMic();}",
+        "remove": "if(micOn&&!micMutedByUser){"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -974,29 +1009,6 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+        "add": "",
+        "remove": "var PB_URL_LANGS=["
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -1232,7 +1244,7 @@ function pbCloseDrawer(){",
+        "add": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>';",
+        "remove": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';"
+      },
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -1248,68 +1260,11 @@ function pbBuildUrl(){",
+        "add": "",
+        "remove": "function pbTogUrlFromOverlay(){"
+      }
+    ],
+    "patch_hash": "875c6d94825180e90a09a9d790e35471e1127e6540b433685b433711a95da7c7"
+  },
+  {
+    "seq": 29,
+    "timestamp": "2026-05-07T22:08:30-07:00",
+    "commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca",
+    "commit_short": "feb3e3b",
+    "code_fingerprint": "499c88510bb69c38684b600515392b4dd85bae723dcce8c0a1ee31c9941aa482",
+    "primary_filename": "fastType/fastText.common.js",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "fastType/fastText.common.js"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +26/-35. fastType/fastText.common.js @@ -1,13 +1,13 @@ | + // Locates WASM relative to this script file - works on any deployment path | - // Wraps Emscripten FastTextModule with the fasttext.js class API || fastType/fastText.common.js @@ -8716,39 +8716,30 @@ run(); | + function FastText(){} | - // FastText class wrapping FastTextModule",
+    "functional_impacts": [
+      "transcription"
+    ],
+    "blob_refs": [
+      "feb3e3beb6081d6e2ad75ae595113339885bcbca:fastType/fastText.common.js"
+    ],
+    "launch_ref": "fastType/fastText.common.js",
+    "note": "Diff-evidenced impacts: transcription.",
+    "previous_commit_hash": "25eb8809a933299895af51a6b723f2c5cb8e2e9f",
+    "diff_evidence": [
+      {
+        "file": "fastType/fastText.common.js",
+        "hunk": "@@ -1,13 +1,13 @@",
+        "add": "// Locates WASM relative to this script file - works on any deployment path",
+        "remove": "// Wraps Emscripten FastTextModule with the fasttext.js class API"
+      },
+      {
+        "file": "fastType/fastText.common.js",
+        "hunk": "@@ -8716,39 +8716,30 @@ run();",
+        "add": "function FastText(){}",
+        "remove": "// FastText class wrapping FastTextModule"
+      }
+    ],
+    "patch_hash": "499c88510bb69c38684b600515392b4dd85bae723dcce8c0a1ee31c9941aa482"
+  },
+  {
+    "seq": 30,
+    "timestamp": "2026-05-07T21:14:26-07:00",
+    "commit_hash": "25eb8809a933299895af51a6b723f2c5cb8e2e9f",
+    "commit_short": "25eb880",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 31,
+    "timestamp": "2026-05-07T20:58:47-07:00",
+    "commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284",
+    "commit_short": "e87a36c",
+    "code_fingerprint": "1d3b3095ce26ec85ce95284a29621958f72e6b3e35743250d45bb364c328edd6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1/-1. bridge-patched-v1.html @@ -831,7 +831,7 @@ var FT_CONF=0.5; | + s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'error');toast('Language detection unavailable');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];}; | - s.onerror=function(){_ftLoadFailed=true;_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8f276b4265914eecab61413aa43aac42ec028517",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -831,7 +831,7 @@ var FT_CONF=0.5;",
+        "add": "s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'error');toast('Language detection unavailable');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};",
+        "remove": "s.onerror=function(){_ftLoadFailed=true;_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};"
+      }
+    ],
+    "patch_hash": "1d3b3095ce26ec85ce95284a29621958f72e6b3e35743250d45bb364c328edd6"
+  },
+  {
+    "seq": 32,
+    "timestamp": "2026-05-07T20:54:12-07:00",
+    "commit_hash": "8f276b4265914eecab61413aa43aac42ec028517",
+    "commit_short": "8f276b4",
+    "code_fingerprint": "e030129539f3c0e7b51aa471999f641a510b996f627da0b20a42e5b00ce45f81",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "fastType/fastText.common.js"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 8 hunk(s), +8772/-18. bridge-patched-v1.html @@ -750,9 +750,8 @@ function getMicConstraints(){ | + s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,''); | - if(s.normalize)s=s.normalize('NFC'); || bridge-patched-v1.html @@ -927,7 +926,7 @@ async function sendChat(){ | + try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){} | - try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){} || bridge-patched-v1.html @@ -1723,11 +1722,6 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis) | + no added line sample | - function cleanTranslationText(t){",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8f276b4265914eecab61413aa43aac42ec028517:bridge-patched-v1.html",
+      "8f276b4265914eecab61413aa43aac42ec028517:fastType/fastText.common.js"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,9 +750,8 @@ function getMicConstraints(){",
+        "add": "s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');",
+        "remove": "if(s.normalize)s=s.normalize('NFC');"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -927,7 +926,7 @@ async function sendChat(){",
+        "add": "try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}",
+        "remove": "try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1723,11 +1722,6 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+        "add": "",
+        "remove": "function cleanTranslationText(t){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1738,7 +1732,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();",
+        "remove": "if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1748,7 +1742,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});",
+        "remove": "return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1765,7 +1759,6 @@ function translate(text,from,to){",
+        "add": "",
+        "remove": "t=cleanTranslationText(t);"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2327,13 +2320,20 @@ function onDGFinal(text){",
+        "add": "Promise.race([",
+        "remove": "var srcText=normalizeText(text,'speech')||text;"
+      },
+      {
+        "file": "fastType/fastText.common.js",
+        "hunk": "@@ -0,0 +1,8754 @@",
+        "add": "// fastText browser adapter for TalkBridge",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "e030129539f3c0e7b51aa471999f641a510b996f627da0b20a42e5b00ce45f81"
+  },
+  {
+    "seq": 33,
+    "timestamp": "2026-05-07T17:27:29-07:00",
+    "commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b",
+    "commit_short": "93446bd",
+    "code_fingerprint": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 7 hunk(s), +18/-18. bridge-patched-v1.html @@ -750,8 +750,9 @@ function getMicConstraints(){ | + if(s.normalize)s=s.normalize('NFC'); | - s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,''); || bridge-patched-v1.html @@ -926,7 +927,7 @@ async function sendChat(){ | + try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){} | - try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){} || bridge-patched-v1.html @@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis) | + function cleanTranslationText(t){ | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "93446bdabd881e40f5c5b709ea713c70af37068b:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,8 +750,9 @@ function getMicConstraints(){",
+        "add": "if(s.normalize)s=s.normalize('NFC');",
+        "remove": "s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -926,7 +927,7 @@ async function sendChat(){",
+        "add": "try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}",
+        "remove": "try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+        "add": "function cleanTranslationText(t){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1732,7 +1738,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);",
+        "remove": "if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1742,7 +1748,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});",
+        "remove": "return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1759,6 +1765,7 @@ function translate(text,from,to){",
+        "add": "t=cleanTranslationText(t);",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2320,20 +2327,13 @@ function onDGFinal(text){",
+        "add": "var srcText=normalizeText(text,'speech')||text;",
+        "remove": "Promise.race(["
+      }
+    ],
+    "patch_hash": "c9b52ae42eebd34ece87f7efb30d078e770d6fa003711b8d0148130797ef8a7d"
+  },
+  {
+    "seq": 34,
+    "timestamp": "2026-05-07T16:54:34-07:00",
+    "commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71",
+    "commit_short": "a31e6cb",
+    "code_fingerprint": "5c7f7f77b360cc453289f5a00c797da27ede361ebe2a2e83882ef0f732f54141",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1/-0. bridge-patched-v1.html @@ -2314,6 +2314,7 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ') | + text=text.replace(/([\\u0E34-\\u0E37\\u0E40-\\u0E44]) ([\\u0E00-\\u0E7F])/g,'$1$2').replace(/([\\u0E00-\\u0E7F]) ([\\u0E30-\\u0E37\\u0E47-\\u0E4E])/g,'$1$2'); | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a31e6cb586f30e974094da7fde554cc2863c2f71:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2314,6 +2314,7 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ')",
+        "add": "text=text.replace(/([\\u0E34-\\u0E37\\u0E40-\\u0E44]) ([\\u0E00-\\u0E7F])/g,'$1$2').replace(/([\\u0E00-\\u0E7F]) ([\\u0E30-\\u0E37\\u0E47-\\u0E4E])/g,'$1$2');",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "5c7f7f77b360cc453289f5a00c797da27ede361ebe2a2e83882ef0f732f54141"
+  },
+  {
+    "seq": 35,
+    "timestamp": "2026-05-07T16:36:40-07:00",
+    "commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6",
+    "commit_short": "d9c0759",
+    "code_fingerprint": "bb15faa67204cbdb2dd160d96a618975dcb502f7a04f5d675ec4fdb4a9bf5fa6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 14 hunk(s), +20/-20. bridge-patched-v1.html @@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} | - .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} || bridge-patched-v1.html @@ -728,7 +728,7 @@ var pc=null,videoStream=null,remoteStream=null; | + var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500; | - var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500; || bridge-patched-v1.html @@ -750,10 +750,14 @@ function getMicConstraints(){ | + if(mode==='speech'){ | - // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d9c07596d0c39e42d23d86b4bc59525a97f467c6:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -728,7 +728,7 @@ var pc=null,videoStream=null,remoteStream=null;",
+        "add": "var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;",
+        "remove": "var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,10 +750,14 @@ function getMicConstraints(){",
+        "add": "if(mode==='speech'){",
+        "remove": "// Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -826,13 +830,13 @@ var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];",
+        "add": "var s=document.createElement('script');s.src='/fastType/fastText.common.js';",
+        "remove": "var s=document.createElement('script');s.src='/fastText/fasttext.js';"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -865,13 +869,10 @@ function _detectLangAsync(text){",
+        "add": "if(micOn&&!micMutedByUser){toggleMic();}",
+        "remove": "var _pbMutedMic=false;"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1241,7 +1242,6 @@ function pbCloseDrawer(){",
+        "add": "",
+        "remove": "_pbRestoreMic();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1320,9 +1320,8 @@ function pbUseText(id,side){",
+        "add": "var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}",
+        "remove": "var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1760,7 +1759,6 @@ function translate(text,from,to){",
+        "add": "",
+        "remove": "t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2047,6 +2045,7 @@ function handleRelay(d){",
+        "add": "if(d.type==='mic-state'){var rmo=$('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2439,7 +2438,7 @@ function addTr(who,src,tr,sL,tL,ss){",
+        "add": "var entry={id:(ss?('sp-'+(who==='me'?'m'+_ssNonce:'p')+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};",
+        "remove": "var entry={id:(ss?('sp-'+who+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2450,8 +2449,7 @@ function patchTr(who,ss,newTr,sL,tL){",
+        "add": "replaceTrDomById(transcript[i].id,transcript[i]);",
+        "remove": "var eid=transcript[i].id;"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2598,6 +2596,7 @@ async function toggleMic(){",
+        "add": "relaySend({type:'mic-state',micOn:false});",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "bb15faa67204cbdb2dd160d96a618975dcb502f7a04f5d675ec4fdb4a9bf5fa6"
+  },
+  {
+    "seq": 36,
+    "timestamp": "2026-05-07T05:59:35-07:00",
+    "commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086",
+    "commit_short": "c61dcf8",
+    "code_fingerprint": "63fac6b3d76eaa6e2e9987750d93fdc28a845570ce734e6f4b50233adfbb4cad",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 16 hunk(s), +46/-148. folder-v2.html @@ -99,11 +99,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - /* Index drawer (left panel) */ || folder-v2.html @@ -119,7 +114,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .enroll-sub{font-size:11px;color:#fff;margin-top:2px} | - .enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px} || folder-v2.html @@ -129,23 +124,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - /* Timeline strip */",
+    "functional_impacts": [
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Diff-evidenced impacts: translation, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c",
+    "diff_evidence": [
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -99,11 +99,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "/* Index drawer (left panel) */"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -119,7 +114,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".enroll-sub{font-size:11px;color:#fff;margin-top:2px}",
+        "remove": ".enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -129,23 +124,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "/* Timeline strip */"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -338,34 +316,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<div class=\"lp-acq-wrap\" id=\"lp-acq-wrap\">"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -378,6 +328,31 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"rp-enroll\" class=\"hidden\" style=\"margin:8px 10px 0\">",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -487,7 +462,7 @@ const st={",
+        "add": "search:'',classFilter:null,stackFilter:null,",
+        "remove": "search:'',classFilter:null,stackFilter:null,tlSegment:null,tlOpen:false,tlHidden:new Set(),"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -924,23 +899,13 @@ const RightPane={",
+        "add": "this.renderStats();this.renderContent();this.renderFooter();",
+        "remove": "if(st.ui.tlSegment){"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -975,67 +940,6 @@ const RightPane={",
+        "add": "",
+        "remove": "renderTimeline(){"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1227,8 +1131,7 @@ const App={",
+        "add": "Tree.render();",
+        "remove": "$id('lp-acq-wrap')?.classList.remove('open');"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1247,7 +1150,7 @@ const App={",
+        "add": "st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;",
+        "remove": "st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;st.ui.tlSegment=null;"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1272,21 +1175,23 @@ const App={",
+        "add": "if(activeJob?.running){toast('Indexing already in progress for this folder','',2200);return;}",
+        "remove": "if(activeJob?.cancelled){"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1297,8 +1202,7 @@ const App={",
+        "add": "releaseSlot();",
+        "remove": "st.workerPool.active=Math.max(0,st.workerPool.active-1);"
+      }
+    ],
+    "patch_hash": "63fac6b3d76eaa6e2e9987750d93fdc28a845570ce734e6f4b50233adfbb4cad"
+  },
+  {
+    "seq": 37,
+    "timestamp": "2026-05-07T05:59:21-07:00",
+    "commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c",
+    "commit_short": "f8eaade",
+    "code_fingerprint": "563982390bbcc280d087a2c365077162f3e75f12cdb0c33487004e447af2e7c6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 19 hunk(s), +162/-48. bridge-patched-v1.html @@ -2439,7 +2439,7 @@ function addTr(who,src,tr,sL,tL,ss){ | + var entry={id:(ss?('sp-'+who+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()}; | - var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()}; || bridge-patched-v1.html @@ -2449,7 +2449,9 @@ function patchTr(who,ss,newTr,sL,tL){ | + transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr(); | - transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();renderTr(); || bridge-patched-v1.html @@ -2515,6 +2517,16 @@ function appendTrDom(entry){ | + function replaceTrDomById(id,entry){ | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:bridge-patched-v1.html",
+      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2439,7 +2439,7 @@ function addTr(who,src,tr,sL,tL,ss){",
+        "add": "var entry={id:(ss?('sp-'+who+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};",
+        "remove": "var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2449,7 +2449,9 @@ function patchTr(who,ss,newTr,sL,tL){",
+        "add": "transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();",
+        "remove": "transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();renderTr();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2515,6 +2517,16 @@ function appendTrDom(entry){",
+        "add": "function replaceTrDomById(id,entry){",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -99,6 +99,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "/* Index drawer (left panel) */",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -114,7 +119,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px}",
+        "remove": ".enroll-sub{font-size:11px;color:#fff;margin-top:2px}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -124,6 +129,23 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "/* Timeline strip */",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -316,6 +338,34 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"lp-acq-wrap\" id=\"lp-acq-wrap\">",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -328,31 +378,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<div id=\"rp-enroll\" class=\"hidden\" style=\"margin:8px 10px 0\">"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -462,7 +487,7 @@ const st={",
+        "add": "search:'',classFilter:null,stackFilter:null,tlSegment:null,tlOpen:false,tlHidden:new Set(),",
+        "remove": "search:'',classFilter:null,stackFilter:null,"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -899,13 +924,23 @@ const RightPane={",
+        "add": "if(st.ui.tlSegment){",
+        "remove": "this.renderStats();this.renderContent();this.renderFooter();"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -940,6 +975,67 @@ const RightPane={",
+        "add": "renderTimeline(){",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1131,7 +1227,8 @@ const App={",
+        "add": "$id('lp-acq-wrap')?.classList.remove('open');",
+        "remove": "Tree.render();"
+      }
+    ],
+    "patch_hash": "563982390bbcc280d087a2c365077162f3e75f12cdb0c33487004e447af2e7c6"
+  },
+  {
+    "seq": 38,
+    "timestamp": "2026-05-07T05:50:32-07:00",
+    "commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd",
+    "commit_short": "d24f8c0",
+    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +3/-6. bridge-patched-v1.html @@ -750,14 +750,10 @@ function getMicConstraints(){ | + // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes | - if(mode==='speech'){ || bridge-patched-v1.html @@ -1764,6 +1760,7 @@ function translate(text,from,to){ | + t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim(); | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d24f8c0d2dab442b98ec0b2ef6346862eee042bd:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,14 +750,10 @@ function getMicConstraints(){",
+        "add": "// Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes",
+        "remove": "if(mode==='speech'){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1764,6 +1760,7 @@ function translate(text,from,to){",
+        "add": "t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539"
+  },
+  {
+    "seq": 39,
+    "timestamp": "2026-05-07T05:50:19-07:00",
+    "commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654",
+    "commit_short": "8d959e5",
+    "code_fingerprint": "c9c12415b17de9b83d29421cad7800870e09c590b634524fdc97ec2b0086e965",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 18 hunk(s), +52/-151. bridge-patched-v1.html @@ -750,10 +750,14 @@ function getMicConstraints(){ | + if(mode==='speech'){ | - // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes || bridge-patched-v1.html @@ -1760,7 +1764,6 @@ function translate(text,from,to){ | + no added line sample | - t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim(); || folder-v2.html @@ -99,11 +99,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - /* Index drawer (left panel) */",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:bridge-patched-v1.html",
+      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a6885187e525a116f499c1bd909b9ff79a76f721",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,10 +750,14 @@ function getMicConstraints(){",
+        "add": "if(mode==='speech'){",
+        "remove": "// Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1760,7 +1764,6 @@ function translate(text,from,to){",
+        "add": "",
+        "remove": "t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -99,11 +99,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "/* Index drawer (left panel) */"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -119,7 +114,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".enroll-sub{font-size:11px;color:#fff;margin-top:2px}",
+        "remove": ".enroll-sub{font-size:11px;color:rgba(59,130,246,.7);margin-top:2px}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -129,23 +124,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "/* Timeline strip */"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -338,34 +316,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<div class=\"lp-acq-wrap\" id=\"lp-acq-wrap\">"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -378,6 +328,31 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"rp-enroll\" class=\"hidden\" style=\"margin:8px 10px 0\">",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -487,7 +462,7 @@ const st={",
+        "add": "search:'',classFilter:null,stackFilter:null,",
+        "remove": "search:'',classFilter:null,stackFilter:null,tlSegment:null,tlOpen:false,tlHidden:new Set(),"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -924,23 +899,13 @@ const RightPane={",
+        "add": "this.renderStats();this.renderContent();this.renderFooter();",
+        "remove": "if(st.ui.tlSegment){"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -975,67 +940,6 @@ const RightPane={",
+        "add": "",
+        "remove": "renderTimeline(){"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1227,8 +1131,7 @@ const App={",
+        "add": "Tree.render();",
+        "remove": "$id('lp-acq-wrap')?.classList.remove('open');"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1247,7 +1150,7 @@ const App={",
+        "add": "st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;",
+        "remove": "st.ui.search='';st.ui.classFilter=null;st.ui.stackFilter=null;st.ui.tlSegment=null;"
+      }
+    ],
+    "patch_hash": "c9c12415b17de9b83d29421cad7800870e09c590b634524fdc97ec2b0086e965"
+  },
+  {
+    "seq": 40,
+    "timestamp": "2026-05-07T05:41:09-07:00",
+    "commit_hash": "a6885187e525a116f499c1bd909b9ff79a76f721",
+    "commit_short": "a688518",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 41,
+    "timestamp": "2026-05-07T05:39:32-07:00",
+    "commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914",
+    "commit_short": "91dc5b7",
+    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +3/-6. bridge-patched-v1.html @@ -750,14 +750,10 @@ function getMicConstraints(){ | + // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes | - if(mode==='speech'){ || bridge-patched-v1.html @@ -1764,6 +1760,7 @@ function translate(text,from,to){ | + t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim(); | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, remediation/repair/fix behavior.",
+    "previous_commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -750,14 +750,10 @@ function getMicConstraints(){",
+        "add": "// Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes",
+        "remove": "if(mode==='speech'){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1764,6 +1760,7 @@ function translate(text,from,to){",
+        "add": "t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539"
+  },
+  {
+    "seq": 42,
+    "timestamp": "2026-05-07T04:54:29-07:00",
+    "commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a",
+    "commit_short": "87a480c",
+    "code_fingerprint": "a25f54cdb70ec936c40656a321c1fbace8b1c732ef9e7575c268ac2d4a2c5d83",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +10/-7. bridge-patched-v1.html @@ -869,12 +869,13 @@ function _detectLangAsync(text){ | + var _pbMutedMic=false; | - if(micOn&&!micMutedByUser){ || bridge-patched-v1.html @@ -1244,6 +1245,7 @@ function pbCloseDrawer(){ | + _pbRestoreMic(); | - no removed line sample || bridge-patched-v1.html @@ -1322,8 +1324,9 @@ function pbUseText(id,side){ | + var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();} | - var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "87a480cc2dbc1c46ff5029be551a40f335b7703a:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -869,12 +869,13 @@ function _detectLangAsync(text){",
+        "add": "var _pbMutedMic=false;",
+        "remove": "if(micOn&&!micMutedByUser){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1244,6 +1245,7 @@ function pbCloseDrawer(){",
+        "add": "_pbRestoreMic();",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1322,8 +1324,9 @@ function pbUseText(id,side){",
+        "add": "var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();}",
+        "remove": "var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2738,7 +2741,7 @@ function cleanUp(){",
+        "add": "transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();",
+        "remove": "transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;syncMic();syncCam();renderRecent();"
+      }
+    ],
+    "patch_hash": "a25f54cdb70ec936c40656a321c1fbace8b1c732ef9e7575c268ac2d4a2c5d83"
+  },
+  {
+    "seq": 43,
+    "timestamp": "2026-05-07T04:27:03-07:00",
+    "commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d",
+    "commit_short": "42feeb2",
+    "code_fingerprint": "d4a4b91416b9f5a5ece980c6b7ca38b7b3a8c213e25271e1ac7175ea26431967",
+    "primary_filename": "talkbridge-northern-thai-bridge-plugin.js",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "talkbridge-northern-thai-bridge-plugin.js"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +646/-0. talkbridge-northern-thai-bridge-plugin.js @@ -0,0 +1,646 @@ | + <.> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "42feeb2dcb0aa771fd2fe82bb5191515dd95814d:talkbridge-northern-thai-bridge-plugin.js"
+    ],
+    "launch_ref": "talkbridge-northern-thai-bridge-plugin.js",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, remediation/repair/fix behavior.",
+    "previous_commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf",
+    "diff_evidence": [
+      {
+        "file": "talkbridge-northern-thai-bridge-plugin.js",
+        "hunk": "@@ -0,0 +1,646 @@",
+        "add": "<.>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "d4a4b91416b9f5a5ece980c6b7ca38b7b3a8c213e25271e1ac7175ea26431967"
+  },
+  {
+    "seq": 44,
+    "timestamp": "2026-05-07T04:07:07-07:00",
+    "commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf",
+    "commit_short": "5e99786",
+    "code_fingerprint": "bfb7ac1ec48eb7a4cc9d7d9511ae83bebaac1a38c0cf760420841a396c369ecb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +97/-13. bridge-patched-v1.html @@ -645,6 +645,56 @@ var LANGS=[ | + // ─── AUDIO WORKLET — single-file Blob URL, falls back to ScriptProcessor ──── | - no removed line sample || bridge-patched-v1.html @@ -702,6 +752,12 @@ function normalizeText(raw,mode){ | + if(mode==='speech'){ | - no removed line sample || bridge-patched-v1.html @@ -1678,7 +1734,7 @@ function translateWithRetry(text,from,to,retries){ | + if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim(); | - if(t&&t.indexOf('MYMEMORY')<0){",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5e997868914a25463fb3e065cc5dcd7312e3ddaf:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -645,6 +645,56 @@ var LANGS=[",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -702,6 +752,12 @@ function normalizeText(raw,mode){",
+        "add": "if(mode==='speech'){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1678,7 +1734,7 @@ function translateWithRetry(text,from,to,retries){",
+        "add": "if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();",
+        "remove": "if(t&&t.indexOf('MYMEMORY')<0){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2259,6 +2315,7 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ')",
+        "add": "text=applyNorthernThaiMap(text);if(!text)return;",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -2297,28 +2354,55 @@ function startDeepgram(){",
+        "add": "var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=false&endpointing=400';",
+        "remove": "var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';"
+      }
+    ],
+    "patch_hash": "bfb7ac1ec48eb7a4cc9d7d9511ae83bebaac1a38c0cf760420841a396c369ecb"
+  },
+  {
+    "seq": 45,
+    "timestamp": "2026-05-05T00:15:36-07:00",
+    "commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b",
+    "commit_short": "f1ae66b",
+    "code_fingerprint": "e0f432275c0f1700e86e4ee6b3636e322390043fd0a51dd9d63e878a217e3fcd",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 8 hunk(s), +10/-126. bridge-patched-v1.html @@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - .pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);} || bridge-patched-v1.html @@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - <button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button> || bridge-patched-v1.html @@ -579,21 +575,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f1ae66bc58a4cb758b13ec589152c64a75b89d7b:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ".pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button>"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -579,21 +575,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -974,29 +955,6 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+        "add": "",
+        "remove": "var PB_URL_LANGS=["
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1232,7 +1190,7 @@ function pbCloseDrawer(){",
+        "add": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>';",
+        "remove": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1248,68 +1206,11 @@ function pbBuildUrl(){",
+        "add": "",
+        "remove": "function pbTogUrlFromOverlay(){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1332,21 +1233,7 @@ function pbResetConfirm(){",
+        "add": "",
+        "remove": "function pbFetchUrl(){"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1588,11 +1475,8 @@ var _pbFilter='all';",
+        "add": "var pair=pbActivePair();",
+        "remove": "if(isCallActive()&&room.myLang&&room.theirLang){"
+      }
+    ],
+    "patch_hash": "e0f432275c0f1700e86e4ee6b3636e322390043fd0a51dd9d63e878a217e3fcd"
+  },
+  {
+    "seq": 46,
+    "timestamp": "2026-05-04T23:59:08-07:00",
+    "commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260",
+    "commit_short": "95b15d6",
+    "code_fingerprint": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +3/-1. bridge-patched-v1.html @@ -1518,7 +1518,9 @@ function pbRunBT(id){ | + // Strip phonetic romanization appended by MyMemory e.g. \"สวัสดี (Sa-wat-dee)\" | - card.backtranslate.resultText=result||'';card.backtranslate.updatedAt=pbNow();",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "95b15d65a00ed741cfd8b3820b38800635058260:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, translation, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1518,7 +1518,9 @@ function pbRunBT(id){",
+        "add": "// Strip phonetic romanization appended by MyMemory e.g. \"สวัสดี (Sa-wat-dee)\"",
+        "remove": "card.backtranslate.resultText=result||'';card.backtranslate.updatedAt=pbNow();"
+      }
+    ],
+    "patch_hash": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852"
+  },
+  {
+    "seq": 47,
+    "timestamp": "2026-05-04T23:49:17-07:00",
+    "commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8",
+    "commit_short": "4d647b6",
+    "code_fingerprint": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +42/-23. bridge-patched-v1.html @@ -1239,6 +1239,15 @@ function pbSearchDrawerHtml(){ | + var _PB_BASE='https://github.acmeproducts.com/stuff/phrase/'; | - no removed line sample || bridge-patched-v1.html @@ -1263,20 +1272,18 @@ function pbBuildPbUrl(){ | + var src2=(document.getElementById('pb-url-src')||{}).value||'en'; | - var custom=(document.getElementById('pb-ov-url-custom')||{value:''}).value.trim(); || bridge-patched-v1.html @@ -1411,9 +1418,9 @@ function pbBubbleHtml(card,ctx){ | + +'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>' | - +'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+(tags.length?'<span style=\\\"font-size:9px;margin-left:2px;\\\">'+tags.length+'</span>':'')+'</button>'",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "4d647b6374df3fc15faae99330a71f6a5ef38ea8:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2ef14bfb581ecf85518691e8ac041943448a7425",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1239,6 +1239,15 @@ function pbSearchDrawerHtml(){",
+        "add": "var _PB_BASE='https://github.acmeproducts.com/stuff/phrase/';",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1263,20 +1272,18 @@ function pbBuildPbUrl(){",
+        "add": "var src2=(document.getElementById('pb-url-src')||{}).value||'en';",
+        "remove": "var custom=(document.getElementById('pb-ov-url-custom')||{value:''}).value.trim();"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1411,9 +1418,9 @@ function pbBubbleHtml(card,ctx){",
+        "add": "+'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'",
+        "remove": "+'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+(tags.length?'<span style=\\\"font-size:9px;margin-left:2px;\\\">'+tags.length+'</span>':'')+'</button>'"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1460,14 +1467,16 @@ function pbTagSugg(id){",
+        "add": "var ts=item.timestamp?new Date(item.timestamp).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';",
+        "remove": "return'<div class=\"pb-clarify-item\"><div class=\"pb-clarify-meta\">'"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1529,21 +1538,31 @@ function pbTogBt(id){var cs=_pbCS(id);cs.btOpen=!cs.btOpen;pbSyncPanel('bt',id);",
+        "add": "var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';",
+        "remove": "var panel=document.getElementById('pb'+(type==='bt'?'bt':type==='tags'?'tags':'clarify')+'-'+id);"
+      }
+    ],
+    "patch_hash": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5"
+  },
+  {
+    "seq": 48,
+    "timestamp": "2026-05-04T23:45:44-07:00",
+    "commit_hash": "2ef14bfb581ecf85518691e8ac041943448a7425",
+    "commit_short": "2ef14bf",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 49,
+    "timestamp": "2026-05-04T23:43:57-07:00",
+    "commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f",
+    "commit_short": "21d7f60",
+    "code_fingerprint": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f",
+    "primary_filename": "bridge-patched-v2.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +2856/-0. bridge-patched-v2.html @@ -0,0 +1,2856 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "21d7f60ed8a12a9a47d6fa252c640220aab1021f:bridge-patched-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v2.html",
+        "hunk": "@@ -0,0 +1,2856 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f"
+  },
+  {
+    "seq": 50,
+    "timestamp": "2026-05-04T22:28:46-07:00",
+    "commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3",
+    "commit_short": "7abbeea",
+    "code_fingerprint": "836b2203d55baa24b492baa594afa4dc8018ccfc8c5ea8b82e554e3a7a5686b1",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +67/-9. bridge-patched-v1.html @@ -579,7 +579,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\"> | - <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:5px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\"><input id=\"pb-ov-url-name\" style=\"border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;width:100%;box-sizing:border-box;\" placeholder=\"Phrasebook name (required)\"><div style=\"display:flex;gap:6px;\"><input id=\"pb-ov-url-inp\" style=\"flex:1;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key==='Enter')pbFetchUrlOverlay()\"><button onclick=\"pbFetchUrlOverlay()\" style=\"background:#2e8b8b;color:#fff;border:none;border-radius:8px;padding:6px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:'DM Sans',sans-serif;\">Go</button></div></div> || bridge-patched-v1.html @@ -960,6 +974,30 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()} | + var PB_URL_LANGS=[ | - no removed line sample || bridge-patched-v1.html @@ -1205,20 +1243,40 @@ function pbTogUrlFromOverlay(){ | + if(!vis){ | - if(!vis){var ni=document.getElementById('pb-ov-url-name');if(ni)ni.focus();}",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "7abbeea38ad2f527b6d154743de7b8c4a598d6b3:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -579,7 +579,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">",
+        "remove": "<div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:5px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\"><input id=\"pb-ov-url-name\" style=\"border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;width:100%;box-sizing:border-box;\" placeholder=\"Phrasebook name (required)\"><div style=\"display:flex;gap:6px;\"><input id=\"pb-ov-url-inp\" style=\"flex:1;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key==='Enter')pbFetchUrlOverlay()\"><button onclick=\"pbFetchUrlOverlay()\" style=\"background:#2e8b8b;color:#fff;border:none;border-radius:8px;padding:6px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:'DM Sans',sans-serif;\">Go</button></div></div>"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -960,6 +974,30 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+        "add": "var PB_URL_LANGS=[",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1205,20 +1243,40 @@ function pbTogUrlFromOverlay(){",
+        "add": "if(!vis){",
+        "remove": "if(!vis){var ni=document.getElementById('pb-ov-url-name');if(ni)ni.focus();}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1484,7 +1542,7 @@ function pbReRenderCardPanel(type,id){",
+        "add": "if(btn2){var cc=(card.clarifyChain||[]).length;btn2.innerHTML=ICO.chat+(cc?'<span style=\"font-size:9px;margin-left:2px;\">'+cc+'</span>':'');}",
+        "remove": "if(type==='clarify'){var btn2=document.getElementById('pbfc-'+id);if(btn2){var cc=(card.clarifyChain||[]).length;btn2.textContent='💬 Clarify'+(cc?' ('+cc+')':'');}}"
+      }
+    ],
+    "patch_hash": "836b2203d55baa24b492baa594afa4dc8018ccfc8c5ea8b82e554e3a7a5686b1"
+  },
+  {
+    "seq": 51,
+    "timestamp": "2026-05-04T22:07:00-07:00",
+    "commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672",
+    "commit_short": "ef895c7",
+    "code_fingerprint": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +2/-1. bridge-patched-v1.html @@ -984,7 +984,8 @@ var ICO={ | + clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>', | - clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>'",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "ef895c75a7f8a2bf580efb5db957f0b6feec6672:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: joining/rejoining flow, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -984,7 +984,8 @@ var ICO={",
+        "add": "clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>',",
+        "remove": "clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>'"
+      }
+    ],
+    "patch_hash": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb"
+  },
+  {
+    "seq": 52,
+    "timestamp": "2026-05-04T21:19:27-07:00",
+    "commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93",
+    "commit_short": "6de44b0",
+    "code_fingerprint": "875fab43924ebc5cc33e13c7b9c67433b7837fddba825196ac7d553ad1ac37cb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 18 hunk(s), +68/-37. bridge-patched-v1.html @@ -176,7 +176,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + #pb-drawer-content{flex:1;display:flex;flex-direction:column;overflow:hidden;} | - #pb-drawer-content{flex:1;overflow-y:auto;} || bridge-patched-v1.html @@ -190,7 +190,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .pb-search-results{overflow-y:auto;padding:8px 10px;flex:1;} | - .pb-search-results{overflow-y:auto;padding:8px 10px;} || bridge-patched-v1.html @@ -243,7 +243,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;padding:6px 8px;border-radius:8px;line-height:0;display:inline-flex;align-items:center;} | - .pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;font-size:20px;padding:6px 8px;border-radius:8px;line-height:1;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6de44b0e9f25115de07a8113d1c538c575ef1e93:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -176,7 +176,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "#pb-drawer-content{flex:1;display:flex;flex-direction:column;overflow:hidden;}",
+        "remove": "#pb-drawer-content{flex:1;overflow-y:auto;}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -190,7 +190,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-search-results{overflow-y:auto;padding:8px 10px;flex:1;}",
+        "remove": ".pb-search-results{overflow-y:auto;padding:8px 10px;}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -243,7 +243,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;padding:6px 8px;border-radius:8px;line-height:0;display:inline-flex;align-items:center;}",
+        "remove": ".pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;font-size:20px;padding:6px 8px;border-radius:8px;line-height:1;}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -366,6 +367,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-strip-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;transition:color .12s;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -521,7 +525,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-attach-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg></button><button class=\"pb-strip-btn\" id=\"pb-strip-btn\" onclick=\"pbToggleDrawer()\" title=\"Phrases\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 19.5A2.5 2.5 0 0 1 6.5 17H20\"/><path d=\"M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z\"/></svg></button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\" onfocus=\"composeFocusMute()\"></textarea>",
+        "remove": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-attach-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg></button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat · / for phrases\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\" onfocus=\"composeFocusMute()\"></textarea>"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -561,17 +565,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"pb-ov-back\" onclick=\"pbCloseOverlay()\" title=\"Back\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\"><polyline points=\"15 18 9 12 15 6\"/></svg></button>",
+        "remove": "<button class=\"pb-ov-back\" onclick=\"pbCloseOverlay()\">←</button>"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -822,10 +830,9 @@ function chatInputEvt(){",
+        "add": "$('chat-send-btn').disabled=!raw.trim();",
+        "remove": "$('chat-send-btn').disabled=!raw.trim()||raw==='/'||raw==='//';"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -853,7 +860,7 @@ function handleChatFile(ev){",
+        "add": "if(!text)return;",
+        "remove": "if(!text||text==='/'||text==='//') return;"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1156,6 +1163,12 @@ function pbSearch(q,cards){",
+        "add": "function pbToggleDrawer(){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1167,14 +1180,17 @@ function pbOpenSearchDrawer(q){",
+        "add": "var btn=document.getElementById('pb-strip-btn');if(btn)btn.classList.add('active');",
+        "remove": "if(si){si.value=q||'';si.focus();pbRunSearch();}"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1182,20 +1198,26 @@ function pbCmdDrawerHtml(){",
+        "add": "return '<div class=\"pb-drawer-hdr\" style=\"flex-shrink:0;\">'    +'<input id=\"pb-search-input\" class=\"pb-search-inp\" placeholder=\"Search phrases…\" oninput=\"pbRunSearch()\" onkeydown=\"pbSearchKD(event)\">'    +badge    +'<button class=\"pb-ov-act\" onclick=\"pbOpenOverlay()\" title=\"Manage phrasebook\" style=\"color:var(--text-dim);padding:4px 6px;\">'+ICO.book+'</button>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer()\" style=\"line-height:0;\">'+ICO.x+'</button></div>'    +'<div id=\"pb-search-results\" class=\"pb-search-results\"></div>';",
+        "remove": "return '<div class=\"pb-drawer-hdr\">'"
+      },
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -1225,9 +1247,10 @@ function pbFetchUrl2(){",
+        "add": "var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\\/:, ]+/g,'-');",
+        "remove": "var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\\/: ,]+/g,'-');"
+      }
+    ],
+    "patch_hash": "875fab43924ebc5cc33e13c7b9c67433b7837fddba825196ac7d553ad1ac37cb"
+  },
+  {
+    "seq": 53,
+    "timestamp": "2026-05-04T20:02:14-07:00",
+    "commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc",
+    "commit_short": "8dc8a82",
+    "code_fingerprint": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +2747/-0. bridge-patched-v1.html @@ -0,0 +1,2747 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched-v1.html",
+        "hunk": "@@ -0,0 +1,2747 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64"
+  },
+  {
+    "seq": 54,
+    "timestamp": "2026-05-04T13:56:09-07:00",
+    "commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5",
+    "commit_short": "41c63d3",
+    "code_fingerprint": "977cd9f260097e55f3ca7a597f7cce1a465668c71894270c0c5d05baf3ab8172",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 10 hunk(s), +58/-21. bridge-patched.html @@ -196,6 +196,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .room-trash-details{margin-top:6px;} | - no removed line sample || bridge-patched.html @@ -432,7 +435,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <button class=\"log-btn\" onclick=\"closeLog()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button> | - <button class=\"log-btn\" onclick=\"closeLog()\">✕ Close</button> || bridge-patched.html @@ -443,7 +446,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <button class=\"log-btn\" onclick=\"closeRoomTr()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button> | - <button class=\"log-btn\" onclick=\"closeRoomTr()\">✕ Close</button>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "41c63d354dfb4d2bb64311eed99e5acd6261d3f5:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -196,6 +196,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".room-trash-details{margin-top:6px;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -432,7 +435,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"log-btn\" onclick=\"closeLog()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button>",
+        "remove": "<button class=\"log-btn\" onclick=\"closeLog()\">✕ Close</button>"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -443,7 +446,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"log-btn\" onclick=\"closeRoomTr()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button>",
+        "remove": "<button class=\"log-btn\" onclick=\"closeRoomTr()\">✕ Close</button>"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1064,9 +1067,13 @@ function pbOpenBooksModal(){",
+        "add": "var ts=b.createdAt?new Date(b.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';",
+        "remove": "var del=b.isDefault?''"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1398,7 +1405,7 @@ function pbBtPanelHtml(card){",
+        "add": "+'<button class=\"pb-bt-run\" onclick=\"pbRunBT(\\''+id+'\\')\"><svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><polyline points=\"1 4 1 10 7 10\"/><path d=\"M3.51 15a9 9 0 1 0 .49-4.2\"/></svg> Back-translate</button>'",
+        "remove": "+'<button class=\"pb-bt-run\" onclick=\"pbRunBT(\\''+id+'\\')\">↩ Run back-translate</button>'"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1443,7 +1450,7 @@ function pbReRenderCardPanel(type,id){",
+        "add": "if(type==='bt'){var btn3=document.getElementById('pbfb-'+id);if(btn3){var bt=card.backtranslate||{};btn3.innerHTML='<svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><polyline points=\"1 4 1 10 7 10\"/><path d=\"M3.51 15a9 9 0 1 0 .49-4.2\"/></svg> Verify'+(bt.resultText?'&nbsp;<svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><polyline points=\"20 6 9 17 4 12\"/></svg>':'');}}",
+        "remove": "if(type==='bt'){var btn3=document.getElementById('pbfb-'+id);if(btn3){var bt=card.backtranslate||{};btn3.textContent='↩ Verify'+(bt.resultText?' ✓':'');}}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1554,10 +1561,21 @@ function pbConfirmImport(){",
+        "add": "var importName=(_pbImportData._importName||'').trim();",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1738,7 +1756,7 @@ async function reuseRoom(id){",
+        "add": "$('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name||'';",
+        "remove": "$('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name?'📋 '+rec.name:'';"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1754,19 +1772,38 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var live=rows.filter(function(r){return !r.deletedAt;});",
+        "remove": "w.style.display=rows.length?'':'none';"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1840,7 +1877,7 @@ async function createRoom(){",
+        "add": "var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name||'';",
+        "remove": "var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name?'📋 '+room.name:'';"
+      }
+    ],
+    "patch_hash": "977cd9f260097e55f3ca7a597f7cce1a465668c71894270c0c5d05baf3ab8172"
+  },
+  {
+    "seq": 55,
+    "timestamp": "2026-05-04T13:47:19-07:00",
+    "commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e",
+    "commit_short": "a80eaee",
+    "code_fingerprint": "849f6c3a6319721c447e1daa2aa8ef83606927c2809140f5382ade44ea5da0ca",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 14 hunk(s), +122/-30. bridge-patched.html @@ -37,7 +37,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}.recent-item.deleted-room{opacity:.85;border-left:3px solid #c0392b;}.recent-act.restore{color:#2e7d4f;} | - .recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;} || bridge-patched.html @@ -155,12 +155,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;} | - .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;} || bridge-patched.html @@ -201,8 +209,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - .pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:3px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a80eaee0241626ab570b35470651a92f8bde8c2e:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "913a20f91698c6317cb0a5d5f564e8027ca99fda",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -37,7 +37,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}.recent-item.deleted-room{opacity:.85;border-left:3px solid #c0392b;}.recent-act.restore{color:#2e7d4f;}",
+        "remove": ".recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -155,12 +155,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}",
+        "remove": ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -201,8 +209,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:3px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -306,6 +312,18 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -319,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;line-height:1.4;display:inline-flex;align-items:center;justify-content:center;}",
+        "remove": ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 7px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;line-height:0;display:inline-flex;align-items:center;justify-content:center;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -506,6 +524,24 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<!-- PiP overlay -->",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1127,7 +1163,7 @@ function pbCloseDrawer(){",
+        "add": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';",
+        "remove": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>';"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1137,17 +1173,14 @@ function pbSearchDrawerHtml(){",
+        "add": "+'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'",
+        "remove": "+'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+' new</button>'"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1163,9 +1196,10 @@ function pbTogUrlRow2(){",
+        "add": "var ni=document.getElementById('pb-url-name2');",
+        "remove": "if(!url){toast('Enter a URL');return;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1175,27 +1209,37 @@ function pbFetchUrl2(){",
+        "add": "var pair=pbActivePair();",
+        "remove": "var def='phrases-'+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[/:, ]+/g,'-');"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1259,11 +1303,11 @@ function pbBubbleHtml(card,ctx){",
+        "add": "+'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'src\\')\" title=\"'+pbEsc(useL)+'\">'+pbEsc(useL)+'</button>'",
+        "remove": "+'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'src\\')\" title=\"'+pbEsc(useL)+'\">'+ICO.use+'</button>'"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1671,7 +1715,22 @@ function saveRecent(){",
+        "add": "function delRecent(id){",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      }
+    ],
+    "patch_hash": "849f6c3a6319721c447e1daa2aa8ef83606927c2809140f5382ade44ea5da0ca"
+  },
+  {
+    "seq": 56,
+    "timestamp": "2026-05-04T12:55:58-07:00",
+    "commit_hash": "913a20f91698c6317cb0a5d5f564e8027ca99fda",
+    "commit_short": "913a20f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5007c65b6eb22c437ccca3b7f0df7d2cf32d74a1",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 57,
+    "timestamp": "2026-05-04T12:55:47-07:00",
+    "commit_hash": "5007c65b6eb22c437ccca3b7f0df7d2cf32d74a1",
+    "commit_short": "5007c65",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 58,
+    "timestamp": "2026-05-04T11:00:46-07:00",
+    "commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c",
+    "commit_short": "6724b52",
+    "code_fingerprint": "d972281fe73fd7354e2b510ac1f10028fb085e9fbf0f8f838250fec48cf2c17d",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 20 hunk(s), +96/-36. bridge-patched.html @@ -155,7 +155,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;} | - .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;} || bridge-patched.html @@ -175,6 +175,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .pb-ico-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:8px 10px;cursor:pointer;line-height:0;display:inline-flex;align-items:center;justify-content:center;transition:background .12s;flex-shrink:0;} | - no removed line sample || bridge-patched.html @@ -184,6 +187,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .pb-bbl-ts{font-size:10px;color:#9a9592;flex:1;font-variant-numeric:tabular-nums;} | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6724b523bfd833fbea25db11abefdf7830d3c04c:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -155,7 +155,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;}",
+        "remove": ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -175,6 +175,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-ico-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:8px 10px;cursor:pointer;line-height:0;display:inline-flex;align-items:center;justify-content:center;transition:background .12s;flex-shrink:0;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -184,6 +187,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-bbl-ts{font-size:10px;color:#9a9592;flex:1;font-variant-numeric:tabular-nums;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -565,6 +571,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div id=\"pb-books-modal\" style=\"position:fixed;inset:0;background:#fdfaf7;z-index:45;display:none;flex-direction:column;font-family:'DM Sans',sans-serif;overflow:hidden;\">",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -762,8 +776,9 @@ function chatInputEvt(){",
+        "add": "$('chat-send-btn').disabled=!raw.trim()||raw==='/'||raw==='//';",
+        "remove": "$('chat-send-btn').disabled=!raw.trim()||raw==='/';"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -792,7 +807,7 @@ function handleChatFile(ev){",
+        "add": "if(!text||text==='/'||text==='//') return;",
+        "remove": "if(!text||text==='/') return;"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -893,6 +908,7 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+        "add": "var PB_BOOKS_KEY='pb_books_registry'; // [{id,name,createdAt,isDefault}]",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -914,10 +930,11 @@ var ICO={",
+        "add": "use:'<svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"9 18 15 12 9 6\"/></svg>',",
+        "remove": "use:'<svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\"><line x1=\"5\" y1=\"12\" x2=\"19\" y2=\"12\"/><polyline points=\"12 5 19 12 12 19\"/></svg>',"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1005,6 +1022,21 @@ function pbChevRowHtml(card){",
+        "add": "function pbGetBooks(){try{return JSON.parse(localStorage.getItem(PB_BOOKS_KEY)||'null')||[{id:'default',name:'Default',createdAt:0,isDefault:true}];}catch(_){return [{id:'default',name:'Default',createdAt:0,isDefault:true}];}}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1026,23 +1058,16 @@ function pbApplyImport(data,opts){",
+        "add": "function pbExport(name){",
+        "remove": "function pbExport(){"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1088,14 +1113,13 @@ function pbOpenCmdDrawer(){",
+        "add": "if(si){si.value=q||'';si.focus();pbRunSearch();}",
+        "remove": "if(!isCallActive()){pbCloseDrawer();return;}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1103,15 +1127,7 @@ function pbCloseDrawer(){",
+        "add": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>';",
+        "remove": "return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\">📖 Phrasebook</span>'"
+      }
+    ],
+    "patch_hash": "d972281fe73fd7354e2b510ac1f10028fb085e9fbf0f8f838250fec48cf2c17d"
+  },
+  {
+    "seq": 59,
+    "timestamp": "2026-05-04T10:26:21-07:00",
+    "commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520",
+    "commit_short": "f4dfad8",
+    "code_fingerprint": "94695e788b203d9d61cc3aba9fc3e9db10c767ca45de2a2b13b92ff8111c090a",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 6 hunk(s), +22/-1. bridge-patched.html @@ -779,6 +779,7 @@ function handleChatFile(ev){ | + _attCache[entry.id]={name:file.name,dataUrl:dataUrl,type:file.type}; | - no removed line sample || bridge-patched.html @@ -842,6 +843,7 @@ function handleChatMsg(d){ | + if(entry.attachment&&entry.attachment.dataUrl)_attCache[entry.id]=entry.attachment; | - no removed line sample || bridge-patched.html @@ -853,6 +855,7 @@ var LS={setup:'setup',call:'call'}; | + function attModalOpenById(id){var att=_attCache[id];if(att)attModalOpen(att);} | - no removed line sample",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f4dfad85040fdfe1d9137271cc466d27c65aa520:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -779,6 +779,7 @@ function handleChatFile(ev){",
+        "add": "_attCache[entry.id]={name:file.name,dataUrl:dataUrl,type:file.type};",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -842,6 +843,7 @@ function handleChatMsg(d){",
+        "add": "if(entry.attachment&&entry.attachment.dataUrl)_attCache[entry.id]=entry.attachment;",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -853,6 +855,7 @@ var LS={setup:'setup',call:'call'};",
+        "add": "function attModalOpenById(id){var att=_attCache[id];if(att)attModalOpen(att);}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -870,6 +873,13 @@ function attModalClose(){",
+        "add": "function removeTrEntry(id){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -907,6 +917,7 @@ var ICO={",
+        "add": "var _attCache={}; // entryId -> {name,dataUrl,type}",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -2211,7 +2222,17 @@ function trHtml(e){",
+        "add": "var attachHtml='';",
+        "remove": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+      }
+    ],
+    "patch_hash": "94695e788b203d9d61cc3aba9fc3e9db10c767ca45de2a2b13b92ff8111c090a"
+  },
+  {
+    "seq": 60,
+    "timestamp": "2026-05-04T09:32:31-07:00",
+    "commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3",
+    "commit_short": "a4a043c",
+    "code_fingerprint": "0ec941fd4a5183a1f2615f02df4f09968cd017b6039791f39bd0de88d99871ff",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +3/-19. bridge-patched.html @@ -1600,7 +1600,7 @@ function saveRecent(){ | + function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()} | - function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()} || bridge-patched.html @@ -1624,17 +1624,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas | + l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join(''); | - var active=rows.filter(function(r){return !r.deletedAt}); || bridge-patched.html @@ -2206,16 +2200,6 @@ function renderMd(txt){ | + no added line sample | - function delAttachment(trId){",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3:bridge-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1600,7 +1600,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}",
+        "remove": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1624,17 +1624,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+        "remove": "var active=rows.filter(function(r){return !r.deletedAt});"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -2206,16 +2200,6 @@ function renderMd(txt){",
+        "add": "",
+        "remove": "function delAttachment(trId){"
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -2227,7 +2211,7 @@ function trHtml(e){",
+        "add": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}",
+        "remove": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}"
+      }
+    ],
+    "patch_hash": "0ec941fd4a5183a1f2615f02df4f09968cd017b6039791f39bd0de88d99871ff"
+  },
+  {
+    "seq": 61,
+    "timestamp": "2026-05-03T23:09:22-07:00",
+    "commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94",
+    "commit_short": "b05216b",
+    "code_fingerprint": "a92ab0221ae9429ce10f716ac2a7cccc5139b8104ea98599aa35a9efabf8488a",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +359/-158. getit.html @@ -1,9 +1,13 @@ | + <!-- ============================================ --> | - <title>Site Bundler</title> || getit.html @@ -13,278 +17,455 @@ | + background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); | - background: #0d1117; || getit.html @@ -292,18 +473,16 @@ | + setStatus('error', 'Please enter a URL'); | - showError('Please enter a URL');",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b05216b41efea4d90e62805b2edcf9890fdafd94:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Diff-evidenced impacts: normalization, translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "98560d0562826531e3fdb33f71735243dfa333f9",
+    "diff_evidence": [
+      {
+        "file": "getit.html",
+        "hunk": "@@ -1,9 +1,13 @@",
+        "add": "<!-- ============================================ -->",
+        "remove": "<title>Site Bundler</title>"
+      },
+      {
+        "file": "getit.html",
+        "hunk": "@@ -13,278 +17,455 @@",
+        "add": "background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);",
+        "remove": "background: #0d1117;"
+      },
+      {
+        "file": "getit.html",
+        "hunk": "@@ -292,18 +473,16 @@",
+        "add": "setStatus('error', 'Please enter a URL');",
+        "remove": "showError('Please enter a URL');"
+      },
+      {
+        "file": "getit.html",
+        "hunk": "@@ -314,47 +493,68 @@",
+        "add": "const data = await response.json();",
+        "remove": "if (!response.ok) {"
+      },
+      {
+        "file": "getit.html",
+        "hunk": "@@ -362,7 +562,8 @@",
+        "add": "setStatus('fetching', 'Ready - enter a URL to create a self-contained offline bundle');",
+        "remove": "setStatus('ready', 'Ready to bundle');"
+      }
+    ],
+    "patch_hash": "a92ab0221ae9429ce10f716ac2a7cccc5139b8104ea98599aa35a9efabf8488a"
+  },
+  {
+    "seq": 62,
+    "timestamp": "2026-05-03T21:46:19-07:00",
+    "commit_hash": "98560d0562826531e3fdb33f71735243dfa333f9",
+    "commit_short": "98560d0",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 63,
+    "timestamp": "2026-05-03T21:46:07-07:00",
+    "commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b",
+    "commit_short": "ec23f33",
+    "code_fingerprint": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 4 hunk(s), +22/-2. bridge-patched.html @@ -2206,6 +2206,16 @@ function renderMd(txt){ | + function delAttachment(trId){ | - no removed line sample || bridge-patched.html @@ -2217,7 +2227,7 @@ function trHtml(e){ | + var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';} | - var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';} || bridge8-patched.html @@ -2206,6 +2206,16 @@ function renderMd(txt){ | + function delAttachment(trId){ | - no removed line sample",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge-patched.html",
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7185a930d74e3c02f120c88ea9b5725f1d339e03",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -2206,6 +2206,16 @@ function renderMd(txt){",
+        "add": "function delAttachment(trId){",
+        "remove": ""
+      },
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -2217,7 +2227,7 @@ function trHtml(e){",
+        "add": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}",
+        "remove": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -2206,6 +2206,16 @@ function renderMd(txt){",
+        "add": "function delAttachment(trId){",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -2217,7 +2227,7 @@ function trHtml(e){",
+        "add": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}",
+        "remove": "var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+      }
+    ],
+    "patch_hash": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203"
+  },
+  {
+    "seq": 64,
+    "timestamp": "2026-05-03T19:28:30-07:00",
+    "commit_hash": "7185a930d74e3c02f120c88ea9b5725f1d339e03",
+    "commit_short": "7185a93",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0aa34922277e9e143b2649ca95bb4f92540e4c84",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 65,
+    "timestamp": "2026-05-03T19:28:16-07:00",
+    "commit_hash": "0aa34922277e9e143b2649ca95bb4f92540e4c84",
+    "commit_short": "0aa3492",
+    "code_fingerprint": "3b9932d5f81417f7e0fb1ea2630da54d6dba8768e57279b30df3a9c735d16ed5",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 14 hunk(s), +25/-71. folder-v2.html @@ -374,15 +374,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div id=\"rp-search\"> | - <div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div> || folder-v2.html @@ -484,6 +482,8 @@ const st={ | + workerPool:{max:5,active:0}, | - no removed line sample || folder-v2.html @@ -1019,7 +1019,7 @@ const RightPane={ | + txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace'); | - txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0aa34922277e9e143b2649ca95bb4f92540e4c84:folder-v2.html",
+      "0aa34922277e9e143b2649ca95bb4f92540e4c84:recover.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Diff-evidenced impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b89289127741c3e4823ab8b07368cd8f082d1e24",
+    "diff_evidence": [
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -374,15 +374,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"rp-search\">",
+        "remove": "<div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div>"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -484,6 +482,8 @@ const st={",
+        "add": "workerPool:{max:5,active:0},",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1019,7 +1019,7 @@ const RightPane={",
+        "add": "txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+        "remove": "txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1271,11 +1271,17 @@ const App={",
+        "add": "const activeJob=st.acqJobs[folderId];",
+        "remove": "if(st.acq.running){toast('Slot not available, try again later.','',2200);return;}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1290,6 +1296,8 @@ const App={",
+        "add": "st.acqJobs[folderId]={running:false,cancelled:false,paused:false,lastFolder:folderName,completed:true};",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1298,6 +1306,8 @@ const App={",
+        "add": "st.acqJobs[folderId]={running:false,cancelled:true,paused:false,lastFolder:folderName};",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1406,10 +1416,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "// Timeline toggle"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1421,17 +1427,21 @@ function initEvents(){",
+        "add": "if(st.selFolderId&&st.acqJobs[st.selFolderId]){st.acqJobs[st.selFolderId].cancelled=true;st.acqJobs[st.selFolderId].running=false;}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1463,7 +1473,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "window.addEventListener('resize',()=>{if(st.ui.tlOpen)RightPane.renderTimeline();});"
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -41,7 +41,7 @@",
+        "add": "let recovered = { scannedAt: null, localStorage: [], indexedDB: [], mergedConversations: [] };",
+        "remove": "let recovered = { scannedAt: null, localStorage: [], indexedDB: [], recentRooms: [], legacyDeletedRooms: [], mergedConversations: [] };"
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -73,54 +73,6 @@",
+        "add": "",
+        "remove": "function parseRecentRooms(){"
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -215,19 +167,17 @@",
+        "add": "if(!map.has(key)) map.set(key,{source:[c.source], key:[c.key], messages:[...c.messages]});",
+        "remove": "if(!map.has(key)) map.set(key,{source:[c.source], key:[c.key], messages:[...c.messages], room:c.room||null});"
+      }
+    ],
+    "patch_hash": "3b9932d5f81417f7e0fb1ea2630da54d6dba8768e57279b30df3a9c735d16ed5"
+  },
+  {
+    "seq": 66,
+    "timestamp": "2026-05-03T19:25:24-07:00",
+    "commit_hash": "b89289127741c3e4823ab8b07368cd8f082d1e24",
+    "commit_short": "b892891",
+    "code_fingerprint": "0fb9d5de3ff747f378dc30884d2568c23e6d96ebbad1263215ad14df7b3a2d89",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 14 hunk(s), +71/-25. folder-v2.html @@ -374,13 +374,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div> | - <div id=\"rp-search\"> || folder-v2.html @@ -482,8 +484,6 @@ const st={ | + no added line sample | - workerPool:{max:5,active:0}, || folder-v2.html @@ -1019,7 +1019,7 @@ const RightPane={ | + txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace'); | - txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b89289127741c3e4823ab8b07368cd8f082d1e24:folder-v2.html",
+      "b89289127741c3e4823ab8b07368cd8f082d1e24:recover.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Diff-evidenced impacts: transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "6ea2c1d409ec002c6c2d781bc66aded05d7721f5",
+    "diff_evidence": [
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -374,13 +374,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div>",
+        "remove": "<div id=\"rp-search\">"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -482,8 +484,6 @@ const st={",
+        "add": "",
+        "remove": "workerPool:{max:5,active:0},"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1019,7 +1019,7 @@ const RightPane={",
+        "add": "txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+        "remove": "txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1271,17 +1271,11 @@ const App={",
+        "add": "if(st.acq.running){toast('Slot not available, try again later.','',2200);return;}",
+        "remove": "const activeJob=st.acqJobs[folderId];"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1296,8 +1290,6 @@ const App={",
+        "add": "",
+        "remove": "st.acqJobs[folderId]={running:false,cancelled:false,paused:false,lastFolder:folderName,completed:true};"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1306,8 +1298,6 @@ const App={",
+        "add": "",
+        "remove": "st.acqJobs[folderId]={running:false,cancelled:true,paused:false,lastFolder:folderName};"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1416,6 +1406,10 @@ function initEvents(){",
+        "add": "// Timeline toggle",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1427,21 +1421,17 @@ function initEvents(){",
+        "add": "",
+        "remove": "if(st.selFolderId&&st.acqJobs[st.selFolderId]){st.acqJobs[st.selFolderId].cancelled=true;st.acqJobs[st.selFolderId].running=false;}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1473,6 +1463,7 @@ function initEvents(){",
+        "add": "window.addEventListener('resize',()=>{if(st.ui.tlOpen)RightPane.renderTimeline();});",
+        "remove": ""
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -41,7 +41,7 @@",
+        "add": "let recovered = { scannedAt: null, localStorage: [], indexedDB: [], recentRooms: [], legacyDeletedRooms: [], mergedConversations: [] };",
+        "remove": "let recovered = { scannedAt: null, localStorage: [], indexedDB: [], mergedConversations: [] };"
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -73,6 +73,54 @@",
+        "add": "function parseRecentRooms(){",
+        "remove": ""
+      },
+      {
+        "file": "recover.html",
+        "hunk": "@@ -167,17 +215,19 @@",
+        "add": "if(!map.has(key)) map.set(key,{source:[c.source], key:[c.key], messages:[...c.messages], room:c.room||null});",
+        "remove": "if(!map.has(key)) map.set(key,{source:[c.source], key:[c.key], messages:[...c.messages]});"
+      }
+    ],
+    "patch_hash": "0fb9d5de3ff747f378dc30884d2568c23e6d96ebbad1263215ad14df7b3a2d89"
+  },
+  {
+    "seq": 67,
+    "timestamp": "2026-05-03T19:09:35-07:00",
+    "commit_hash": "6ea2c1d409ec002c6c2d781bc66aded05d7721f5",
+    "commit_short": "6ea2c1d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 68,
+    "timestamp": "2026-05-03T19:09:25-07:00",
+    "commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1",
+    "commit_short": "ee75f51",
+    "code_fingerprint": "faf0959328f67a0b4d94eea87891d8907fc6ec7d6e01f05cca45066d2631f933",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 9 hunk(s), +19/-10. folder-v2.html @@ -374,15 +374,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div id=\"rp-search\"> | - <div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div> || folder-v2.html @@ -484,6 +482,8 @@ const st={ | + workerPool:{max:5,active:0}, | - no removed line sample || folder-v2.html @@ -1019,7 +1019,7 @@ const RightPane={ | + txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace'); | - txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "ee75f51efd1fdf5e8945775d120b15408d22c2c1:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "3f2437caf2785c101927215842d900e157c7ec75",
+    "diff_evidence": [
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -374,15 +374,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"rp-search\">",
+        "remove": "<div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div>"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -484,6 +482,8 @@ const st={",
+        "add": "workerPool:{max:5,active:0},",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1019,7 +1019,7 @@ const RightPane={",
+        "add": "txt.setAttribute('fill','#ffffff');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');",
+        "remove": "txt.setAttribute('fill','#3a3a52');txt.setAttribute('font-size','9');txt.setAttribute('font-family','IBM Plex Mono,monospace');"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1271,11 +1271,17 @@ const App={",
+        "add": "const activeJob=st.acqJobs[folderId];",
+        "remove": "if(st.acq.running){toast('Slot not available, try again later.','',2200);return;}"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1290,6 +1296,8 @@ const App={",
+        "add": "st.acqJobs[folderId]={running:false,cancelled:false,paused:false,lastFolder:folderName,completed:true};",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1298,6 +1306,8 @@ const App={",
+        "add": "st.acqJobs[folderId]={running:false,cancelled:true,paused:false,lastFolder:folderName};",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1406,10 +1416,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "// Timeline toggle"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1421,17 +1427,21 @@ function initEvents(){",
+        "add": "if(st.selFolderId&&st.acqJobs[st.selFolderId]){st.acqJobs[st.selFolderId].cancelled=true;st.acqJobs[st.selFolderId].running=false;}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -1463,7 +1473,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "window.addEventListener('resize',()=>{if(st.ui.tlOpen)RightPane.renderTimeline();});"
+      }
+    ],
+    "patch_hash": "faf0959328f67a0b4d94eea87891d8907fc6ec7d6e01f05cca45066d2631f933"
+  },
+  {
+    "seq": 69,
+    "timestamp": "2026-05-03T18:13:26-07:00",
+    "commit_hash": "3f2437caf2785c101927215842d900e157c7ec75",
+    "commit_short": "3f2437c",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 70,
+    "timestamp": "2026-05-03T18:13:13-07:00",
+    "commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed",
+    "commit_short": "5946aea",
+    "code_fingerprint": "9c1a46bbde95e7a1b290173323a5cd066751fce43ce8ff0bf9e5c2bcb17a7cca",
+    "primary_filename": "recover.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "recover.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +224/-0. recover.html @@ -0,0 +1,224 @@ | + <!doctype html> | - no removed line sample",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5946aea35f2a5fa282b878b9c05e76091107e8ed:recover.html"
+    ],
+    "launch_ref": "recover.html",
+    "note": "Diff-evidenced impacts: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30",
+    "diff_evidence": [
+      {
+        "file": "recover.html",
+        "hunk": "@@ -0,0 +1,224 @@",
+        "add": "<!doctype html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "9c1a46bbde95e7a1b290173323a5cd066751fce43ce8ff0bf9e5c2bcb17a7cca"
+  },
+  {
+    "seq": 71,
+    "timestamp": "2026-05-03T17:20:24-07:00",
+    "commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30",
+    "commit_short": "98c907e",
+    "code_fingerprint": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 4 file(s), 7 hunk(s), +2531/-6. bridge-patched.html @@ -0,0 +1,2507 @@ | + <!DOCTYPE html> | - no removed line sample || bridge-v1.html @@ -487,7 +487,7 @@ function saveRecent(){ | + function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()} | - function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()} || bridge-v1.html @@ -516,11 +516,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas | + var active=rows.filter(function(r){return !r.deletedAt}); | - l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-patched.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v1.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v2.html",
+      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -0,0 +1,2507 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -487,7 +487,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -516,11 +516,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -481,7 +481,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -506,11 +506,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1600,7 +1600,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1624,11 +1624,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      }
+    ],
+    "patch_hash": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1"
+  },
+  {
+    "seq": 72,
+    "timestamp": "2026-05-03T17:20:12-07:00",
+    "commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0",
+    "commit_short": "3ff2166",
+    "code_fingerprint": "63a6e7aefe960781885fe16f5bfa6a55ef6a9a4b17df1f9880c2a507cc4ef4c0",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 5 file(s), 19 hunk(s), +33/-2558. bridge-patched.html @@ -1,2507 +0,0 @@ | + no added line sample | - <!DOCTYPE html> || bridge-v1.html @@ -487,7 +487,7 @@ function saveRecent(){ | + function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()} | - function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()} || bridge-v1.html @@ -516,17 +516,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas | + l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join(''); | - var active=rows.filter(function(r){return !r.deletedAt});",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-patched.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v1.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v2.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge8-patched.html",
+      "3ff2166082df241f5cda8d67bca4cb821a66edc0:folder-v2.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0d0e627a052bb8b78facd19226f22078ecd7e296",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -1,2507 +0,0 @@",
+        "add": "",
+        "remove": "<!DOCTYPE html>"
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -487,7 +487,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}",
+        "remove": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}"
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -516,17 +516,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+        "remove": "var active=rows.filter(function(r){return !r.deletedAt});"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -481,7 +481,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}",
+        "remove": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -506,17 +506,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+        "remove": "var active=rows.filter(function(r){return !r.deletedAt});"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1600,7 +1600,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}",
+        "remove": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1624,17 +1624,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+        "remove": "var active=rows.filter(function(r){return !r.deletedAt});"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -12,7 +12,7 @@",
+        "add": "--tp:#e0e0ee;--ts:#ffffff;--tm:#cfcfe0;",
+        "remove": "--tp:#e0e0ee;--ts:#80809a;--tm:#3a3a52;"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -336,13 +336,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<button class=\"lp-tab\">Timeline</button>"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -357,7 +350,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div style=\"display:flex;gap:6px\">",
+        "remove": "<button class=\"btn btn-danger btn-sm\" id=\"btn-acq-cancel\">Cancel</button>"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -377,25 +374,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span></div>",
+        "remove": "<div style=\"padding:6px 12px;border-bottom:1px solid var(--border);background:var(--surface);font-family:var(--mono);font-size:11px;color:var(--ts)\">Scope: <span style=\"color:var(--tp)\">Current folder context</span> · Result mix updates as filters are applied.</div>"
+      },
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -499,7 +483,7 @@ const st={",
+        "add": "acq:{running:false,cancelled:false,paused:false,t0:0,tick:null},",
+        "remove": "acq:{running:false,cancelled:false,t0:0,tick:null},"
+      }
+    ],
+    "patch_hash": "63a6e7aefe960781885fe16f5bfa6a55ef6a9a4b17df1f9880c2a507cc4ef4c0"
+  },
+  {
+    "seq": 73,
+    "timestamp": "2026-05-03T17:19:51-07:00",
+    "commit_hash": "0d0e627a052bb8b78facd19226f22078ecd7e296",
+    "commit_short": "0d0e627",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 74,
+    "timestamp": "2026-05-03T17:19:34-07:00",
+    "commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c",
+    "commit_short": "224cf53",
+    "code_fingerprint": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1",
+    "primary_filename": "bridge-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 4 file(s), 7 hunk(s), +2531/-6. bridge-patched.html @@ -0,0 +1,2507 @@ | + <!DOCTYPE html> | - no removed line sample || bridge-v1.html @@ -487,7 +487,7 @@ function saveRecent(){ | + function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()} | - function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()} || bridge-v1.html @@ -516,11 +516,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas | + var active=rows.filter(function(r){return !r.deletedAt}); | - l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-patched.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v1.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v2.html",
+      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "15b387ad945caa3f62832f4179a00d335f9caa8e",
+    "diff_evidence": [
+      {
+        "file": "bridge-patched.html",
+        "hunk": "@@ -0,0 +1,2507 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -487,7 +487,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge-v1.html",
+        "hunk": "@@ -516,11 +516,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -481,7 +481,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge-v2.html",
+        "hunk": "@@ -506,11 +506,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button></div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1600,7 +1600,7 @@ function saveRecent(){",
+        "add": "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}",
+        "remove": "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1624,11 +1624,17 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+        "add": "var active=rows.filter(function(r){return !r.deletedAt});",
+        "remove": "l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+      }
+    ],
+    "patch_hash": "f2962eaf3495ac110237d4d8f9a76a1657f4a7a7c8f14c923c8e633c12d555b1"
+  },
+  {
+    "seq": 75,
+    "timestamp": "2026-05-03T15:56:12-07:00",
+    "commit_hash": "15b387ad945caa3f62832f4179a00d335f9caa8e",
+    "commit_short": "15b387a",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 76,
+    "timestamp": "2026-05-03T15:55:49-07:00",
+    "commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2",
+    "commit_short": "2544c6f",
+    "code_fingerprint": "563535e56879f8e89329d09a78a6810702d4bad217c7b300b04f41b8fc41bb29",
+    "primary_filename": "folder-v2.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "folder-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1476/-0. folder-v2.html @@ -0,0 +1,1476 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2544c6fe6660ffa86d63b4982be6d71b234575f2:folder-v2.html"
+    ],
+    "launch_ref": "folder-v2.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e6b99a6c03513ab98a37279e321264ef63268f2b",
+    "diff_evidence": [
+      {
+        "file": "folder-v2.html",
+        "hunk": "@@ -0,0 +1,1476 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "563535e56879f8e89329d09a78a6810702d4bad217c7b300b04f41b8fc41bb29"
+  },
+  {
+    "seq": 77,
+    "timestamp": "2026-05-03T14:48:35-07:00",
+    "commit_hash": "e6b99a6c03513ab98a37279e321264ef63268f2b",
+    "commit_short": "e6b99a6",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 78,
+    "timestamp": "2026-05-03T14:43:39-07:00",
+    "commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b",
+    "commit_short": "f9decf2",
+    "code_fingerprint": "67fc30d2e5b0d8ba249cfdd386991060e96d8aeed84f0081ba4ed5736772bbf4",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 17 hunk(s), +178/-39. bridge8-patched.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.3.0 — phrasebook v2+ --> | - <!-- talkbridge · dcr · v3.2.1 — phrasebook v2 unified drawer --> || bridge8-patched.html @@ -299,6 +299,46 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* ─── PB v2+ additions ───────────────────────────────── */ | - no removed line sample || bridge8-patched.html @@ -346,7 +386,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"e.g. Doctor visit\" maxlength=\"60\"></div> | - <input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"My Place\" maxlength=\"60\"></div>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f9decf22f5d1994d4434a8c24f873d5b628b3a2b:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.3.0 — phrasebook v2+ -->",
+        "remove": "<!-- talkbridge · dcr · v3.2.1 — phrasebook v2 unified drawer -->"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -299,6 +299,46 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -346,7 +386,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"e.g. Doctor visit\" maxlength=\"60\"></div>",
+        "remove": "<input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"My Place\" maxlength=\"60\"></div>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -454,12 +494,23 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-attach-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg></button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat · / for phrases\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>",
+        "remove": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat · / for phrases\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -802,6 +853,23 @@ var LS={setup:'setup',call:'call'};",
+        "add": "function attModalOpen(att){",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -821,6 +889,24 @@ var PB_SEED={\"type\":\"phrasebook\",\"cards\":[{\"id\":\"mnhd6ozl7hxlpp\",\"catalogIds\":[]",
+        "add": "var ICO={",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -842,13 +928,15 @@ function pbNorm(c){",
+        "add": "deletedAt:c.deletedAt||null,",
+        "remove": "function pbGetCards(){try{return JSON.parse(localStorage.getItem(PB_CARDS)||'[]').map(pbNorm);}catch(_){return[];}}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -861,17 +949,47 @@ function pbUpsert(card){",
+        "add": "function pbGetCardById(id){return pbGetAllCards().find(function(c){return c.id===id;})||null;}",
+        "remove": "function pbGetCardById(id){return pbGetCards().find(function(c){return c.id===id;})||null;}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -977,7 +1095,7 @@ function pbCmdDrawerHtml(){",
+        "add": "+'<button class=\"pb-cmd-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenOverlay()\">'+ICO.book+' open</button>'",
+        "remove": "+'<button class=\"pb-cmd-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenOverlay()\">📖 open</button>'"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -992,14 +1110,35 @@ function pbSearchDrawerHtml(){",
+        "add": "+'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+' new</button>'",
+        "remove": "+'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\">＋ new</button>'"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1049,37 +1188,32 @@ function pbBubbleHtml(card,ctx){",
+        "add": "var cs=_pbCS(id);var isDel=!!card.deletedAt;",
+        "remove": "var cs=_pbCS(id);"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1147,7 +1281,8 @@ function pbRemoveClarify(id,idx){",
+        "add": "var btLang=(card.backtranslate&&card.backtranslate.targetLang)||card.sourceLang||'en';",
+        "remove": "var resultHtml=result?('<div style=\"font-style:italic;color:#555;font-size:13px;margin:6px 0;\">'+pbEsc(result)+'</div>'):('<div style=\"color:#aaa;font-size:12px;\">No result yet.</div>');"
+      }
+    ],
+    "patch_hash": "67fc30d2e5b0d8ba249cfdd386991060e96d8aeed84f0081ba4ed5736772bbf4"
+  },
+  {
+    "seq": 79,
+    "timestamp": "2026-05-03T00:42:36-07:00",
+    "commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87",
+    "commit_short": "2c5fa2d",
+    "code_fingerprint": "f231ae3379df4226b0def2f9763a648c3a59e0caefbaf5db997174c424ed3dea",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 8 hunk(s), +20/-15. bridge8-patched.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.2.1 — phrasebook v2 unified drawer --> | - <!-- talkbridge · dcr · v3.2.0 — phrasebook v2 --> || bridge8-patched.html @@ -169,11 +169,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .pb-chip-ribbon{display:flex;overflow-x:auto;gap:7px;padding:7px 10px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;-webkit-overflow-scrolling:touch;scrollbar-width:none;} | - .pb-cmd-chips{display:flex;flex-wrap:wrap;gap:8px;padding:12px;} || bridge8-patched.html @@ -345,7 +346,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"My Place\" maxlength=\"60\"></div> | - <input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"e.g. Doctor visit\" maxlength=\"60\"></div>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2c5fa2def30b9629989e35cc5aaa3effb1750d87:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.2.1 — phrasebook v2 unified drawer -->",
+        "remove": "<!-- talkbridge · dcr · v3.2.0 — phrasebook v2 -->"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -169,11 +169,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".pb-chip-ribbon{display:flex;overflow-x:auto;gap:7px;padding:7px 10px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;-webkit-overflow-scrolling:touch;scrollbar-width:none;}",
+        "remove": ".pb-cmd-chips{display:flex;flex-wrap:wrap;gap:8px;padding:12px;}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -345,7 +346,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"My Place\" maxlength=\"60\"></div>",
+        "remove": "<input class=\"lobby-input\" id=\"modal-room-name\" placeholder=\"e.g. Doctor visit\" maxlength=\"60\"></div>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -453,7 +454,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat · / for phrases\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>",
+        "remove": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat or enter // for menu\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -710,11 +711,8 @@ function chatInputEvt(){",
+        "add": "$('chat-send-btn').disabled=!raw.trim()||raw==='/';",
+        "remove": "$('chat-send-btn').disabled=!raw.trim()||raw==='/'||raw==='//';"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -742,7 +740,7 @@ function handleChatFile(ev){",
+        "add": "if(!text||text==='/') return;",
+        "remove": "if(!text||text==='/'||text==='//') return;"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -993,6 +991,13 @@ function pbSearchDrawerHtml(){",
+        "add": "+'<div class=\"pb-chip-ribbon\">'",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1695,7 +1700,7 @@ async function enterCall(){",
+        "add": "var ci=$('chat-input');if(ci)ci.placeholder='type here to chat \\u00b7 / for phrases';",
+        "remove": "var ci=$('chat-input');if(ci)ci.placeholder='type here to chat or enter // for menu';"
+      }
+    ],
+    "patch_hash": "f231ae3379df4226b0def2f9763a648c3a59e0caefbaf5db997174c424ed3dea"
+  },
+  {
+    "seq": 80,
+    "timestamp": "2026-05-03T00:21:52-07:00",
+    "commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e",
+    "commit_short": "f961596",
+    "code_fingerprint": "06a2cf14f0c350e0f90df52df32f339a67baced7a9c19f27cbc8bf928b04bf7f",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 9 hunk(s), +707/-66. bridge8-patched.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.2.0 — phrasebook v2 --> | - <!-- talkbridge · dcr · v3.1.0 --> || bridge8-patched.html @@ -161,8 +161,111 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* ═══ PHRASEBOOK v2 STYLES ═══════════════════════════════════════════════ */ | - .phrase-drawer{position:fixed;left:0;right:0;bottom:-52dvh;height:48dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:12;transition:bottom .18s ease;padding:8px 10px;overflow-y:auto;} || bridge8-patched.html @@ -356,8 +459,61 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <!-- ══ PHRASEBOOK v2 ══ --> | - <div class=\"phrase-drawer\" id=\"phrase-drawer\"><div style=\"display:flex;justify-content:space-between;align-items:center;\"><div id=\"drawer-title\" style=\"font-size:12px;color:var(--text-dim);font-weight:600;\">Command Drawer</div><button onclick=\"closePhraseDrawer()\" style=\"background:none;border:none;color:var(--text-dim);font-size:18px;line-height:1;\">×</button></div><div id=\"phrase-results\"></div></div>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f961596e94dc0f16e26732f86e50841b4db0db6e:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.2.0 — phrasebook v2 -->",
+        "remove": "<!-- talkbridge · dcr · v3.1.0 -->"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -161,8 +161,111 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* ═══ PHRASEBOOK v2 STYLES ═══════════════════════════════════════════════ */",
+        "remove": ".phrase-drawer{position:fixed;left:0;right:0;bottom:-52dvh;height:48dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:12;transition:bottom .18s ease;padding:8px 10px;overflow-y:auto;}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -356,8 +459,61 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<!-- ══ PHRASEBOOK v2 ══ -->",
+        "remove": "<div class=\"phrase-drawer\" id=\"phrase-drawer\"><div style=\"display:flex;justify-content:space-between;align-items:center;\"><div id=\"drawer-title\" style=\"font-size:12px;color:var(--text-dim);font-weight:600;\">Command Drawer</div><button onclick=\"closePhraseDrawer()\" style=\"background:none;border:none;color:var(--text-dim);font-size:18px;line-height:1;\">×</button></div><div id=\"phrase-results\"></div></div>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -426,10 +582,6 @@ var savedOffer=null;",
+        "add": "",
+        "remove": "var PHRASE_KEY='tb_standard_phrasebook';"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -555,13 +707,15 @@ function _detectLangAsync(text){",
+        "add": "var raw=ta.value||'';",
+        "remove": "var raw=ta.value||'',v=raw.trim();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -588,11 +742,9 @@ function handleChatFile(ev){",
+        "add": "if(!text||text==='/'||text==='//') return;",
+        "remove": "if(text.indexOf('//')===0){runPhraseCommand(text.slice(2).trim());ta.value='';chatInputEvt();return;}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -656,53 +808,542 @@ function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');c",
+        "add": "// ═══════════════════════════════════════════════════",
+        "remove": "function normalizePbCard(x){"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1685,7 +2326,7 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(",
+        "add": "pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();",
+        "remove": "initPhrasebook();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1713,4 +2354,4 @@ window.addEventListener('visibilitychange',function(){",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "06a2cf14f0c350e0f90df52df32f339a67baced7a9c19f27cbc8bf928b04bf7f"
+  },
+  {
+    "seq": 81,
+    "timestamp": "2026-05-02T17:04:00-07:00",
+    "commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c",
+    "commit_short": "3ce547b",
+    "code_fingerprint": "8fc2bc008fdfc875c04617b33c12d26c419e49f0e45e12ea52974720c69f2178",
+    "primary_filename": "bridge8-v1.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1563/-0. bridge8-v1.html @@ -0,0 +1,1563 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ce547b137b09576fa3d234229474df5bc92691c:bridge8-v1.html"
+    ],
+    "launch_ref": "bridge8-v1.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "602d9f942ef11936fcbff10a8bc262e3afd71f1f",
+    "diff_evidence": [
+      {
+        "file": "bridge8-v1.html",
+        "hunk": "@@ -0,0 +1,1563 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "8fc2bc008fdfc875c04617b33c12d26c419e49f0e45e12ea52974720c69f2178"
+  },
+  {
+    "seq": 82,
+    "timestamp": "2026-05-02T12:44:58-07:00",
+    "commit_hash": "602d9f942ef11936fcbff10a8bc262e3afd71f1f",
+    "commit_short": "602d9f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 83,
+    "timestamp": "2026-05-02T12:44:43-07:00",
+    "commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572",
+    "commit_short": "4495e0c",
+    "code_fingerprint": "cae85d27080805ae33ec0b37d8e15521db3d3cdf13228749aae57839bba63e96",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +4/-26. folder.html @@ -115,11 +115,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - /* Intelligence loading */ || folder.html @@ -338,8 +333,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div class=\"enroll-txt\" id=\"enroll-txt\">Select a folder to view indexing status.</div> | - <div class=\"enroll-txt\" id=\"enroll-txt\">Fetching folder list…</div> || folder.html @@ -365,15 +360,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - <!-- Inline loading progress -->",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "4495e0c7e62d4542847618ca264e396097ba5572:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -115,11 +115,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "/* Intelligence loading */"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -338,8 +333,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"enroll-txt\" id=\"enroll-txt\">Select a folder to view indexing status.</div>",
+        "remove": "<div class=\"enroll-txt\" id=\"enroll-txt\">Fetching folder list…</div>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -365,15 +360,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<!-- Inline loading progress -->"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1235,23 +1221,15 @@ const App={",
+        "add": "}catch(e){toast('Load failed: '+e.message,'t-err');}",
+        "remove": "this.showLoading(true,'Fetching folder list…','');"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1275,7 +1253,7 @@ const App={",
+        "add": "const sub=$id('enroll-sub');if(sub)sub.textContent='Index it once to enable search, filtering, and curation.';",
+        "remove": "const sub=$id('enroll-sub');if(sub)sub.textContent='Index to enable search and filters.';"
+      }
+    ],
+    "patch_hash": "cae85d27080805ae33ec0b37d8e15521db3d3cdf13228749aae57839bba63e96"
+  },
+  {
+    "seq": 84,
+    "timestamp": "2026-05-02T00:10:47-07:00",
+    "commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404",
+    "commit_short": "de27f93",
+    "code_fingerprint": "40bb83a982f2a7c1cd57aa6bddadc4904198f1e5cb508a19c9ab8f44d565b890",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +345/-250. getit.html @@ -1,273 +1,368 @@ | + <meta charset=\"UTF-8\"> | - <meta charset=\"UTF-8\">",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "de27f935331846f56c5e0c1a1291bd236e44a404:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d",
+    "diff_evidence": [
+      {
+        "file": "getit.html",
+        "hunk": "@@ -1,273 +1,368 @@",
+        "add": "<meta charset=\"UTF-8\">",
+        "remove": "<meta charset=\"UTF-8\">"
+      }
+    ],
+    "patch_hash": "40bb83a982f2a7c1cd57aa6bddadc4904198f1e5cb508a19c9ab8f44d565b890"
+  },
+  {
+    "seq": 85,
+    "timestamp": "2026-05-01T23:49:39-07:00",
+    "commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d",
+    "commit_short": "fdb1c11",
+    "code_fingerprint": "25dda0eabe82792ced706a675b517b2bdf01bfbcbd15138dd5dc64ee98815548",
+    "primary_filename": "getit.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "getit.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +245/-500. getit.html @@ -1,528 +1,273 @@ | + <meta charset=\"UTF-8\"> | - <meta charset=\"UTF-8\">",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "fdb1c11f37574daa2b6c7427215a746eca88949d:getit.html"
+    ],
+    "launch_ref": "getit.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e6a5078b18106cc92e131b41e305c8d61bc5e150",
+    "diff_evidence": [
+      {
+        "file": "getit.html",
+        "hunk": "@@ -1,528 +1,273 @@",
+        "add": "<meta charset=\"UTF-8\">",
+        "remove": "<meta charset=\"UTF-8\">"
+      }
+    ],
+    "patch_hash": "25dda0eabe82792ced706a675b517b2bdf01bfbcbd15138dd5dc64ee98815548"
+  },
+  {
+    "seq": 86,
+    "timestamp": "2026-05-01T23:15:47-07:00",
+    "commit_hash": "e6a5078b18106cc92e131b41e305c8d61bc5e150",
+    "commit_short": "e6a5078",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2c54df1402f657652073de165d75e94185d0291c",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 87,
+    "timestamp": "2026-05-01T23:15:36-07:00",
+    "commit_hash": "2c54df1402f657652073de165d75e94185d0291c",
+    "commit_short": "2c54df1",
+    "code_fingerprint": "e916fec539cf0083ec8fb03adce6e37fb2e3339dbbea1b795c683bc5533cfaf9",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 6 hunk(s), +11/-13. folder.html @@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .lp-acq-wrap:not(.open) #rp-acq,.lp-acq-wrap:not(.open) #rp-enroll{display:none} | - .lp-acq-wrap:not(.open) #rp-acq{display:none} || folder.html @@ -109,7 +109,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #rp-enroll{flex-shrink:0;background:var(--blu-d);border:1px solid rgba(59,130,246,.2);border-radius:var(--rs);padding:10px;display:flex;align-items:center;gap:10px;margin-top:8px} | - #rp-enroll{flex-shrink:0;background:var(--blu-d);border-bottom:1px solid rgba(59,130,246,.2);padding:12px 16px;display:flex;align-items:center;gap:12px} || folder.html @@ -121,7 +121,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #rp-search{position:sticky;top:0;z-index:12;flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px} | - #rp-search{flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "2c54df1402f657652073de165d75e94185d0291c:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: normalization, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".lp-acq-wrap:not(.open) #rp-acq,.lp-acq-wrap:not(.open) #rp-enroll{display:none}",
+        "remove": ".lp-acq-wrap:not(.open) #rp-acq{display:none}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -109,7 +109,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#rp-enroll{flex-shrink:0;background:var(--blu-d);border:1px solid rgba(59,130,246,.2);border-radius:var(--rs);padding:10px;display:flex;align-items:center;gap:10px;margin-top:8px}",
+        "remove": "#rp-enroll{flex-shrink:0;background:var(--blu-d);border-bottom:1px solid rgba(59,130,246,.2);padding:12px 16px;display:flex;align-items:center;gap:12px}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -121,7 +121,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#rp-search{position:sticky;top:0;z-index:12;flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}",
+        "remove": "#rp-search{flex-shrink:0;padding:8px 12px;background:var(--surface);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -336,6 +336,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"rp-enroll\" class=\"hidden\">",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -367,15 +374,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<!-- Enrollment banner -->"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1417,7 +1415,7 @@ function initEvents(){",
+        "add": "div.addEventListener('pointermove',e=>{if(!dragging)return;const minW=80,maxW=Math.max(minW,window.innerWidth-120);const nw=Math.max(minW,Math.min(maxW,sw+(e.clientX-sx)));document.documentElement.style.setProperty('--lpw',nw+'px');});",
+        "remove": "div.addEventListener('pointermove',e=>{if(!dragging)return;const nw=Math.max(160,Math.min(480,sw+(e.clientX-sx)));document.documentElement.style.setProperty('--lpw',nw+'px');});"
+      }
+    ],
+    "patch_hash": "e916fec539cf0083ec8fb03adce6e37fb2e3339dbbea1b795c683bc5533cfaf9"
+  },
+  {
+    "seq": 88,
+    "timestamp": "2026-05-01T22:47:50-07:00",
+    "commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e",
+    "commit_short": "921ae43",
+    "code_fingerprint": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 9 hunk(s), +18/-46. folder.html @@ -238,7 +238,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .portlet{position:relative;background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s} | - .portlet{background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s} || folder.html @@ -371,7 +371,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div class=\"enroll-sub\" id=\"enroll-sub\">Index to enable search and filters.</div> | - <div class=\"enroll-sub\" id=\"enroll-sub\">Index it once to enable search, filtering, and curation.</div> || folder.html @@ -405,22 +405,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <button class=\"vtab\" data-view=\"portal\">Tile</button> | - <button class=\"vtab\" data-view=\"portal\">Portal</button>",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "921ae437c597745ecc3e4ae697c897dd7b133c2e:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -238,7 +238,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".portlet{position:relative;background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}",
+        "remove": ".portlet{background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -371,7 +371,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index to enable search and filters.</div>",
+        "remove": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index it once to enable search, filtering, and curation.</div>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -405,22 +405,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<button class=\"vtab\" data-view=\"portal\">Tile</button>",
+        "remove": "<button class=\"vtab\" data-view=\"portal\">Portal</button>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -964,7 +956,7 @@ const RightPane={",
+        "add": "const sortDirBtn=$id('sort-dir-btn');if(sortDirBtn)sortDirBtn.textContent=st.ui.sortDir==='asc'?'↑':'↓';",
+        "remove": "$id('sort-dir-btn').textContent=st.ui.sortDir==='asc'?'↑':'↓';"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1094,15 +1086,22 @@ const ListView={",
+        "add": "[['',''],['name','#'],['name','Name'],['class','Type'],['effectiveDate','Date'],['size','Size'],['stack','Stack']].forEach(([col,label])=>{",
+        "remove": "[['',''],['name','#'],['name','Name'],['size','Size'],['effectiveDate','Date'],['stack','Stack']].forEach(([col,label])=>{"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1130,16 +1129,6 @@ const ListView={",
+        "add": "",
+        "remove": "// Actions"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1175,6 +1164,7 @@ const PortalView={",
+        "add": "const cardCb=document.createElement('input');cardCb.type='checkbox';cardCb.style.position='absolute';cardCb.style.top='8px';cardCb.style.left='8px';cardCb.style.zIndex='2';cardCb.style.accentColor='var(--acc)';cardCb.checked=st.ui.selectedIds.has(file.id);cardCb.addEventListener('click',e=>e.stopPropagation());cardCb.addEventListener('change',()=>{if(cardCb.checked)st.ui.selectedIds.add(file.id);else st.ui.selectedIds.delete(file.id);RightPane.updateSelectedCount(RightPane.getFilteredFiles().length);});",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1194,13 +1184,7 @@ const PortalView={",
+        "add": "card.appendChild(cardCb);card.appendChild(bar);card.appendChild(contentEl);",
+        "remove": "// Footer"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1470,18 +1454,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "// Sort"
+      }
+    ],
+    "patch_hash": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962"
+  },
+  {
+    "seq": 89,
+    "timestamp": "2026-05-01T22:47:35-07:00",
+    "commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d",
+    "commit_short": "8df99b4",
+    "code_fingerprint": "1e34bb0a21e864dca0e60e349bc5d1fd706d33ab1ef482038923165654bceb3b",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 12 hunk(s), +83/-21. bridge8-patched.html @@ -428,6 +428,7 @@ var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_c | + var phrasebookOpen=false; | - no removed line sample || bridge8-patched.html @@ -556,7 +557,8 @@ function chatInputEvt(){ | + else if(raw.charAt(0)==='/'&&raw.indexOf('//')!==0&&norm(raw.slice(1)))runPhraseSearch(raw.slice(1)); | - if(raw.charAt(0)==='/'&&raw.indexOf('//')!==0&&norm(raw.slice(1)))runPhraseSearch(raw.slice(1));else closePhraseDrawer(); || bridge8-patched.html @@ -662,12 +664,44 @@ function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data= | + function commandChip(cmd,label){return '<button data-cmd=\"'+esc(cmd)+'\" style=\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\">'+esc(label||cmd)+'</button>'} | - function openCommandDrawer(raw){var box=$('phrase-results');if(!box)return;var q=(raw||'').trim();if($('drawer-title'))$('drawer-title').textContent=q.indexOf('/ open')===0?'Omni Search':'Command Drawer';var cmds=['//open','//list','//help?'];var html='<div style=\"display:flex;flex-wrap:wrap;gap:8px;padding:8px 0 10px;\">'+cmds.map(function(c){return '<button data-cmd=\\\"'+esc(c)+'\\\" style=\\\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\\\">'+esc(c)+'</button>'}).join('')+'</div>';if(q==='help?')html+='<div class=\"tr-empty\">Commands: //open, //list, //help?</div>';if(q.indexOf('/ open')===0)html+='<div class=\"tr-empty\">Omni search active. Continue typing /...</div>';box.innerHTML=html;box.querySelectorAll('[data-cmd]').forEach(function(btn){btn.onclick=function(){var cmd=btn.getAttribute('data-cmd')||'';var input=$('chat-input');if(!input)return;input.value=cmd;chatInputEvt();sendChat();};});$('phrase-drawer').classList.add('open')}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:bridge8-patched.html",
+      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:folder.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "343fdb2d97b5fc6831726d9120aa7589007784d7",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -428,6 +428,7 @@ var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_c",
+        "add": "var phrasebookOpen=false;",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -556,7 +557,8 @@ function chatInputEvt(){",
+        "add": "else if(raw.charAt(0)==='/'&&raw.indexOf('//')!==0&&norm(raw.slice(1)))runPhraseSearch(raw.slice(1));",
+        "remove": "if(raw.charAt(0)==='/'&&raw.indexOf('//')!==0&&norm(raw.slice(1)))runPhraseSearch(raw.slice(1));else closePhraseDrawer();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -662,12 +664,44 @@ function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data=",
+        "add": "function commandChip(cmd,label){return '<button data-cmd=\"'+esc(cmd)+'\" style=\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\">'+esc(label||cmd)+'</button>'}",
+        "remove": "function openCommandDrawer(raw){var box=$('phrase-results');if(!box)return;var q=(raw||'').trim();if($('drawer-title'))$('drawer-title').textContent=q.indexOf('/ open')===0?'Omni Search':'Command Drawer';var cmds=['//open','//list','//help?'];var html='<div style=\"display:flex;flex-wrap:wrap;gap:8px;padding:8px 0 10px;\">'+cmds.map(function(c){return '<button data-cmd=\\\"'+esc(c)+'\\\" style=\\\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\\\">'+esc(c)+'</button>'}).join('')+'</div>';if(q==='help?')html+='<div class=\"tr-empty\">Commands: //open, //list, //help?</div>';if(q.indexOf('/ open')===0)html+='<div class=\"tr-empty\">Omni search active. Continue typing /...</div>';box.innerHTML=html;box.querySelectorAll('[data-cmd]').forEach(function(btn){btn.onclick=function(){var cmd=btn.getAttribute('data-cmd')||'';var input=$('chat-input');if(!input)return;input.value=cmd;chatInputEvt();sendChat();};});$('phrase-drawer').classList.add('open')}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -238,7 +238,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".portlet{background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}",
+        "remove": ".portlet{position:relative;background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -371,7 +371,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index it once to enable search, filtering, and curation.</div>",
+        "remove": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index to enable search and filters.</div>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -405,14 +405,22 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<button class=\"vtab\" data-view=\"portal\">Portal</button>",
+        "remove": "<button class=\"vtab\" data-view=\"portal\">Tile</button>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -956,7 +964,7 @@ const RightPane={",
+        "add": "$id('sort-dir-btn').textContent=st.ui.sortDir==='asc'?'↑':'↓';",
+        "remove": "const sortDirBtn=$id('sort-dir-btn');if(sortDirBtn)sortDirBtn.textContent=st.ui.sortDir==='asc'?'↑':'↓';"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1086,22 +1094,15 @@ const ListView={",
+        "add": "[['',''],['name','#'],['name','Name'],['size','Size'],['effectiveDate','Date'],['stack','Stack']].forEach(([col,label])=>{",
+        "remove": "[['',''],['name','#'],['name','Name'],['class','Type'],['effectiveDate','Date'],['size','Size'],['stack','Stack']].forEach(([col,label])=>{"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1129,6 +1130,16 @@ const ListView={",
+        "add": "// Actions",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1164,7 +1175,6 @@ const PortalView={",
+        "add": "",
+        "remove": "const cardCb=document.createElement('input');cardCb.type='checkbox';cardCb.style.position='absolute';cardCb.style.top='8px';cardCb.style.left='8px';cardCb.style.zIndex='2';cardCb.style.accentColor='var(--acc)';cardCb.checked=st.ui.selectedIds.has(file.id);cardCb.addEventListener('click',e=>e.stopPropagation());cardCb.addEventListener('change',()=>{if(cardCb.checked)st.ui.selectedIds.add(file.id);else st.ui.selectedIds.delete(file.id);RightPane.updateSelectedCount(RightPane.getFilteredFiles().length);});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1184,7 +1194,13 @@ const PortalView={",
+        "add": "// Footer",
+        "remove": "card.appendChild(cardCb);card.appendChild(bar);card.appendChild(contentEl);"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1454,6 +1470,18 @@ function initEvents(){",
+        "add": "// Sort",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "1e34bb0a21e864dca0e60e349bc5d1fd706d33ab1ef482038923165654bceb3b"
+  },
+  {
+    "seq": 90,
+    "timestamp": "2026-05-01T22:41:26-07:00",
+    "commit_hash": "343fdb2d97b5fc6831726d9120aa7589007784d7",
+    "commit_short": "343fdb2",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 91,
+    "timestamp": "2026-05-01T22:40:42-07:00",
+    "commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886",
+    "commit_short": "efcf3c8",
+    "code_fingerprint": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 9 hunk(s), +18/-46. folder.html @@ -238,7 +238,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .portlet{position:relative;background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s} | - .portlet{background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s} || folder.html @@ -371,7 +371,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <div class=\"enroll-sub\" id=\"enroll-sub\">Index to enable search and filters.</div> | - <div class=\"enroll-sub\" id=\"enroll-sub\">Index it once to enable search, filtering, and curation.</div> || folder.html @@ -405,22 +405,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + <button class=\"vtab\" data-view=\"portal\">Tile</button> | - <button class=\"vtab\" data-view=\"portal\">Portal</button>",
+    "functional_impacts": [
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "bcf34643e9413fc5ccaf7e7cae5debf4a2718a5a",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -238,7 +238,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".portlet{position:relative;background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}",
+        "remove": ".portlet{background:var(--surface);border:1px solid var(--bmd);border-radius:var(--r);overflow:hidden;display:flex;flex-direction:column;transition:box-shadow .15s}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -371,7 +371,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index to enable search and filters.</div>",
+        "remove": "<div class=\"enroll-sub\" id=\"enroll-sub\">Index it once to enable search, filtering, and curation.</div>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -405,22 +405,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<button class=\"vtab\" data-view=\"portal\">Tile</button>",
+        "remove": "<button class=\"vtab\" data-view=\"portal\">Portal</button>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -964,7 +956,7 @@ const RightPane={",
+        "add": "const sortDirBtn=$id('sort-dir-btn');if(sortDirBtn)sortDirBtn.textContent=st.ui.sortDir==='asc'?'↑':'↓';",
+        "remove": "$id('sort-dir-btn').textContent=st.ui.sortDir==='asc'?'↑':'↓';"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1094,15 +1086,22 @@ const ListView={",
+        "add": "[['',''],['name','#'],['name','Name'],['class','Type'],['effectiveDate','Date'],['size','Size'],['stack','Stack']].forEach(([col,label])=>{",
+        "remove": "[['',''],['name','#'],['name','Name'],['size','Size'],['effectiveDate','Date'],['stack','Stack']].forEach(([col,label])=>{"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1130,16 +1129,6 @@ const ListView={",
+        "add": "",
+        "remove": "// Actions"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1175,6 +1164,7 @@ const PortalView={",
+        "add": "const cardCb=document.createElement('input');cardCb.type='checkbox';cardCb.style.position='absolute';cardCb.style.top='8px';cardCb.style.left='8px';cardCb.style.zIndex='2';cardCb.style.accentColor='var(--acc)';cardCb.checked=st.ui.selectedIds.has(file.id);cardCb.addEventListener('click',e=>e.stopPropagation());cardCb.addEventListener('change',()=>{if(cardCb.checked)st.ui.selectedIds.add(file.id);else st.ui.selectedIds.delete(file.id);RightPane.updateSelectedCount(RightPane.getFilteredFiles().length);});",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1194,13 +1184,7 @@ const PortalView={",
+        "add": "card.appendChild(cardCb);card.appendChild(bar);card.appendChild(contentEl);",
+        "remove": "// Footer"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1470,18 +1454,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "// Sort"
+      }
+    ],
+    "patch_hash": "0df882964dfb1959151045385e4dadcfad2fc8d71e57770e91ffe3ba36a98962"
+  },
+  {
+    "seq": 92,
+    "timestamp": "2026-05-01T19:23:44-07:00",
+    "commit_hash": "bcf34643e9413fc5ccaf7e7cae5debf4a2718a5a",
+    "commit_short": "bcf3464",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 93,
+    "timestamp": "2026-05-01T19:23:30-07:00",
+    "commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5",
+    "commit_short": "b453763",
+    "code_fingerprint": "14a2df72aa2e8a5670f355dee74579274156d687e4c8874401da80b6ec2f69a3",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 11 hunk(s), +31/-60. folder.html @@ -111,7 +111,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #btn-index-now{white-space:nowrap;word-break:keep-all} | - #btn-index-now{white-space:nowrap} || folder.html @@ -158,7 +158,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #rp-toolbar{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:5px 10px;background:var(--surface);border-bottom:1px solid var(--border);flex-wrap:wrap} | - #rp-toolbar{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:5px 10px;background:var(--surface);border-bottom:1px solid var(--border)} || folder.html @@ -512,6 +512,7 @@ const st={ | + selectedIds:new Set(), | - no removed line sample",
+    "functional_impacts": [
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b453763041c6ec72f7dc19520862e29470d5a5e5:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2cb633012cb1eb5c0b1540bb6fce57ceaf6d7e4e",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -111,7 +111,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#btn-index-now{white-space:nowrap;word-break:keep-all}",
+        "remove": "#btn-index-now{white-space:nowrap}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -158,7 +158,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#rp-toolbar{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:5px 10px;background:var(--surface);border-bottom:1px solid var(--border);flex-wrap:wrap}",
+        "remove": "#rp-toolbar{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:5px 10px;background:var(--surface);border-bottom:1px solid var(--border)}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -512,6 +512,7 @@ const st={",
+        "add": "selectedIds:new Set(),",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -533,8 +534,8 @@ function toast(msg,type,dur=3000){",
+        "add": "function fmtSize(b){if(!b)return'—';if(b<1024)return b+' B';if(b<1048576)return(b/1024).toFixed(1)+' KB';if(b<1073741824){const mb=b/1048576;return mb<1?'<1 MB':mb.toFixed(1)+' MB';}return(b/1073741824).toFixed(2)+' GB';}",
+        "remove": "function fmtSize(b){if(!b)return'—';if(b<1024)return b+' B';if(b<1048576)return(b/1024).toFixed(1)+' KB';if(b<1073741824)return(b/1048576).toFixed(1)+' MB';return(b/1073741824).toFixed(2)+' GB';}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1065,11 +1066,15 @@ const RightPane={",
+        "add": "this.updateSelectedCount(files.length);",
+        "remove": "const lbl=$id('file-lbl-count');if(lbl)lbl.textContent=`${files.length} file${files.length!==1?'s':''}`;"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1089,7 +1094,7 @@ const ListView={",
+        "add": "[['',''],['name','#'],['name','Name'],['size','Size'],['effectiveDate','Date'],['stack','Stack']].forEach(([col,label])=>{",
+        "remove": "[['','checkbox'],['name','Name'],['class','Type'],['size','Size'],['effectiveDate','Date'],['stack','Stack'],['','Actions']].forEach(([col,label])=>{"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1097,17 +1102,18 @@ const ListView={",
+        "add": "if(!files.length){const tr=document.createElement('tr');const td=document.createElement('td');td.colSpan=6;td.style.textAlign='center';td.style.color='var(--tm)';td.style.padding='32px';td.textContent='No files match current filters.';tr.appendChild(td);tbody.appendChild(tr);}",
+        "remove": "if(!files.length){const tr=document.createElement('tr');const td=document.createElement('td');td.colSpan=7;td.style.textAlign='center';td.style.color='var(--tm)';td.style.padding='32px';td.textContent='No files match current filters.';tr.appendChild(td);tbody.appendChild(tr);}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1128,60 +1134,25 @@ const ListView={",
+        "add": "btnExp.addEventListener('click',e=>{e.stopPropagation();this.openModal(file);});",
+        "remove": "btnExp.addEventListener('click',e=>{e.stopPropagation();this.toggleExpand(file);});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1314,7 +1285,7 @@ const App={",
+        "add": "st.ui.expandedItemId=null;st.ui.fabItemId=null;st.ui.portalPage=1;st.ui.selectedIds=new Set();",
+        "remove": "st.ui.expandedItemId=null;st.ui.fabItemId=null;st.ui.portalPage=1;"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1322,7 +1293,7 @@ const App={",
+        "add": "const sub=$id('enroll-sub');if(sub)sub.textContent='Index to enable search and filters.';",
+        "remove": "const sub=$id('enroll-sub');if(sub)sub.textContent='Index it once to enable search, filtering, and curation.';"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1354,14 +1325,14 @@ const App={",
+        "add": "const mini=$id('acq-mini');if(mini)mini.textContent='Complete';",
+        "remove": "const mini=$id('acq-mini');if(mini)mini.textContent='Idle';"
+      }
+    ],
+    "patch_hash": "14a2df72aa2e8a5670f355dee74579274156d687e4c8874401da80b6ec2f69a3"
+  },
+  {
+    "seq": 94,
+    "timestamp": "2026-05-01T18:37:00-07:00",
+    "commit_hash": "2cb633012cb1eb5c0b1540bb6fce57ceaf6d7e4e",
+    "commit_short": "2cb6330",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 95,
+    "timestamp": "2026-05-01T18:36:44-07:00",
+    "commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703",
+    "commit_short": "a3e213d",
+    "code_fingerprint": "651aaf0548d7d49d0bafad77c1396096bbe087d2195019aef407ae0471c4c0fd",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +8/-5. bridge8-patched.html @@ -350,13 +350,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat or enter // for menu\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea> | - <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"help? for commands or type to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea> || bridge8-patched.html @@ -555,6 +555,7 @@ function _detectLangAsync(text){ | + if(v==='/'||v==='//'||v==='help?'||v.indexOf('/ open')===0){openCommandDrawer(v);} | - no removed line sample || bridge8-patched.html @@ -661,11 +662,12 @@ function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data= | + function openCommandDrawer(raw){var box=$('phrase-results');if(!box)return;var q=(raw||'').trim();if($('drawer-title'))$('drawer-title').textContent=q.indexOf('/ open')===0?'Omni Search':'Command Drawer';var cmds=['//open','//list','//help?'];var html='<div style=\"display:flex;flex-wrap:wrap;gap:8px;padding:8px 0 10px;\">'+cmds.map(function(c){return '<button data-cmd=\\\"'+esc(c)+'\\\" style=\\\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\\\">'+esc(c)+'</button>'}).join('')+'</div>';if(q==='help?')html+='<div class=\"tr-empty\">Commands: //open, //list, //help?</div>';if(q.indexOf('/ open')===0)html+='<div class=\"tr-empty\">Omni search active. Continue typing /...</div>';box.innerHTML=html;box.querySelectorAll('[data-cmd]').forEach(function(btn){btn.onclick=function(){var cmd=btn.getAttribute('data-cmd')||'';var input=$('chat-input');if(!input)return;input.value=cmd;chatInputEvt();sendChat();};});$('phrase-drawer').classList.add('open')} | - function runPhraseCommand(cmd){var op=(cmd.split(' ')[0]||'').toLowerCase(),payload=cmd.slice(op.length).trim(),m,p,id;if(op==='help?'){toast('Commands: //add //change //delete //tag //clarify //verdict //list //import //export //save //open | help?')}else if(op==='save'){var seen={};phrasebook=phrasebook.map(normalizePbCard).filter(function(c){var k=[c.source,c.sourceLang,c.target,c.targetLang].join('|').toLowerCase();if(seen[k])return false;seen[k]=1;return true;});savePhrasebook();toast('Phrasebook saved')}else if(op==='open'){window.open('test.html','_blank');}else if(op==='add'){m=payload.split('=>');if(m[0]&&m[1]){phrasebook.unshift(normalizePbCard({id:uid(),source:norm(m[0]),target:norm(m[1]),tags:[],clarifyChain:[],backtranslate:{verdict:'none'}}));savePhrasebook();toast('Phrase added')}}else if(op==='change'){id=(payload.split(' ')[0]||'').trim();p=phrasebook.find(function(x){return x.id===id});if(p){payload.replace(/(source|target|tags|clarify|verdict):([^]+?)(?=\\s+\\w+:|$)/g,function(_,k,v){v=norm(v);if(k==='tags')p.tags=v?v.split(',').map(norm).filter(Boolean):[];else if(k==='clarify')p.clarifyChain=v?[{by:'cmd',text:v,at:Date.now()}]:[];else if(k==='verdict'){p.backtranslate=p.backtranslate||{};p.backtranslate.verdict=v||'none';}else p[k]=v});p.updatedAt=Date.now();savePhrasebook();toast('Phrase changed')}}else if(op==='delete'){phrasebook=phrasebook.filter(function(x){return x.id!==payload});savePhrasebook();toast('Phrase deleted')}else if(op==='tag'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m[0]});if(p&&m[1]){p.tags=p.tags||[];if(p.tags.indexOf(m[1])<0)p.tags.push(m[1]);p.updatedAt=Date.now();savePhrasebook();toast('Tag added')}}else if(op==='clarify'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m.shift()});if(p){p.clarifyChain=p.clarifyChain||[];p.clarifyChain.push({by:'cmd',text:norm(m.join(' ')),at:Date.now()});p.updatedAt=Date.now();savePhrasebook();toast('Clarify added')}}else if(op==='verdict'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m[0]});if(p){p.backtranslate=p.backtranslate||{};p.backtranslate.verdict=norm(m[1]||'none');p.updatedAt=Date.now();savePhrasebook();toast('Verdict updated')}}else if(op==='import'){$('phrase-import-file').click()}else if(op==='export'){var a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(phrasebook,null,2)],{type:'application/json'}));a.download='standard-phrasebook.json';a.click()}else if(op==='list'){toast('Phrase count: '+phrasebook.length)}}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a3e213d2f427f2275569c7ba94c9aea0f7f12703:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a04804657c51e98899bb7879ed97b0bab625d7c6",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -350,13 +350,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat or enter // for menu\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>",
+        "remove": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"help? for commands or type to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -555,6 +555,7 @@ function _detectLangAsync(text){",
+        "add": "if(v==='/'||v==='//'||v==='help?'||v.indexOf('/ open')===0){openCommandDrawer(v);}",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -661,11 +662,12 @@ function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data=",
+        "add": "function openCommandDrawer(raw){var box=$('phrase-results');if(!box)return;var q=(raw||'').trim();if($('drawer-title'))$('drawer-title').textContent=q.indexOf('/ open')===0?'Omni Search':'Command Drawer';var cmds=['//open','//list','//help?'];var html='<div style=\"display:flex;flex-wrap:wrap;gap:8px;padding:8px 0 10px;\">'+cmds.map(function(c){return '<button data-cmd=\\\"'+esc(c)+'\\\" style=\\\"border:1px solid rgba(255,255,255,.25);background:rgba(255,255,255,.06);color:var(--text);padding:5px 10px;border-radius:999px;\\\">'+esc(c)+'</button>'}).join('')+'</div>';if(q==='help?')html+='<div class=\"tr-empty\">Commands: //open, //list, //help?</div>';if(q.indexOf('/ open')===0)html+='<div class=\"tr-empty\">Omni search active. Continue typing /...</div>';box.innerHTML=html;box.querySelectorAll('[data-cmd]').forEach(function(btn){btn.onclick=function(){var cmd=btn.getAttribute('data-cmd')||'';var input=$('chat-input');if(!input)return;input.value=cmd;chatInputEvt();sendChat();};});$('phrase-drawer').classList.add('open')}",
+        "remove": "function runPhraseCommand(cmd){var op=(cmd.split(' ')[0]||'').toLowerCase(),payload=cmd.slice(op.length).trim(),m,p,id;if(op==='help?'){toast('Commands: //add //change //delete //tag //clarify //verdict //list //import //export //save //open | help?')}else if(op==='save'){var seen={};phrasebook=phrasebook.map(normalizePbCard).filter(function(c){var k=[c.source,c.sourceLang,c.target,c.targetLang].join('|').toLowerCase();if(seen[k])return false;seen[k]=1;return true;});savePhrasebook();toast('Phrasebook saved')}else if(op==='open'){window.open('test.html','_blank');}else if(op==='add'){m=payload.split('=>');if(m[0]&&m[1]){phrasebook.unshift(normalizePbCard({id:uid(),source:norm(m[0]),target:norm(m[1]),tags:[],clarifyChain:[],backtranslate:{verdict:'none'}}));savePhrasebook();toast('Phrase added')}}else if(op==='change'){id=(payload.split(' ')[0]||'').trim();p=phrasebook.find(function(x){return x.id===id});if(p){payload.replace(/(source|target|tags|clarify|verdict):([^]+?)(?=\\s+\\w+:|$)/g,function(_,k,v){v=norm(v);if(k==='tags')p.tags=v?v.split(',').map(norm).filter(Boolean):[];else if(k==='clarify')p.clarifyChain=v?[{by:'cmd',text:v,at:Date.now()}]:[];else if(k==='verdict'){p.backtranslate=p.backtranslate||{};p.backtranslate.verdict=v||'none';}else p[k]=v});p.updatedAt=Date.now();savePhrasebook();toast('Phrase changed')}}else if(op==='delete'){phrasebook=phrasebook.filter(function(x){return x.id!==payload});savePhrasebook();toast('Phrase deleted')}else if(op==='tag'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m[0]});if(p&&m[1]){p.tags=p.tags||[];if(p.tags.indexOf(m[1])<0)p.tags.push(m[1]);p.updatedAt=Date.now();savePhrasebook();toast('Tag added')}}else if(op==='clarify'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m.shift()});if(p){p.clarifyChain=p.clarifyChain||[];p.clarifyChain.push({by:'cmd',text:norm(m.join(' ')),at:Date.now()});p.updatedAt=Date.now();savePhrasebook();toast('Clarify added')}}else if(op==='verdict'){m=payload.split(' ');p=phrasebook.find(function(x){return x.id===m[0]});if(p){p.backtranslate=p.backtranslate||{};p.backtranslate.verdict=norm(m[1]||'none');p.updatedAt=Date.now();savePhrasebook();toast('Verdict updated')}}else if(op==='import'){$('phrase-import-file').click()}else if(op==='export'){var a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(phrasebook,null,2)],{type:'application/json'}));a.download='standard-phrasebook.json';a.click()}else if(op==='list'){toast('Phrase count: '+phrasebook.length)}}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1018,7 +1020,7 @@ async function enterCall(){",
+        "add": "var ci=$('chat-input');if(ci)ci.placeholder='type here to chat or enter // for menu';",
+        "remove": "var ci=$('chat-input');if(ci)ci.placeholder='help? for commands or type to chat';"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1349,8 +1351,9 @@ function showSub(text,cls){",
+        "add": "if(ss){for(var j=transcript.length-1;j>=0;j--){if(transcript[j].who===who&&transcript[j].subtitleSeq===ss){transcript[j].sourceText=src;transcript[j].translatedText=tr;transcript[j].ts=Date.now();saveTr();renderTr();return;}}}",
+        "remove": "if(prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;"
+      }
+    ],
+    "patch_hash": "651aaf0548d7d49d0bafad77c1396096bbe087d2195019aef407ae0471c4c0fd"
+  },
+  {
+    "seq": 96,
+    "timestamp": "2026-05-01T17:24:35-07:00",
+    "commit_hash": "a04804657c51e98899bb7879ed97b0bab625d7c6",
+    "commit_short": "a048046",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 97,
+    "timestamp": "2026-05-01T17:24:22-07:00",
+    "commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95",
+    "commit_short": "d36c711",
+    "code_fingerprint": "0f1847158621c0e146ac985bc6ce98fb76cdd02c461cbb113baab35d10446280",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 11 hunk(s), +43/-31. folder.html @@ -93,8 +93,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + /* Index drawer (left panel) */ | - /* Inline acquisition */ || folder.html @@ -107,6 +111,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #btn-index-now{white-space:nowrap} | - no removed line sample || folder.html @@ -319,10 +324,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + no added line sample | - <div class=\"h-acts\">",
+    "functional_impacts": [
+      "normalization",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "d36c711b38df63cf4750882c9a197d7928569a95:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: normalization, call termination behavior, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "9adca585152a92e48b14a887efacd989810e423d",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -93,8 +93,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "/* Index drawer (left panel) */",
+        "remove": "/* Inline acquisition */"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -107,6 +111,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#btn-index-now{white-space:nowrap}",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -319,10 +324,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<div class=\"h-acts\">"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -333,6 +334,23 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"lp-acq-wrap\" id=\"lp-acq-wrap\">",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -349,22 +367,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<!-- Inline acquisition progress -->"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -372,7 +374,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<button class=\"btn btn-ghost btn-sm\" id=\"btn-index-skip\">Skip</button>"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1285,10 +1286,12 @@ const App={",
+        "add": "$id('lp-acq-wrap')?.classList.remove('open');",
+        "remove": "Intel.load().then(()=>{Tree.render();}).catch(()=>{});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1335,12 +1338,14 @@ const App={",
+        "add": "$id('lp-acq-wrap')?.classList.add('open');",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1349,12 +1354,14 @@ const App={",
+        "add": "const mini=$id('acq-mini');if(mini)mini.textContent='Idle';",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1458,10 +1465,6 @@ function initEvents(){",
+        "add": "",
+        "remove": "// Header actions"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1472,9 +1475,18 @@ function initEvents(){",
+        "add": "$id('btn-index-now').addEventListener('click',()=>{",
+        "remove": "$id('btn-index-now').addEventListener('click',()=>{if(st.selFolderId){const folder=st.levelOneFolders.find(f=>f.id===st.selFolderId)||(st.intel?.folders?.[st.selFolderId]||{name:st.selFolderId});App.startIndexing(st.selFolderId,folder.name||st.selFolderId);}});"
+      }
+    ],
+    "patch_hash": "0f1847158621c0e146ac985bc6ce98fb76cdd02c461cbb113baab35d10446280"
+  },
+  {
+    "seq": 98,
+    "timestamp": "2026-05-01T11:27:08-07:00",
+    "commit_hash": "9adca585152a92e48b14a887efacd989810e423d",
+    "commit_short": "9adca58",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 99,
+    "timestamp": "2026-05-01T11:26:39-07:00",
+    "commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2",
+    "commit_short": "af1e316",
+    "code_fingerprint": "c631145b59d616d990ae151581b6257e387b82e3bc1814fce766878438fe967e",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 3 hunk(s), +14/-9. bridge8-patched.html @@ -554,8 +554,8 @@ function _detectLangAsync(text){ | + var raw=ta.value||'',v=raw.trim(); | - var v=(ta.value||'').trim(); || bridge8-patched.html @@ -653,14 +653,19 @@ function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');c | + function normalizePbCard(x){ | - function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data=raw?JSON.parse(raw):null;phrasebook=Array.isArray(data)?data:DEFAULT_PHRASEBOOK.slice()}catch(_){phrasebook=DEFAULT_PHRASEBOOK.slice()}savePhrasebook()} || bridge8-patched.html @@ -1013,7 +1018,7 @@ async function enterCall(){ | + var ci=$('chat-input');if(ci)ci.placeholder='help? for commands or type to chat'; | - var ci=$('chat-input');if(ci)ci.placeholder=L('type_msg');",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "af1e316ba52ea02575df8877ed4c49b1cccbb3e2:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -554,8 +554,8 @@ function _detectLangAsync(text){",
+        "add": "var raw=ta.value||'',v=raw.trim();",
+        "remove": "var v=(ta.value||'').trim();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -653,14 +653,19 @@ function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');c",
+        "add": "function normalizePbCard(x){",
+        "remove": "function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data=raw?JSON.parse(raw):null;phrasebook=Array.isArray(data)?data:DEFAULT_PHRASEBOOK.slice()}catch(_){phrasebook=DEFAULT_PHRASEBOOK.slice()}savePhrasebook()}"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1013,7 +1018,7 @@ async function enterCall(){",
+        "add": "var ci=$('chat-input');if(ci)ci.placeholder='help? for commands or type to chat';",
+        "remove": "var ci=$('chat-input');if(ci)ci.placeholder=L('type_msg');"
+      }
+    ],
+    "patch_hash": "c631145b59d616d990ae151581b6257e387b82e3bc1814fce766878438fe967e"
+  },
+  {
+    "seq": 100,
+    "timestamp": "2026-05-01T01:28:59-07:00",
+    "commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6",
+    "commit_short": "c62a620",
+    "code_fingerprint": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +4/-3. folder.html @@ -106,6 +106,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #rp-enroll .btn{flex-shrink:0} | - no removed line sample || folder.html @@ -1279,7 +1280,7 @@ const App={ | + // Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work. | - // Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation. || folder.html @@ -1287,7 +1288,7 @@ const App={ | + Intel.load().then(()=>{Tree.render();}).catch(()=>{}); | - Intel.load().then(rec=>{if(rec&&rec.enrolledRoots.length>0)toast('Intelligence loaded','t-ok');Tree.render();if(st.selFolderId)RightPane.render();}).catch(()=>{});",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "c62a620eb345d738a7c6876a2653d68715735bf6:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -106,6 +106,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#rp-enroll .btn{flex-shrink:0}",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1279,7 +1280,7 @@ const App={",
+        "add": "// Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work.",
+        "remove": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation."
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1287,7 +1288,7 @@ const App={",
+        "add": "Intel.load().then(()=>{Tree.render();}).catch(()=>{});",
+        "remove": "Intel.load().then(rec=>{if(rec&&rec.enrolledRoots.length>0)toast('Intelligence loaded','t-ok');Tree.render();if(st.selFolderId)RightPane.render();}).catch(()=>{});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1523,4 +1524,4 @@ document.addEventListener('DOMContentLoaded',()=>{",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c"
+  },
+  {
+    "seq": 101,
+    "timestamp": "2026-05-01T01:28:17-07:00",
+    "commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8",
+    "commit_short": "babd6c5",
+    "code_fingerprint": "abbe658ae982eec5b287e147fa9f7811f59bb7fbe1addf95dd1b20928ab7f094",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 11 hunk(s), +91/-11. bridge8-patched.html @@ -424,6 +424,8 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null; | + var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_connectTimeoutTimer=null,_seenRemoteCand=new Set(); | - no removed line sample || bridge8-patched.html @@ -485,6 +487,7 @@ function teardownSession(mode,reason){ | + resetRecoveryState(); | - no removed line sample || bridge8-patched.html @@ -988,9 +991,11 @@ function handleRelay(d){ | + resetRecoveryState(); | - no removed line sample",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:bridge8-patched.html",
+      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:folder.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "b0cd4f9c894917c16853b3ff054241dc438c46ef",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -424,6 +424,8 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null;",
+        "add": "var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_connectTimeoutTimer=null,_seenRemoteCand=new Set();",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -485,6 +487,7 @@ function teardownSession(mode,reason){",
+        "add": "resetRecoveryState();",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -988,9 +991,11 @@ function handleRelay(d){",
+        "add": "resetRecoveryState();",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1012,6 +1017,8 @@ async function enterCall(){",
+        "add": "resetRecoveryState();",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1050,6 +1057,65 @@ function resetRemoteMediaState(){",
+        "add": "function resetRecoveryState(){",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1087,19 +1153,30 @@ async function setupPC(){",
+        "add": "clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;",
+        "remove": "setCallPhase('call_live','pc_connected');"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1147,11 +1224,15 @@ async function handleSig(d){",
+        "add": "var c=d.signal.candidate||{};",
+        "remove": "pendingCandidates.push(d.signal.candidate);"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -106,7 +106,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "#rp-enroll .btn{flex-shrink:0}"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1280,7 +1279,7 @@ const App={",
+        "add": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation.",
+        "remove": "// Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work."
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1288,7 +1287,7 @@ const App={",
+        "add": "Intel.load().then(rec=>{if(rec&&rec.enrolledRoots.length>0)toast('Intelligence loaded','t-ok');Tree.render();if(st.selFolderId)RightPane.render();}).catch(()=>{});",
+        "remove": "Intel.load().then(()=>{Tree.render();}).catch(()=>{});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1524,4 +1523,4 @@ document.addEventListener('DOMContentLoaded',()=>{",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "abbe658ae982eec5b287e147fa9f7811f59bb7fbe1addf95dd1b20928ab7f094"
+  },
+  {
+    "seq": 102,
+    "timestamp": "2026-05-01T01:27:12-07:00",
+    "commit_hash": "b0cd4f9c894917c16853b3ff054241dc438c46ef",
+    "commit_short": "b0cd4f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 103,
+    "timestamp": "2026-05-01T01:26:55-07:00",
+    "commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66",
+    "commit_short": "0bbe3bb",
+    "code_fingerprint": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +4/-3. folder.html @@ -106,6 +106,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #rp-enroll .btn{flex-shrink:0} | - no removed line sample || folder.html @@ -1279,7 +1280,7 @@ const App={ | + // Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work. | - // Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation. || folder.html @@ -1287,7 +1288,7 @@ const App={ | + Intel.load().then(()=>{Tree.render();}).catch(()=>{}); | - Intel.load().then(rec=>{if(rec&&rec.enrolledRoots.length>0)toast('Intelligence loaded','t-ok');Tree.render();if(st.selFolderId)RightPane.render();}).catch(()=>{});",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "908c1f9770aa768dd54eb87e4ac26f2a34dbce82",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -106,6 +106,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#rp-enroll .btn{flex-shrink:0}",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1279,7 +1280,7 @@ const App={",
+        "add": "// Startup fast path: render L1 tree first, keep right pane blank, defer intelligence work.",
+        "remove": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation."
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1287,7 +1288,7 @@ const App={",
+        "add": "Intel.load().then(()=>{Tree.render();}).catch(()=>{});",
+        "remove": "Intel.load().then(rec=>{if(rec&&rec.enrolledRoots.length>0)toast('Intelligence loaded','t-ok');Tree.render();if(st.selFolderId)RightPane.render();}).catch(()=>{});"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1523,4 +1524,4 @@ document.addEventListener('DOMContentLoaded',()=>{",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "0229ce9cf76f64601ff84d9aa03a06617c7fb3253b7b13712d6328626d03c40c"
+  },
+  {
+    "seq": 104,
+    "timestamp": "2026-05-01T01:18:52-07:00",
+    "commit_hash": "908c1f9770aa768dd54eb87e4ac26f2a34dbce82",
+    "commit_short": "908c1f9",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "2661a802963c02b840d9be6107d00391063aae84",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 105,
+    "timestamp": "2026-05-01T01:16:11-07:00",
+    "commit_hash": "2661a802963c02b840d9be6107d00391063aae84",
+    "commit_short": "2661a80",
+    "code_fingerprint": "9ea95cf5e3c9dd21ced1f0755d7d0fef3b34856652696116b30bcb1bdbc9d740",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 3 hunk(s), +7/-3. bridge8-patched.html @@ -164,6 +164,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;} | - no removed line sample || bridge8-patched.html @@ -347,13 +350,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"help? for commands or type to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea> | - <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"Type a message…\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea> || bridge8-patched.html @@ -580,7 +583,8 @@ async function sendChat(){ | + if(text==='help?'){runPhraseCommand('help?');ta.value='';chatInputEvt();return;} | - if(text.indexOf('/')===0){runPhraseSearch(text.slice(1));return;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "2661a802963c02b840d9be6107d00391063aae84:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "0fad6e1e1cb3ce88413ca54212807f9ebb11dc50",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -164,6 +164,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -347,13 +350,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"help? for commands or type to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>",
+        "remove": "<input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-icon-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\" style=\"background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;font-size:16px;flex-shrink:0;\">📎</button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"Type a message…\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\"></textarea>"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -580,7 +583,8 @@ async function sendChat(){",
+        "add": "if(text==='help?'){runPhraseCommand('help?');ta.value='';chatInputEvt();return;}",
+        "remove": "if(text.indexOf('/')===0){runPhraseSearch(text.slice(1));return;}"
+      }
+    ],
+    "patch_hash": "9ea95cf5e3c9dd21ced1f0755d7d0fef3b34856652696116b30bcb1bdbc9d740"
+  },
+  {
+    "seq": 106,
+    "timestamp": "2026-05-01T00:40:28-07:00",
+    "commit_hash": "0fad6e1e1cb3ce88413ca54212807f9ebb11dc50",
+    "commit_short": "0fad6e1",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 107,
+    "timestamp": "2026-05-01T00:38:52-07:00",
+    "commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2",
+    "commit_short": "6074eb1",
+    "code_fingerprint": "45131bbfbc34c700f37c7a2ccb80ea73c6b319ecf2e5cf20ccee70332a2eb2f9",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "combine.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 8 hunk(s), +28/-89. bridge8-patched.html @@ -161,6 +161,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .phrase-drawer{position:fixed;left:0;right:0;bottom:-52dvh;height:48dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:12;transition:bottom .18s ease;padding:8px 10px;overflow-y:auto;} | - no removed line sample || bridge8-patched.html @@ -346,6 +353,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"phrase-drawer\" id=\"phrase-drawer\"><div id=\"phrase-results\"></div></div> | - no removed line sample || bridge8-patched.html @@ -412,6 +421,9 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null; | + var PHRASE_KEY='tb_standard_phrasebook'; | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "6074eb1be207e02c35ef43fceda38081481019a2:bridge8-patched.html",
+      "6074eb1be207e02c35ef43fceda38081481019a2:combine.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -161,6 +161,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".phrase-drawer{position:fixed;left:0;right:0;bottom:-52dvh;height:48dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:12;transition:bottom .18s ease;padding:8px 10px;overflow-y:auto;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -346,6 +353,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"phrase-drawer\" id=\"phrase-drawer\"><div id=\"phrase-results\"></div></div>",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -412,6 +421,9 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null;",
+        "add": "var PHRASE_KEY='tb_standard_phrasebook';",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -536,6 +548,8 @@ function _detectLangAsync(text){",
+        "add": "var v=(ta.value||'').trim();",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -565,7 +579,10 @@ function handleChatFile(ev){",
+        "add": "if(text.indexOf('//')===0){runPhraseCommand(text.slice(2).trim());ta.value='';chatInputEvt();return;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -629,6 +646,15 @@ function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');c",
+        "add": "function initPhrasebook(){try{var raw=localStorage.getItem(PHRASE_KEY);var data=raw?JSON.parse(raw):null;phrasebook=Array.isArray(data)?data:DEFAULT_PHRASEBOOK.slice()}catch(_){phrasebook=DEFAULT_PHRASEBOOK.slice()}savePhrasebook()}",
+        "remove": ""
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1532,7 +1558,7 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(",
+        "add": "initPhrasebook();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();",
+        "remove": "populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();"
+      },
+      {
+        "file": "combine.html",
+        "hunk": "@@ -1,89 +1,2 @@",
+        "add": "<!-- Deprecated shim: phrasebook is now integrated into bridge8-patched.html. -->",
+        "remove": "<html lang=\"en\">"
+      }
+    ],
+    "patch_hash": "45131bbfbc34c700f37c7a2ccb80ea73c6b319ecf2e5cf20ccee70332a2eb2f9"
+  },
+  {
+    "seq": 108,
+    "timestamp": "2026-04-30T19:12:48-07:00",
+    "commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc",
+    "commit_short": "1ca55a4",
+    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +11/-21. folder.html @@ -758,12 +758,12 @@ const Intel={ | + if(onStep)onStep('Checking local cache…',1); | - if(onStep)onStep('Checking cloud storage for existing record…',1); || folder.html @@ -1278,26 +1278,16 @@ const App={ | + // Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation. | - // Show loading",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "1ca55a4db797027a611be068345f5d002e5ba7dc:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -758,12 +758,12 @@ const Intel={",
+        "add": "if(onStep)onStep('Checking local cache…',1);",
+        "remove": "if(onStep)onStep('Checking cloud storage for existing record…',1);"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1278,26 +1278,16 @@ const App={",
+        "add": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation.",
+        "remove": "// Show loading"
+      }
+    ],
+    "patch_hash": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77"
+  },
+  {
+    "seq": 109,
+    "timestamp": "2026-04-30T19:12:32-07:00",
+    "commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269",
+    "commit_short": "75f8049",
+    "code_fingerprint": "b076bf56fdca9239433888816749094ffa315e8beebf7ab1669dacd4b77a13fa",
+    "primary_filename": "combine.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "combine.html"
+      },
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 3 hunk(s), +110/-11. combine.html @@ -0,0 +1,89 @@ | + <!DOCTYPE html> | - no removed line sample || folder.html @@ -758,12 +758,12 @@ const Intel={ | + if(onStep)onStep('Checking cloud storage for existing record…',1); | - if(onStep)onStep('Checking local cache…',1); || folder.html @@ -1278,16 +1278,26 @@ const App={ | + // Show loading | - // Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation.",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "75f804905813803e1af5c50c2872a79b1c5d9269:combine.html",
+      "75f804905813803e1af5c50c2872a79b1c5d9269:folder.html"
+    ],
+    "launch_ref": "combine.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "4cdceee325361d42c14d254d65338e6cdc417ea3",
+    "diff_evidence": [
+      {
+        "file": "combine.html",
+        "hunk": "@@ -0,0 +1,89 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -758,12 +758,12 @@ const Intel={",
+        "add": "if(onStep)onStep('Checking cloud storage for existing record…',1);",
+        "remove": "if(onStep)onStep('Checking local cache…',1);"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1278,16 +1278,26 @@ const App={",
+        "add": "// Show loading",
+        "remove": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation."
+      }
+    ],
+    "patch_hash": "b076bf56fdca9239433888816749094ffa315e8beebf7ab1669dacd4b77a13fa"
+  },
+  {
+    "seq": 110,
+    "timestamp": "2026-04-30T19:11:41-07:00",
+    "commit_hash": "4cdceee325361d42c14d254d65338e6cdc417ea3",
+    "commit_short": "4cdceee",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 111,
+    "timestamp": "2026-04-30T19:11:29-07:00",
+    "commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a",
+    "commit_short": "9807fc9",
+    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +11/-21. folder.html @@ -758,12 +758,12 @@ const Intel={ | + if(onStep)onStep('Checking local cache…',1); | - if(onStep)onStep('Checking cloud storage for existing record…',1); || folder.html @@ -1278,26 +1278,16 @@ const App={ | + // Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation. | - // Show loading",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "9807fc9d9ee78265619f56573090a33dd8fae85a:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "934bea854b4d8131b28eab028e0dde85f53cb70c",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -758,12 +758,12 @@ const Intel={",
+        "add": "if(onStep)onStep('Checking local cache…',1);",
+        "remove": "if(onStep)onStep('Checking cloud storage for existing record…',1);"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1278,26 +1278,16 @@ const App={",
+        "add": "// Prioritize instant first paint: render level-1 tree before deferred intelligence reconciliation.",
+        "remove": "// Show loading"
+      }
+    ],
+    "patch_hash": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77"
+  },
+  {
+    "seq": 112,
+    "timestamp": "2026-04-30T17:29:57-07:00",
+    "commit_hash": "934bea854b4d8131b28eab028e0dde85f53cb70c",
+    "commit_short": "934bea8",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 113,
+    "timestamp": "2026-04-30T17:29:42-07:00",
+    "commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287",
+    "commit_short": "505ee36",
+    "code_fingerprint": "cc0985e2c4b673cf467e69ed79f4e6a0a37a092ced406d9586fdbd2999e92a5d",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 3 hunk(s), +17/-12. folder.html @@ -913,17 +913,11 @@ const Tree={ | + tog.addEventListener('click',e=>{ | - tog.addEventListener('click',async e=>{ || folder.html @@ -1313,6 +1307,15 @@ const App={ | + shouldQuickRefresh(folderId){ | - no removed line sample || folder.html @@ -1329,11 +1332,13 @@ const App={ | + // Quick non-recursive refresh check only for selected level-1 folders | - // Lazy delta check if enrolled",
+    "functional_impacts": [
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "505ee3639da7242f762ffc75f6426ad242cfb287:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: ui/ux flow changes.",
+    "previous_commit_hash": "b488a29cb1efbc9ac9494b6d3c3c144a8c0d904f",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -913,17 +913,11 @@ const Tree={",
+        "add": "tog.addEventListener('click',e=>{",
+        "remove": "tog.addEventListener('click',async e=>{"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1313,6 +1307,15 @@ const App={",
+        "add": "shouldQuickRefresh(folderId){",
+        "remove": ""
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -1329,11 +1332,13 @@ const App={",
+        "add": "// Quick non-recursive refresh check only for selected level-1 folders",
+        "remove": "// Lazy delta check if enrolled"
+      }
+    ],
+    "patch_hash": "cc0985e2c4b673cf467e69ed79f4e6a0a37a092ced406d9586fdbd2999e92a5d"
+  },
+  {
+    "seq": 114,
+    "timestamp": "2026-04-30T15:37:38-07:00",
+    "commit_hash": "b488a29cb1efbc9ac9494b6d3c3c144a8c0d904f",
+    "commit_short": "b488a29",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 115,
+    "timestamp": "2026-04-30T15:37:26-07:00",
+    "commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a",
+    "commit_short": "0109ef7",
+    "code_fingerprint": "4b13eb54734afbb3d2bcd65274c2642a682768150b90f078d3bdab86af06f28d",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +9/-9. bridge8-patched.html @@ -843,13 +843,13 @@ async function createRoom(){ | + var _pendingJoin=null,inviteDgKey='',inviteCfTid='',inviteCfTok=''; | - var _pendingJoin=null; || bridge8-patched.html @@ -1028,8 +1028,8 @@ function stopKeepalive(){clearInterval(_keepaliveTimer);_keepaliveTimer=null;} | + var tid=((inviteCfTid||'')||(localStorage.getItem('tb_cf_tid')||'')).trim(); | - var tid=(localStorage.getItem('tb_cf_tid')||'').trim(); || bridge8-patched.html @@ -1170,9 +1170,9 @@ function stopDeepgram(){ | + var key=(($('dg-key')&&$('dg-key').value)||inviteDgKey||localStorage.getItem('tb_dg_key')||'').trim(); | - var key=(($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'').trim();",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "0109ef79bf0d709dcf6db76489132abdfda1b83a:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "afa2e7d25bb456cbe054c40ee32a6ef4dabea51a",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -843,13 +843,13 @@ async function createRoom(){",
+        "add": "var _pendingJoin=null,inviteDgKey='',inviteCfTid='',inviteCfTok='';",
+        "remove": "var _pendingJoin=null;"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1028,8 +1028,8 @@ function stopKeepalive(){clearInterval(_keepaliveTimer);_keepaliveTimer=null;}",
+        "add": "var tid=((inviteCfTid||'')||(localStorage.getItem('tb_cf_tid')||'')).trim();",
+        "remove": "var tid=(localStorage.getItem('tb_cf_tid')||'').trim();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1170,9 +1170,9 @@ function stopDeepgram(){",
+        "add": "var key=(($('dg-key')&&$('dg-key').value)||inviteDgKey||localStorage.getItem('tb_dg_key')||'').trim();",
+        "remove": "var key=(($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'').trim();"
+      },
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1560,4 +1560,4 @@ window.addEventListener('visibilitychange',function(){",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "4b13eb54734afbb3d2bcd65274c2642a682768150b90f078d3bdab86af06f28d"
+  },
+  {
+    "seq": 116,
+    "timestamp": "2026-04-30T15:26:28-07:00",
+    "commit_hash": "afa2e7d25bb456cbe054c40ee32a6ef4dabea51a",
+    "commit_short": "afa2e7d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 117,
+    "timestamp": "2026-04-30T15:25:02-07:00",
+    "commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a",
+    "commit_short": "47d49d4",
+    "code_fingerprint": "97f96f03041ba26112366f457f65ed57557094751c9d13e6b1615db7f13290fa",
+    "primary_filename": "folder.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 2 hunk(s), +1425/-1286. folder.html @@ -2,344 +2,453 @@ | + <meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0,user-scalable=no\"> | - <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, user-scalable=no\"> || folder.html @@ -347,1045 +456,1075 @@ th.drag-over{border-left:2px solid var(--acc)} | + // ── Content classification ──────────────────────────────── | - const INTEL_FILE = '.orbital8-intelligence.json';",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a:folder.html"
+    ],
+    "launch_ref": "folder.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f",
+    "diff_evidence": [
+      {
+        "file": "folder.html",
+        "hunk": "@@ -2,344 +2,453 @@",
+        "add": "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1.0,user-scalable=no\">",
+        "remove": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, user-scalable=no\">"
+      },
+      {
+        "file": "folder.html",
+        "hunk": "@@ -347,1045 +456,1075 @@ th.drag-over{border-left:2px solid var(--acc)}",
+        "add": "// ── Content classification ────────────────────────────────",
+        "remove": "const INTEL_FILE = '.orbital8-intelligence.json';"
+      }
+    ],
+    "patch_hash": "97f96f03041ba26112366f457f65ed57557094751c9d13e6b1615db7f13290fa"
+  },
+  {
+    "seq": 118,
+    "timestamp": "2026-04-30T09:52:39-07:00",
+    "commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f",
+    "commit_short": "f5ca35c",
+    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1563/-0. bridge8-patched.html @@ -0,0 +1,1563 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -0,0 +1,1563 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035"
+  },
+  {
+    "seq": 119,
+    "timestamp": "2026-04-30T09:52:21-07:00",
+    "commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39",
+    "commit_short": "000d821",
+    "code_fingerprint": "c66a4f6033dd6d9befd2ec40c624a24b4a46b33e451fdb698c19902eb66e7b50",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "D",
+        "path": "bridge8-patched.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 11 hunk(s), +17/-1574. bridge8-patched.html @@ -1,1563 +0,0 @@ | + no added line sample | - <!DOCTYPE html> || folder-v1.html @@ -156,7 +156,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0;min-height:0} | - #t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0} || folder-v1.html @@ -195,7 +195,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .tbl-wrap{flex:1;overflow:auto;min-width:0} | - .tbl-wrap{flex:1;overflow:auto}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:bridge8-patched.html",
+      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:folder-v1.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "569a703dae03c627ee7f04bcbb1bfa2074566da5",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -1,1563 +0,0 @@",
+        "add": "",
+        "remove": "<!DOCTYPE html>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -156,7 +156,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0;min-height:0}",
+        "remove": "#t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -195,7 +195,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".tbl-wrap{flex:1;overflow:auto;min-width:0}",
+        "remove": ".tbl-wrap{flex:1;overflow:auto}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -252,6 +252,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".provider-progress{margin-top:10px;background:var(--raised);border:1px solid var(--border);border-radius:8px;padding:8px}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -314,7 +318,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"pvr-status\" class=\"smsg s-info\">Select your cloud storage provider</div><div class=\"provider-progress hidden\" id=\"provider-progress\"><div class=\"provider-progress-bar\"><div class=\"provider-progress-fill\" id=\"provider-progress-fill\"></div></div><div class=\"provider-progress-text\" id=\"provider-progress-text\">Idle</div></div>",
+        "remove": "<div id=\"pvr-status\" class=\"smsg s-info\">Select your cloud storage provider</div>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -565,7 +569,7 @@ const st = {",
+        "add": "view:'tree', ui:{rightView:'list',segmentCollapsed:false,portalPage:0,portalDensity:4,portalPinned:true,timelineFilter:null,loadingStep:'',portalRunToken:0},",
+        "remove": "view:'tree', ui:{rightView:'list',segmentCollapsed:false,portalPage:0,portalDensity:4,portalPinned:true,timelineFilter:null,loadingStep:''},"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1609,10 +1613,12 @@ const FileViewer = {",
+        "add": "render(){const wrap=$id('portal-wrap'),grid=$id('portal-grid');if(!wrap||!grid)return;const files=TreeView.getDisplayFiles?TreeView.getDisplayFiles():[];const page=st.ui.portalPage;const pageFiles=files.slice(page*16,page*16+16);grid.style.gridTemplateColumns=`repeat(${st.ui.portalDensity},minmax(0,1fr))`;grid.innerHTML='';let i=0;const chunk=4;const paint=()=>{pageFiles.slice(i,i+chunk).forEach(f=>{const p=document.createElement('div');p.className='portlet';p.draggable=true;p.innerHTML=`<div contenteditable=\"true\" data-id=\"${f.id}\" class=\"col-link\">${f.name}</div><div class=\"col-mono\">${fmtDate(f.effectiveDate)}</div>`;p.addEventListener('click',()=>{st.files.selectedId=f.id;TreeView.renderPreviewInPane(f);});grid.appendChild(p);});i+=chunk;if(i<pageFiles.length)requestAnimationFrame(paint);};requestAnimationFrame(paint);}",
+        "remove": "render(){const wrap=$id('portal-wrap'),grid=$id('portal-grid');if(!wrap||!grid)return;const files=TreeView.getDisplayFiles?TreeView.getDisplayFiles():[];const page=st.ui.portalPage;const pageFiles=files.slice(page*16,page*16+16);grid.style.gridTemplateColumns=`repeat(${st.ui.portalDensity},minmax(0,1fr))`;grid.innerHTML='';pageFiles.forEach(f=>{const p=document.createElement('div');p.className='portlet';p.draggable=true;p.innerHTML=`<div contenteditable=\"true\" data-id=\"${f.id}\" class=\"col-link\">${f.name}</div><div class=\"col-mono\">${fmtDate(f.effectiveDate)}</div>`;p.addEventListener('click',()=>{st.files.selectedId=f.id;FileViewer.open(f,true);});grid.appendChild(p);});}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1624,7 +1630,7 @@ const App = {",
+        "add": "this.setProviderProgress('Connecting provider…',8);if(st.provider.isAuthenticated){this.afterAuth();}else{showScreen('scr-auth');}",
+        "remove": "if(st.provider.isAuthenticated){this.afterAuth();}else{showScreen('scr-auth');}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1782,13 +1788,13 @@ const App = {",
+        "add": "this.applyLayout();",
+        "remove": "document.getElementById('t-body').style.gridTemplateColumns='0 0 1fr';"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1858,7 +1864,7 @@ function initEvents(){",
+        "add": "App.applyLayout();",
+        "remove": "body.style.gridTemplateColumns=body.classList.contains('left-collapsed')||st.view==='timeline'?'0 0 1fr':'var(--lpw) 4px minmax(0,1fr)';"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1909,10 +1915,10 @@ function initEvents(){",
+        "add": "$id('portal-run').addEventListener('click',async()=>{const token=++st.ui.portalRunToken;const files=TreeView.getDisplayFiles().slice(st.ui.portalPage*16,st.ui.portalPage*16+8);for(const f of files){if(token!==st.ui.portalRunToken)break;st.files.selectedId=f.id;await TreeView.renderPreviewInPane(f);await sleep(180);}});",
+        "remove": "$id('portal-run').addEventListener('click',async()=>{const files=TreeView.getDisplayFiles();for(const f of files.slice(0,8)){st.files.selectedId=f.id;await FileViewer.open(f,true);await sleep(250);}});"
+      }
+    ],
+    "patch_hash": "c66a4f6033dd6d9befd2ec40c624a24b4a46b33e451fdb698c19902eb66e7b50"
+  },
+  {
+    "seq": 120,
+    "timestamp": "2026-04-30T09:43:21-07:00",
+    "commit_hash": "569a703dae03c627ee7f04bcbb1bfa2074566da5",
+    "commit_short": "569a703",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 121,
+    "timestamp": "2026-04-30T09:43:05-07:00",
+    "commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4",
+    "commit_short": "5fbfd05",
+    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
+    "primary_filename": "bridge8-patched.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge8-patched.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1563/-0. bridge8-patched.html @@ -0,0 +1,1563 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5fbfd050889202865fd1d369a9f9f46835347cf4:bridge8-patched.html"
+    ],
+    "launch_ref": "bridge8-patched.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "ee01d9435c3948ae0af40ab48a9e202c43868f33",
+    "diff_evidence": [
+      {
+        "file": "bridge8-patched.html",
+        "hunk": "@@ -0,0 +1,1563 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035"
+  },
+  {
+    "seq": 122,
+    "timestamp": "2026-04-30T05:58:19-07:00",
+    "commit_hash": "ee01d9435c3948ae0af40ab48a9e202c43868f33",
+    "commit_short": "ee01d94",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 123,
+    "timestamp": "2026-04-30T05:58:04-07:00",
+    "commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b",
+    "commit_short": "612ed7c",
+    "code_fingerprint": "e5bbdcc50e5d4154fbf9fa89ce596b893f6c558a89db083b32ab0a2956391286",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 7 hunk(s), +18/-10. folder-v1.html @@ -124,7 +124,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #t-body{display:grid;grid-template-columns:var(--lpw) 4px minmax(0,1fr);overflow:hidden} | - #t-body{display:grid;grid-template-columns:var(--lpw) 4px 1fr;overflow:hidden} || folder-v1.html @@ -156,7 +156,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0} | - #t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg)} || folder-v1.html @@ -185,7 +185,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .file-main{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,40%);flex:1;min-height:0} | - .file-main{display:grid;grid-template-columns:minmax(380px,1fr) minmax(300px,40%);flex:1;min-height:0}",
+    "functional_impacts": [
+      "normalization",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "612ed7c646da2e6fe69bd82c2f57013ebdecc65b:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Diff-evidenced impacts: normalization, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "2f474239b8c20296fb4ee6bdd95e705f84605792",
+    "diff_evidence": [
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -124,7 +124,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#t-body{display:grid;grid-template-columns:var(--lpw) 4px minmax(0,1fr);overflow:hidden}",
+        "remove": "#t-body{display:grid;grid-template-columns:var(--lpw) 4px 1fr;overflow:hidden}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -156,7 +156,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg);min-width:0}",
+        "remove": "#t-attr{display:flex;flex-direction:column;overflow:hidden;background:var(--bg)}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -185,7 +185,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".file-main{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,40%);flex:1;min-height:0}",
+        "remove": ".file-main{display:grid;grid-template-columns:minmax(380px,1fr) minmax(300px,40%);flex:1;min-height:0}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -254,12 +254,18 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".h-acts{margin-left:0;flex-wrap:wrap}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1624,14 +1630,16 @@ const App = {",
+        "add": "const steps=['authenticating','resolving account','reading intelligence','warming index cache','finalizing'];",
+        "remove": "stat.textContent='Reading intelligence 1/5: authenticating…';stat.className='smsg s-info';"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1850,7 +1858,7 @@ function initEvents(){",
+        "add": "body.style.gridTemplateColumns=body.classList.contains('left-collapsed')||st.view==='timeline'?'0 0 1fr':'var(--lpw) 4px minmax(0,1fr)';",
+        "remove": "if(st.view==='tree') body.style.gridTemplateColumns=body.classList.contains('left-collapsed')?'0 0 1fr':'var(--lpw) 4px 1fr';"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1894,8 +1902,8 @@ function initEvents(){",
+        "add": "$id('btn-list-view').addEventListener('click',()=>{st.ui.rightView='list';$id('list-wrap').style.display='block';$id('portal-wrap').classList.remove('active');});",
+        "remove": "$id('btn-list-view').addEventListener('click',()=>{$id('list-wrap').style.display='block';$id('portal-wrap').classList.remove('active');});"
+      }
+    ],
+    "patch_hash": "e5bbdcc50e5d4154fbf9fa89ce596b893f6c558a89db083b32ab0a2956391286"
+  },
+  {
+    "seq": 124,
+    "timestamp": "2026-04-29T20:48:29-07:00",
+    "commit_hash": "2f474239b8c20296fb4ee6bdd95e705f84605792",
+    "commit_short": "2f47423",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 125,
+    "timestamp": "2026-04-29T20:48:12-07:00",
+    "commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826",
+    "commit_short": "47dcdfe",
+    "code_fingerprint": "d997591f10449d2ba31886b8dbd9f66d6f6f414a8c73fe3f95ab1a891207d3c4",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 4 hunk(s), +30/-3. folder-v1.html @@ -151,7 +151,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #t-div{background:var(--border);cursor:col-resize;transition:background .15s;position:relative} | - #t-div{background:var(--border);cursor:col-resize;transition:background .15s} || folder-v1.html @@ -911,6 +912,10 @@ const Intel = { | + const existingFolder=rec.folders[fid]; | - no removed line sample || folder-v1.html @@ -961,11 +966,31 @@ const Intel = { | + allFiles.forEach(f=>{ | - hp.push(`${fr.id}:${fr.modifiedTime||''}`);",
+    "functional_impacts": [
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes"
+    ],
+    "blob_refs": [
+      "47dcdfe54ff286772521ccc0992d4506c8807826:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Diff-evidenced impacts: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
+    "previous_commit_hash": "fa2c2c7885a9db8c35c398946f6cb6ef55b72339",
+    "diff_evidence": [
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -151,7 +151,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#t-div{background:var(--border);cursor:col-resize;transition:background .15s;position:relative}",
+        "remove": "#t-div{background:var(--border);cursor:col-resize;transition:background .15s}"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -911,6 +912,10 @@ const Intel = {",
+        "add": "const existingFolder=rec.folders[fid];",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -961,11 +966,31 @@ const Intel = {",
+        "add": "allFiles.forEach(f=>{",
+        "remove": "hp.push(`${fr.id}:${fr.modifiedTime||''}`);"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -980,8 +1005,10 @@ const Intel = {",
+        "add": "priorFileIds.forEach(id=>{if(!seenFileIds.has(id)) delete rec.files[id];});",
+        "remove": "folder.hash=simpleHash(hp.sort().join('|'));"
+      }
+    ],
+    "patch_hash": "d997591f10449d2ba31886b8dbd9f66d6f6f414a8c73fe3f95ab1a891207d3c4"
+  },
+  {
+    "seq": 126,
+    "timestamp": "2026-04-29T15:30:02-07:00",
+    "commit_hash": "fa2c2c7885a9db8c35c398946f6cb6ef55b72339",
+    "commit_short": "fa2c2c7",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 127,
+    "timestamp": "2026-04-29T15:28:50-07:00",
+    "commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a",
+    "commit_short": "51fdf0b",
+    "code_fingerprint": "73e06a56193f04241aa2e76bab7109e2a8e5f5acc78069e4e1e43645b68947b0",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +7/-4. bridge8.html @@ -929,13 +929,16 @@ function handleRelay(d){ | + var normText=normalizeText(d.text, 'speech'); | - if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "joining/rejoining flow",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "51fdf0baf671eca52961f8ae50683f2257f4860a:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -929,13 +929,16 @@ function handleRelay(d){",
+        "add": "var normText=normalizeText(d.text, 'speech');",
+        "remove": "if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');"
+      }
+    ],
+    "patch_hash": "73e06a56193f04241aa2e76bab7109e2a8e5f5acc78069e4e1e43645b68947b0"
+  },
+  {
+    "seq": 128,
+    "timestamp": "2026-04-29T15:13:46-07:00",
+    "commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8",
+    "commit_short": "9f9f905",
+    "code_fingerprint": "72b442e36cbd488b720d9d9f07b61444a73393c29d10b400abbd9a946d4cf3d8",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 12 hunk(s), +13/-46. bridge8.html @@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);} | - .transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--green);color:#000;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);} || bridge8.html @@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div> | - <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div> || bridge8.html @@ -345,7 +345,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - <div class=\"transcript-more-indicator\" id=\"chat-more-indicator\" onclick=\"scrollChatToBottom()\">↑</div>",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9f9f905d5e81a12101a8175e9ede5772bc0276a8:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}",
+        "remove": ".transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--green);color:#000;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div>",
+        "remove": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -345,7 +345,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<div class=\"transcript-more-indicator\" id=\"chat-more-indicator\" onclick=\"scrollChatToBottom()\">↑</div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -409,7 +408,6 @@ var debugLog=[],HEARTBEAT_MS=30000,SUB_LINGER=5000,MAX_TR=300;",
+        "add": "",
+        "remove": "var remotePlayToken=0,remotePlayPending=false,remoteUnmutedKey='';"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -930,17 +928,14 @@ function handleRelay(d){",
+        "add": "if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');",
+        "remove": "var subText=normalizeText(d.text||'','speech');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -992,34 +987,17 @@ function refreshRemoteVideo(){",
+        "add": "if(tryPlay&&tryPlay.then){tryPlay.then(function(){rv.muted=false;log('rtc_unmuted',{},'ok');}).catch(function(e){log('rtc_play_err',{e:String(e)},'error');});}",
+        "remove": "var streamId=remoteStream&&(remoteStream.id||'');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1028,7 +1006,6 @@ function bindRemoteTrackState(track){",
+        "add": "",
+        "remove": "remotePlayToken++;remotePlayPending=false;remoteUnmutedKey='';"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1185,18 +1162,16 @@ function startDeepgram(){",
+        "add": "if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'warn');return;}",
+        "remove": "if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'info');return;}"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1333,17 +1308,10 @@ function renderTr(){",
+        "add": "",
+        "remove": "var cb=$('chat-body');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1497,7 +1465,7 @@ function cleanUp(){",
+        "add": "$('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);syncTranscriptToggleButton();",
+        "remove": "$('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);setChatMore(false);syncTranscriptToggleButton();"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1511,7 +1479,6 @@ if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=lo",
+        "add": "",
+        "remove": "$('chat-body').addEventListener('scroll',function(){if(chatNearBottom())setChatMore(false)});"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1538,4 +1505,4 @@ window.addEventListener('visibilitychange',function(){",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "72b442e36cbd488b720d9d9f07b61444a73393c29d10b400abbd9a946d4cf3d8"
+  },
+  {
+    "seq": 129,
+    "timestamp": "2026-04-29T14:53:22-07:00",
+    "commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8",
+    "commit_short": "78b712f",
+    "code_fingerprint": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +31/-26. bridge8.html @@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div> | - <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div> || bridge8.html @@ -930,14 +930,17 @@ function handleRelay(d){ | + var subText=normalizeText(d.text||'','speech'); | - if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner'); || bridge8.html @@ -985,36 +988,38 @@ async function enterCall(){ | + var streamId=remoteStream&&(remoteStream.id||''); | - var callEpoch=sessionEpoch;",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "78b712f6f394afc43c81e0edb6236379401c21d8:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div>",
+        "remove": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -930,14 +930,17 @@ function handleRelay(d){",
+        "add": "var subText=normalizeText(d.text||'','speech');",
+        "remove": "if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -985,36 +988,38 @@ async function enterCall(){",
+        "add": "var streamId=remoteStream&&(remoteStream.id||'');",
+        "remove": "var callEpoch=sessionEpoch;"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1023,8 +1028,8 @@ function bindRemoteTrackState(track){",
+        "add": "remotePlayToken++;remotePlayPending=false;remoteUnmutedKey='';",
+        "remove": "remotePlayPending=false;remotePlayToken++;remoteUnmutedKey='';"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1184,8 +1189,8 @@ function startDeepgram(){",
+        "add": "var langLower=String(langCode||'').toLowerCase();",
+        "remove": "var langBase=(langCode||'en').toLowerCase().split('-')[0];"
+      }
+    ],
+    "patch_hash": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470"
+  },
+  {
+    "seq": 130,
+    "timestamp": "2026-04-29T14:53:05-07:00",
+    "commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee",
+    "commit_short": "8e48d01",
+    "code_fingerprint": "792526c369bf80bc46f7299d4befb81d6621f20a6d8c537ad79dcbf4e5c7c78d",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      },
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 2 file(s), 18 hunk(s), +81/-59. bridge8.html @@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div> | - <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div> || bridge8.html @@ -930,17 +930,14 @@ function handleRelay(d){ | + if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner'); | - var subText=normalizeText(d.text||'','speech'); || bridge8.html @@ -988,38 +985,36 @@ async function enterCall(){ | + var callEpoch=sessionEpoch; | - var streamId=remoteStream&&(remoteStream.id||'');",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:bridge8.html",
+      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:folder-v1.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "f103ade44d16f1e40c5ba545352ea1be0b45deaf",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div>",
+        "remove": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -930,17 +930,14 @@ function handleRelay(d){",
+        "add": "if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');",
+        "remove": "var subText=normalizeText(d.text||'','speech');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -988,38 +985,36 @@ async function enterCall(){",
+        "add": "var callEpoch=sessionEpoch;",
+        "remove": "var streamId=remoteStream&&(remoteStream.id||'');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1028,8 +1023,8 @@ function bindRemoteTrackState(track){",
+        "add": "remotePlayPending=false;remotePlayToken++;remoteUnmutedKey='';",
+        "remove": "remotePlayToken++;remotePlayPending=false;remoteUnmutedKey='';"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1189,8 +1184,8 @@ function startDeepgram(){",
+        "add": "var langBase=(langCode||'en').toLowerCase().split('-')[0];",
+        "remove": "var langLower=String(langCode||'').toLowerCase();"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -241,6 +241,24 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".right-shell-head{display:flex;align-items:center;gap:8px;padding:6px 12px;background:var(--surface);border-bottom:1px solid var(--border);}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -383,7 +401,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<button class=\"h-vtab\" id=\"vtab-portal\" data-view=\"portal\">Portal</button>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -413,15 +431,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<div id=\"v-portal\" class=\"hidden\">"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -429,15 +442,16 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"file-view-toggle\"><button class=\"btn btn-ghost btn-sm\" id=\"btn-list-view\">List</button><button class=\"btn btn-ghost btn-sm\" id=\"btn-portal-view\">Portal</button></div><span class=\"file-cnt\" id=\"file-cnt\"></span>",
+        "remove": "<span class=\"file-cnt\" id=\"file-cnt\"></span>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -544,7 +558,7 @@ const st = {",
+        "add": "view:'tree', ui:{rightView:'list',segmentCollapsed:false,portalPage:0,portalDensity:4,portalPinned:true,timelineFilter:null,loadingStep:''},",
+        "remove": "view:'tree',"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1277,6 +1291,8 @@ const TreeView = {",
+        "add": "getDisplayFiles(){ let files=Intel.getFilesForFolder(st.tree.selFolder,st.files.classFilter,st.files.stackFilter); if(st.ui.timelineFilter&&st.ui.timelineFilter.length){files=files.filter(f=>{const d=new Date(f.effectiveDate);const t=st.ui.timelineFilter;return !isNaN(d)&&d.getFullYear()===t[0]&&(!t[1]||d.getMonth()+1===t[1])&&(!t[2]||d.getDate()===t[2]);});} return files;},",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1406,7 +1422,7 @@ const Timeline = {",
+        "add": "this.renderBreadcrumb();this.renderChart();this.applySegmentFilter();",
+        "remove": "this.renderBreadcrumb();this.renderChart();"
+      }
+    ],
+    "patch_hash": "792526c369bf80bc46f7299d4befb81d6621f20a6d8c537ad79dcbf4e5c7c78d"
+  },
+  {
+    "seq": 131,
+    "timestamp": "2026-04-29T14:52:42-07:00",
+    "commit_hash": "f103ade44d16f1e40c5ba545352ea1be0b45deaf",
+    "commit_short": "f103ade",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 132,
+    "timestamp": "2026-04-29T14:52:28-07:00",
+    "commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354",
+    "commit_short": "9a517b6",
+    "code_fingerprint": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +31/-26. bridge8.html @@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div> | - <div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div> || bridge8.html @@ -930,14 +930,17 @@ function handleRelay(d){ | + var subText=normalizeText(d.text||'','speech'); | - if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner'); || bridge8.html @@ -985,36 +988,38 @@ async function enterCall(){ | + var streamId=remoteStream&&(remoteStream.id||''); | - var callEpoch=sessionEpoch;",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9a517b6654ac77afe65153ff64e781d02f25a354:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "7542365931a6ebcb792f375d2384b062343ff818",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -337,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↑</div>",
+        "remove": "<div class=\"transcript-more-indicator\" id=\"transcript-more-indicator\" onclick=\"scrollToBottom()\">↓</div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -930,14 +930,17 @@ function handleRelay(d){",
+        "add": "var subText=normalizeText(d.text||'','speech');",
+        "remove": "if(d.text&&d.targetLang===room.myLang)showSub(d.text,'partner');"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -985,36 +988,38 @@ async function enterCall(){",
+        "add": "var streamId=remoteStream&&(remoteStream.id||'');",
+        "remove": "var callEpoch=sessionEpoch;"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1023,8 +1028,8 @@ function bindRemoteTrackState(track){",
+        "add": "remotePlayToken++;remotePlayPending=false;remoteUnmutedKey='';",
+        "remove": "remotePlayPending=false;remotePlayToken++;remoteUnmutedKey='';"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1184,8 +1189,8 @@ function startDeepgram(){",
+        "add": "var langLower=String(langCode||'').toLowerCase();",
+        "remove": "var langBase=(langCode||'en').toLowerCase().split('-')[0];"
+      }
+    ],
+    "patch_hash": "652c07186d368702c9dd81d9e7584b1a0d51a1cb0cb5b5906b28a86e68479470"
+  },
+  {
+    "seq": 133,
+    "timestamp": "2026-04-29T14:26:11-07:00",
+    "commit_hash": "7542365931a6ebcb792f375d2384b062343ff818",
+    "commit_short": "7542365",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 134,
+    "timestamp": "2026-04-29T14:25:57-07:00",
+    "commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11",
+    "commit_short": "f92b1a8",
+    "code_fingerprint": "864f0eeff516258423dd51c23108c3a60954188271104480c8c6a5f5a86b29cd",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 10 hunk(s), +37/-9. bridge8.html @@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--green);color:#000;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);} | - .transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);} || bridge8.html @@ -345,6 +345,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"transcript-more-indicator\" id=\"chat-more-indicator\" onclick=\"scrollChatToBottom()\">↑</div> | - no removed line sample || bridge8.html @@ -408,6 +409,7 @@ var debugLog=[],HEARTBEAT_MS=30000,SUB_LINGER=5000,MAX_TR=300; | + var remotePlayToken=0,remotePlayPending=false,remoteUnmutedKey=''; | - no removed line sample",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "f92b1a8823d53cfdb012e2acfe3081f5ea12de11:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -97,7 +97,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--green);color:#000;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}",
+        "remove": ".transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -345,6 +345,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"transcript-more-indicator\" id=\"chat-more-indicator\" onclick=\"scrollChatToBottom()\">↑</div>",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -408,6 +409,7 @@ var debugLog=[],HEARTBEAT_MS=30000,SUB_LINGER=5000,MAX_TR=300;",
+        "add": "var remotePlayToken=0,remotePlayPending=false,remoteUnmutedKey='';",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -983,21 +985,36 @@ async function enterCall(){",
+        "add": "var callEpoch=sessionEpoch;",
+        "remove": "var tryPlay=rv.play&&rv.play();"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1007,6 +1024,7 @@ function resetRemoteMediaState(){",
+        "add": "remotePlayPending=false;remotePlayToken++;remoteUnmutedKey='';",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1162,16 +1180,18 @@ function startDeepgram(){",
+        "add": "if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'info');return;}",
+        "remove": "if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'warn');return;}"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1308,10 +1328,17 @@ function renderTr(){",
+        "add": "var cb=$('chat-body');",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1465,7 +1492,7 @@ function cleanUp(){",
+        "add": "$('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);setChatMore(false);syncTranscriptToggleButton();",
+        "remove": "$('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);syncTranscriptToggleButton();"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1479,6 +1506,7 @@ if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=lo",
+        "add": "$('chat-body').addEventListener('scroll',function(){if(chatNearBottom())setChatMore(false)});",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1505,4 +1533,4 @@ window.addEventListener('visibilitychange',function(){",
+        "add": "</html>",
+        "remove": "</html>"
+      }
+    ],
+    "patch_hash": "864f0eeff516258423dd51c23108c3a60954188271104480c8c6a5f5a86b29cd"
+  },
+  {
+    "seq": 135,
+    "timestamp": "2026-04-29T13:37:59-07:00",
+    "commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f",
+    "commit_short": "a8459ec",
+    "code_fingerprint": "8f0dca3def9c684d12ba3efafb6f05eda1e3c64e1c78ef9a6892fa45e5fefe0c",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 5 hunk(s), +22/-9. bridge8.html @@ -278,15 +278,16 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"thankyou-page\" id=\"thankyou-page\"> | - <div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\"> || bridge8.html @@ -477,6 +478,9 @@ function routePostCallByRole(sourceReason){ | + // Safe stub — returns current lang so the race fallback never throws | - no removed line sample || bridge8.html @@ -936,9 +940,17 @@ function handleRelay(d){ | + else{ | - // Phase 2: role-based remote hangup handling",
+    "functional_impacts": [
+      "transcription",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a8459ec1dcc0b081f970b53b341167e8e5cd829f:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -278,15 +278,16 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\">",
+        "remove": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\">"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -477,6 +478,9 @@ function routePostCallByRole(sourceReason){",
+        "add": "// Safe stub — returns current lang so the race fallback never throws",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -936,9 +940,17 @@ function handleRelay(d){",
+        "add": "else{",
+        "remove": "// Phase 2: role-based remote hangup handling"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1386,7 +1398,7 @@ function showThankYou(msg){",
+        "add": "if(s)s.textContent=L('close_tab',ty_lang);",
+        "remove": "if(s){var rn=room.name||'';s.textContent=rn?rn:(L('close_tab',ty_lang));}"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1404,13 +1416,14 @@ function showHostLeftCountdown(){",
+        "add": "if(s)s.textContent=L('close_tab',ty_lang);",
+        "remove": "if(s)s.textContent='Closing in 5s…';"
+      }
+    ],
+    "patch_hash": "8f0dca3def9c684d12ba3efafb6f05eda1e3c64e1c78ef9a6892fa45e5fefe0c"
+  },
+  {
+    "seq": 136,
+    "timestamp": "2026-04-29T12:57:43-07:00",
+    "commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029",
+    "commit_short": "70905ee",
+    "code_fingerprint": "735cdce0dccea703583b3fd33ceb72a4b957f86c333196d395b27703688c8db1",
+    "primary_filename": "bridge8.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge8.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 45 hunk(s), +350/-209. bridge8.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.1.0 --> | - <!-- talkbridge · dcr · v3.0.7 --> || bridge8.html @@ -69,16 +69,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - /* === TOP BAR with controls === */ || bridge8.html @@ -158,8 +154,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + no added line sample | - /* === CHAT COMPOSE STRIP === */",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "70905ee5ad416786a2cfefa64f619d0ed4eb2029:bridge8.html"
+    ],
+    "launch_ref": "bridge8.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e4ebf4d1058ed4efbb0d30e4da68005d801eec44",
+    "diff_evidence": [
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.1.0 -->",
+        "remove": "<!-- talkbridge · dcr · v3.0.7 -->"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -69,16 +69,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -158,8 +154,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -179,8 +173,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": ""
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -188,9 +180,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".thankyou-page.show{display:flex;}",
+        "remove": "/* v3.0.7: Thank-you page */"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -226,7 +217,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<span style=\"font-size:10px;color:var(--text-muted);\">v3.1.0</span>",
+        "remove": "<span style=\"font-size:10px;color:var(--text-muted);\">v3.0.7</span>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -283,17 +274,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\">",
+        "remove": "<div style=\"display:flex;align-items:center;gap:6px;opacity:.6;margin-top:-8px;\"><span id=\"host-lang-pill\" style=\"font-size:20px;\"></span><span id=\"joiner-room-name-orig\" style=\"font-size:13px;color:rgba(255,255,255,.8);font-family:'Lora',serif;\"></span></div>"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -382,32 +371,113 @@ var DG_LANGS={en:'en-US',th:'th',ja:'ja',ko:'ko',zh:'zh-CN',ar:'ar',hi:'hi',ru:'",
+        "add": "// ─── SESSION STATE (Phase 1) ───────────────────────────────────────────────",
+        "remove": "// Global relay WS — named _relayWs internally to avoid collision with verifyDgKey's local ws"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -428,7 +498,6 @@ function _loadFastText(){",
+        "add": "",
+        "remove": "// Script-range fast path — instant, no WASM needed"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -436,7 +505,6 @@ function _detectLangAsync(text){",
+        "add": "",
+        "remove": "// Latin — use fastText if available"
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -452,13 +520,7 @@ function _detectLangAsync(text){",
+        "add": "/* === CHAT === */",
+        "remove": "/* === CHAT — typed bidirectional messages over relay ==="
+      },
+      {
+        "file": "bridge8.html",
+        "hunk": "@@ -467,7 +529,6 @@ function chatInputEvt(){",
+        "add": "",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "735cdce0dccea703583b3fd33ceb72a4b957f86c333196d395b27703688c8db1"
+  },
+  {
+    "seq": 137,
+    "timestamp": "2026-04-29T11:50:00-07:00",
+    "commit_hash": "e4ebf4d1058ed4efbb0d30e4da68005d801eec44",
+    "commit_short": "e4ebf4d",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 138,
+    "timestamp": "2026-04-29T11:49:48-07:00",
+    "commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007",
+    "commit_short": "5498e01",
+    "code_fingerprint": "6efe9dd0cbc45aa93c722855ec9c01bb3370730cc985c978ee617f8bb649870f",
+    "primary_filename": "bridge5-reliability-implementation-guide.md",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge5-reliability-implementation-guide.md"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +411/-0. bridge5-reliability-implementation-guide.md @@ -0,0 +1,411 @@ | + # Bridge5 Reliability Implementation Guide | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5498e012fcbea3d98b08ac8f8719f3483ef9c007:bridge5-reliability-implementation-guide.md"
+    ],
+    "launch_ref": "bridge5-reliability-implementation-guide.md",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "cb7f4a5fb2166bd9ec3b9287eb1a1d35d6fc77ba",
+    "diff_evidence": [
+      {
+        "file": "bridge5-reliability-implementation-guide.md",
+        "hunk": "@@ -0,0 +1,411 @@",
+        "add": "# Bridge5 Reliability Implementation Guide",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "6efe9dd0cbc45aa93c722855ec9c01bb3370730cc985c978ee617f8bb649870f"
+  },
+  {
+    "seq": 139,
+    "timestamp": "2026-04-29T10:51:56-07:00",
+    "commit_hash": "cb7f4a5fb2166bd9ec3b9287eb1a1d35d6fc77ba",
+    "commit_short": "cb7f4a5",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 140,
+    "timestamp": "2026-04-29T10:36:35-07:00",
+    "commit_hash": "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded",
+    "commit_short": "9f6ea5b",
+    "code_fingerprint": "93ec0a491c353f0872762d5267b6aea8d6b377f72e20f5379db04c4a670127cb",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1/-1. bridge5.html @@ -1342,7 +1342,7 @@ function hidePartnerDisconnected(){ | + function hangUp(){relaySend({type:'hangup'});showThankYou('You ended the call.');} | - function hangUp(){relaySend({type:'hangup'});if(room.role==='joiner'){showThankYou('You ended the call.');}else{cleanUp();}}",
+    "functional_impacts": [
+      "joining/rejoining flow",
+      "call termination behavior"
+    ],
+    "blob_refs": [
+      "9f6ea5b95ff50c111a93376d8e9ffe80f06f9ded:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Diff-evidenced impacts: joining/rejoining flow, call termination behavior.",
+    "previous_commit_hash": "4cb828fb96b0d7102a17f345aa8cf96684fb6ed1",
+    "diff_evidence": [
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1342,7 +1342,7 @@ function hidePartnerDisconnected(){",
+        "add": "function hangUp(){relaySend({type:'hangup'});showThankYou('You ended the call.');}",
+        "remove": "function hangUp(){relaySend({type:'hangup'});if(room.role==='joiner'){showThankYou('You ended the call.');}else{cleanUp();}}"
+      }
+    ],
+    "patch_hash": "93ec0a491c353f0872762d5267b6aea8d6b377f72e20f5379db04c4a670127cb"
+  },
+  {
+    "seq": 141,
+    "timestamp": "2026-04-29T10:20:29-07:00",
+    "commit_hash": "4cb828fb96b0d7102a17f345aa8cf96684fb6ed1",
+    "commit_short": "4cb828f",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 142,
+    "timestamp": "2026-04-29T10:20:03-07:00",
+    "commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5",
+    "commit_short": "a91df5c",
+    "code_fingerprint": "f1786ef0b28fbb6e56b257e956aef6c9e6886e4465b8df0479468c06532e012e",
+    "primary_filename": "folder-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "folder-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 18 hunk(s), +79/-20. folder-v1.html @@ -108,6 +108,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .h-left{display:flex;align-items:center;gap:8px;flex-shrink:0} | - no removed line sample || folder-v1.html @@ -124,9 +125,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + #t-body.left-collapsed{grid-template-columns:0 0 1fr} | - no removed line sample || folder-v1.html @@ -180,6 +184,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font- | + .file-main{display:grid;grid-template-columns:minmax(380px,1fr) minmax(300px,40%);flex:1;min-height:0} | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "a91df5c90b90d2debc24f01d5f627ec973ad05e5:folder-v1.html"
+    ],
+    "launch_ref": "folder-v1.html",
+    "note": "Diff-evidenced impacts: normalization, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3771cba07ddd8d7bc9dc1b5bf93141e7f9d184a7",
+    "diff_evidence": [
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -108,6 +108,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".h-left{display:flex;align-items:center;gap:8px;flex-shrink:0}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -124,9 +125,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "#t-body.left-collapsed{grid-template-columns:0 0 1fr}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -180,6 +184,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".file-main{display:grid;grid-template-columns:minmax(380px,1fr) minmax(300px,40%);flex:1;min-height:0}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -227,6 +238,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": ".portal-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;padding:12px;overflow:auto}",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -361,11 +374,16 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"h-left\">",
+        "remove": "<span class=\"h-pvr\" id=\"h-pvr\">—</span>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -373,7 +391,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "",
+        "remove": "<button class=\"btn btn-ghost btn-sm\" id=\"btn-disconnect\">Disconnect</button>"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -396,6 +413,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div id=\"v-portal\" class=\"hidden\">",
+        "remove": ""
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -407,11 +431,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-",
+        "add": "<div class=\"file-main\">",
+        "remove": "<div class=\"tbl-wrap\">"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -509,7 +542,7 @@ const st = {",
+        "add": "files:{ sortCol:'effectiveDate', sortDir:'desc', classFilter:null, stackFilter:null, selectedId:null },",
+        "remove": "files:{ sortCol:'effectiveDate', sortDir:'desc', classFilter:null, stackFilter:null },"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1220,7 +1253,7 @@ const TreeView = {",
+        "add": "a.addEventListener('click',e=>{e.stopPropagation();st.files.selectedId=file.id;FileViewer.open(file,true);this.renderFileTable();});",
+        "remove": "a.addEventListener('click',e=>{e.stopPropagation();FileViewer.open(file);});"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1237,7 +1270,8 @@ const TreeView = {",
+        "add": "if(st.files.selectedId===file.id) row.classList.add('row-sel');",
+        "remove": "row.addEventListener('click',()=>FileViewer.open(file));"
+      },
+      {
+        "file": "folder-v1.html",
+        "hunk": "@@ -1416,7 +1450,12 @@ const Timeline = {",
+        "add": "async open(file,inline=false){",
+        "remove": "async open(file){"
+      }
+    ],
+    "patch_hash": "f1786ef0b28fbb6e56b257e956aef6c9e6886e4465b8df0479468c06532e012e"
+  },
+  {
+    "seq": 143,
+    "timestamp": "2026-04-29T10:13:39-07:00",
+    "commit_hash": "3771cba07ddd8d7bc9dc1b5bf93141e7f9d184a7",
+    "commit_short": "3771cba",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 144,
+    "timestamp": "2026-04-29T10:09:14-07:00",
+    "commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f",
+    "commit_short": "da34712",
+    "code_fingerprint": "1e06043cd0030a497fc58aad99c67809600395c9ea1d55fa985ff54cb2af3104",
+    "primary_filename": "mvp.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "mvp.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 1 hunk(s), +1200/-0. mvp.html @@ -0,0 +1,1200 @@ | + <!DOCTYPE html> | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "translation",
+      "joining/rejoining flow",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "da3471207c91bbb0eab4c89b80cb7d0e8896375f:mvp.html"
+    ],
+    "launch_ref": "mvp.html",
+    "note": "Diff-evidenced impacts: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2",
+    "diff_evidence": [
+      {
+        "file": "mvp.html",
+        "hunk": "@@ -0,0 +1,1200 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "1e06043cd0030a497fc58aad99c67809600395c9ea1d55fa985ff54cb2af3104"
+  },
+  {
+    "seq": 145,
+    "timestamp": "2026-04-29T04:02:01-07:00",
+    "commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2",
+    "commit_short": "334bb37",
+    "code_fingerprint": "597f08ccd96f53d0613bdf40db730ac48ca002fdb94a65801088dbb819520b7f",
+    "primary_filename": "bridge4.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge4.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 42 hunk(s), +257/-212. bridge4.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v2.9 --> | - <!-- talkbridge · dcr · v3.0.8 --> || bridge4.html @@ -33,11 +33,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .lobby-link-row{display:flex;gap:8px;} | - .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;} || bridge4.html @@ -71,7 +73,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* v2.9: video control buttons in transcript strip */ | - /* v3.0.6: video control buttons in transcript strip */",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "334bb3779a443984362ae932b2d77b7d7449eca2:bridge4.html"
+    ],
+    "launch_ref": "bridge4.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "c5dcad79008fa3bab84889ea0282052e4039a7cd",
+    "diff_evidence": [
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v2.9 -->",
+        "remove": "<!-- talkbridge · dcr · v3.0.8 -->"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -33,11 +33,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".lobby-link-row{display:flex;gap:8px;}",
+        "remove": ".modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;}"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -71,7 +73,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v2.9: video control buttons in transcript strip */",
+        "remove": "/* v3.0.6: video control buttons in transcript strip */"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -82,8 +84,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.78);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;}"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -181,20 +185,19 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v2.9: Joiner landing page */",
+        "remove": "/* v3.0.6: Joiner landing page */"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -205,7 +208,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"lobby-btn\" id=\"open-create-modal-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>",
+        "remove": "<button class=\"lobby-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -222,32 +226,45 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div id=\"recent-rooms-list\" style=\"max-height:36dvh;overflow-y:auto;\"></div>",
+        "remove": "<div class=\"recent-rooms-scroll\" id=\"recent-rooms-list\"></div>"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -255,7 +272,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"joining-label\" id=\"joining-label\">Joining call…</div>",
+        "remove": "<div class=\"joining-label\">Joining call…</div>"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -288,36 +305,36 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\">",
+        "remove": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px 24px;background:#0a1a1a;\">"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -335,15 +352,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<button class=\"call-transcript-btn\" onclick=\"copyTr()\" title=\"Copy\">"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -390,7 +403,7 @@ var LANGS=[",
+        "add": "var room={id:null,myLang:'',theirLang:'',role:null,name:'',solo:false};",
+        "remove": "var room={id:null,myLang:'',theirLang:'',role:null,name:''};"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -400,7 +413,7 @@ var micOn=true,camOn=true,makingOffer=false;",
+        "add": "var hbTimer=null,seq=0,wsReconnectTimer=null,_relayFailCount=0;",
+        "remove": "var hbTimer=null,seq=0,wsReconnectTimer=null;"
+      }
+    ],
+    "patch_hash": "597f08ccd96f53d0613bdf40db730ac48ca002fdb94a65801088dbb819520b7f"
+  },
+  {
+    "seq": 146,
+    "timestamp": "2026-04-29T03:47:24-07:00",
+    "commit_hash": "c5dcad79008fa3bab84889ea0282052e4039a7cd",
+    "commit_short": "c5dcad7",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 147,
+    "timestamp": "2026-04-29T03:43:03-07:00",
+    "commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b",
+    "commit_short": "edb2b14",
+    "code_fingerprint": "adcaa871588b0cf77fca60db45f67dc10ca76d052c26cfae57b7011525be85c6",
+    "primary_filename": "bridge3.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge3.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 7 hunk(s), +33/-10. bridge3.html @@ -310,6 +310,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"thankyou-sub\" id=\"thankyou-sub-host\" style=\"opacity:.5;font-size:12px;margin-top:-12px;\"></div> | - no removed line sample || bridge3.html @@ -424,12 +425,20 @@ var savedOffer=null; // Creator stores offer here so it can be resent when joine | + // Top bar auto-show — no top bar element; kept as no-op for onclick handler on call-videos | - // Top bar auto-show || bridge3.html @@ -670,7 +679,13 @@ function exportRoomTr(id){ | + function copyRoomTr(id){ | - function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toast('No transcript');return}var t=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}",
+    "functional_impacts": [
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "edb2b1455cbbe3e5b0a15b998acc68931606ae9b:bridge3.html"
+    ],
+    "launch_ref": "bridge3.html",
+    "note": "Diff-evidenced impacts: transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "e5cc4459d6810f99e3905e7e1a754c162a8e7d80",
+    "diff_evidence": [
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -310,6 +310,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-sub\" id=\"thankyou-sub-host\" style=\"opacity:.5;font-size:12px;margin-top:-12px;\"></div>",
+        "remove": ""
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -424,12 +425,20 @@ var savedOffer=null; // Creator stores offer here so it can be resent when joine",
+        "add": "// Top bar auto-show — no top bar element; kept as no-op for onclick handler on call-videos",
+        "remove": "// Top bar auto-show"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -670,7 +679,13 @@ function exportRoomTr(id){",
+        "add": "function copyRoomTr(id){",
+        "remove": "function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toast('No transcript');return}var t=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -1254,6 +1269,7 @@ async function toggleMic(){",
+        "add": "stopDeepgram();",
+        "remove": ""
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -1261,13 +1277,14 @@ async function toggleMic(){",
+        "add": "// Unmute: re-acquire real mic, replace silent track, restart Deepgram",
+        "remove": "// Unmute: re-acquire real mic, replace silent track"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -1346,7 +1363,6 @@ function cleanUp(){",
+        "add": "",
+        "remove": "$('call-top-bar').classList.remove('show');clearTimeout(topBarHideTimer);"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -1366,7 +1382,14 @@ $('local-video').addEventListener('click',swapVideos);",
+        "add": "window.addEventListener('popstate',function(){",
+        "remove": "window.addEventListener('popstate',function(){var tyShowing=$('thankyou-page')&&$('thankyou-page').classList.contains('show');var jlShowing=$('joiner-landing')&&$('joiner-landing').classList.contains('show');if(tyShowing||jlShowing){history.pushState({},'',location.pathname);return;}if(lobbyState===LS.call&&room.id){hangUp();return}if(room.role==='joiner'){history.pushState({},'',location.pathname);return;}});"
+      }
+    ],
+    "patch_hash": "adcaa871588b0cf77fca60db45f67dc10ca76d052c26cfae57b7011525be85c6"
+  },
+  {
+    "seq": 148,
+    "timestamp": "2026-04-29T02:48:36-07:00",
+    "commit_hash": "e5cc4459d6810f99e3905e7e1a754c162a8e7d80",
+    "commit_short": "e5cc445",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 149,
+    "timestamp": "2026-04-29T02:43:41-07:00",
+    "commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6",
+    "commit_short": "5de44ec",
+    "code_fingerprint": "b59df86da5495be79f711042396670871c56ea2a87a0a82e01a3f40f55545e6b",
+    "primary_filename": "bridge3.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge3.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 31 hunk(s), +301/-86. bridge3.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v2.9 --> | - <!-- talkbridge · dcr · v2.3 --> || bridge3.html @@ -73,7 +73,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* v2.9: video control buttons in transcript strip */ | - /* v2.3: video control buttons in transcript strip */ || bridge3.html @@ -84,7 +84,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.78);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;} | - .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "5de44ec461db4973f9253be2f1224da1bc802af6:bridge3.html"
+    ],
+    "launch_ref": "bridge3.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579",
+    "diff_evidence": [
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v2.9 -->",
+        "remove": "<!-- talkbridge · dcr · v2.3 -->"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -73,7 +73,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v2.9: video control buttons in transcript strip */",
+        "remove": "/* v2.3: video control buttons in transcript strip */"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -84,7 +84,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.78);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -95,7 +98,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:6px 4px 6px 2px;position:sticky;top:0;background:var(--bg);z-index:1;gap:6px;}",
+        "remove": ".call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:8px 0;position:sticky;top:0;background:var(--bg);z-index:1;gap:8px;}"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -182,18 +185,18 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v2.9: Joiner landing page */",
+        "remove": "/* v2.3: Joiner landing page */"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -205,10 +208,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"lobby-btn\" id=\"open-create-modal-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>",
+        "remove": "<input class=\"lobby-input\" id=\"room-name\" placeholder=\"Room name\" maxlength=\"60\">"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -222,12 +226,12 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div id=\"recent-rooms-list\" style=\"max-height:36dvh;overflow-y:auto;\"></div>",
+        "remove": "<div id=\"recent-rooms-list\"></div>"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -245,9 +249,30 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"modal-backdrop\" id=\"create-room-backdrop\" style=\"display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;align-items:center;justify-content:center;\">",
+        "remove": "<div class=\"joining-label\">Joining call…</div>"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -274,24 +299,41 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"joiner-lang-pill\" id=\"joiner-lang-pill\"></div>",
+        "remove": "<button class=\"joiner-join-btn\" onclick=\"joinerProceed()\">Join Call</button>"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -309,15 +351,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<button class=\"call-transcript-btn\" onclick=\"shareLink()\" title=\"Share\">"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -374,7 +412,7 @@ var micOn=true,camOn=true,makingOffer=false;",
+        "add": "var hbTimer=null,seq=0,wsReconnectTimer=null,_relayFailCount=0;",
+        "remove": "var hbTimer=null,seq=0,wsReconnectTimer=null;"
+      },
+      {
+        "file": "bridge3.html",
+        "hunk": "@@ -486,15 +524,19 @@ async function sendChat(){",
+        "add": "// Step 1: normalize typed text to room.myLang",
+        "remove": "// Step 1: ALWAYS normalize to room.myLang if user typed a different language"
+      }
+    ],
+    "patch_hash": "b59df86da5495be79f711042396670871c56ea2a87a0a82e01a3f40f55545e6b"
+  },
+  {
+    "seq": 150,
+    "timestamp": "2026-04-29T02:02:52-07:00",
+    "commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579",
+    "commit_short": "d226e42",
+    "code_fingerprint": "c04e237dc345efd5272f3d6c99e7eea2e50daa2f1b7105b2661239b839f92c63",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 20 hunk(s), +117/-76. bridge5.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.0.7 --> | - <!-- talkbridge · dcr · v3.0.8 --> || bridge5.html @@ -82,8 +82,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} | - .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;} || bridge5.html @@ -191,7 +190,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .thankyou-page.show{display:flex;} | - .thankyou-page.show{display:flex!important;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "d226e42a50e87bcca0724c882cfffe7870b16579:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad",
+    "diff_evidence": [
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.0.7 -->",
+        "remove": "<!-- talkbridge · dcr · v3.0.8 -->"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -82,8 +82,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -191,7 +190,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".thankyou-page.show{display:flex;}",
+        "remove": ".thankyou-page.show{display:flex!important;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -227,7 +226,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<span style=\"font-size:10px;color:var(--text-muted);\">v3.0.7</span>",
+        "remove": "<span style=\"font-size:10px;color:var(--text-muted);\">v3.0.6</span>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -288,33 +287,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\">",
+        "remove": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px 24px;background:#0a1a1a;\">"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -399,7 +386,7 @@ var pc=null,videoStream=null,remoteStream=null;",
+        "add": "var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500;",
+        "remove": "var localSubSeq=0,transcript=[],trCache=new Map();"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -437,17 +424,6 @@ function _loadFastText(){",
+        "add": "",
+        "remove": "function _detectScriptRange(text){"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -514,18 +490,21 @@ async function sendChat(){",
+        "add": "// Step 1: normalize to myLang — 150ms race: WASM or sync fallback",
+        "remove": "// Step 1: normalize — instant for non-Latin scripts, WASM for Latin"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -616,11 +595,49 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+        "add": "function translateWithRetry(text,from,to,retries){",
+        "remove": "var k=from+'|'+to+'|'+text;if(trCache.has(k))return Promise.resolve(trCache.get(k));"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -842,7 +859,6 @@ function handleRelay(d){",
+        "add": "",
+        "remove": "if(d.type==='mic-state'){var rmo=document.getElementById('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -941,7 +957,7 @@ async function setupPC(){",
+        "add": "if(s==='disconnected'){showPartnerDisconnected(L('disconnected'));}",
+        "remove": "if(s==='disconnected'){log('rtc_disconnected_transient',{},'warn');}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1024,27 +1040,33 @@ function onDGFinal(text){",
+        "add": "// Normalize: 150ms race — WASM for mixed/latin, sync fallback for script-range",
+        "remove": "// Normalize: script-range instant, WASM for Latin"
+      }
+    ],
+    "patch_hash": "c04e237dc345efd5272f3d6c99e7eea2e50daa2f1b7105b2661239b839f92c63"
+  },
+  {
+    "seq": 151,
+    "timestamp": "2026-04-29T01:59:17-07:00",
+    "commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad",
+    "commit_short": "075ddc1",
+    "code_fingerprint": "9a4155d76e21298008ce53d9776cf0478aa876eb0495dd9beabc87118e4fc321",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 7 hunk(s), +34/-19. bridge5.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.0.8 --> | - <!-- talkbridge · dcr · v3.0.7 --> || bridge5.html @@ -288,12 +288,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + <div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px 24px;background:#0a1a1a;\"> | - <div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\"> || bridge5.html @@ -429,6 +437,17 @@ function _loadFastText(){ | + function _detectScriptRange(text){ | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "80f7e99160da6d88863758680feec842cde59544",
+    "diff_evidence": [
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.0.8 -->",
+        "remove": "<!-- talkbridge · dcr · v3.0.7 -->"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -288,12 +288,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px 24px;background:#0a1a1a;\">",
+        "remove": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\">"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -429,6 +437,17 @@ function _loadFastText(){",
+        "add": "function _detectScriptRange(text){",
+        "remove": ""
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -495,15 +514,12 @@ async function sendChat(){",
+        "add": "// Step 1: normalize — instant for non-Latin scripts, WASM for Latin",
+        "remove": "// Step 1: normalize to myLang — 150ms race: WASM or sync fallback"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -925,7 +941,7 @@ async function setupPC(){",
+        "add": "if(s==='disconnected'){log('rtc_disconnected_transient',{},'warn');}",
+        "remove": "if(s==='disconnected'){showPartnerDisconnected(L('disconnected'));}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1008,11 +1024,9 @@ function onDGFinal(text){",
+        "add": "// Normalize: script-range instant, WASM for Latin",
+        "remove": "// Normalize: 150ms race — WASM for mixed/latin, sync fallback for script-range"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1261,6 +1275,7 @@ function showThankYou(msg){",
+        "add": "var sh=$('thankyou-sub-host');if(sh)sh.textContent=L('close_tab',hl);",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "9a4155d76e21298008ce53d9776cf0478aa876eb0495dd9beabc87118e4fc321"
+  },
+  {
+    "seq": 152,
+    "timestamp": "2026-04-29T01:03:40-07:00",
+    "commit_hash": "80f7e99160da6d88863758680feec842cde59544",
+    "commit_short": "80f7e99",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "74b6cc2ccd14140b8ff3c6334c82a0441e030788",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 153,
+    "timestamp": "2026-04-29T00:59:58-07:00",
+    "commit_hash": "74b6cc2ccd14140b8ff3c6334c82a0441e030788",
+    "commit_short": "74b6cc2",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "a99c5f67c13ad33e75e4b984167778c985c100ef",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 154,
+    "timestamp": "2026-04-29T00:59:32-07:00",
+    "commit_hash": "a99c5f67c13ad33e75e4b984167778c985c100ef",
+    "commit_short": "a99c5f6",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 155,
+    "timestamp": "2026-04-29T00:16:16-07:00",
+    "commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388",
+    "commit_short": "b940a35",
+    "code_fingerprint": "fdb02fb6d97abec8dd5d7433b022cc956430f63f5bbbf80ea33da467701d48eb",
+    "primary_filename": "bridge4.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge4.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 39 hunk(s), +297/-112. bridge4.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.0.8 --> | - <!-- talkbridge · dcr · v2.4 --> || bridge4.html @@ -33,13 +33,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;} | - .lobby-link-row{display:flex;gap:8px;} || bridge4.html @@ -73,7 +71,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* v3.0.6: video control buttons in transcript strip */ | - /* v2.4: video control buttons in transcript strip */",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "b940a35c57c2249a1556ec296ab98ce1c4ab8388:bridge4.html"
+    ],
+    "launch_ref": "bridge4.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "fda8ffabef024f45583ed863e8583d8382b84b71",
+    "diff_evidence": [
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.0.8 -->",
+        "remove": "<!-- talkbridge · dcr · v2.4 -->"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -33,13 +33,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;}",
+        "remove": ".lobby-link-row{display:flex;gap:8px;}"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -73,7 +71,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v3.0.6: video control buttons in transcript strip */",
+        "remove": "/* v2.4: video control buttons in transcript strip */"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -84,7 +82,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -95,7 +94,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:6px 4px 6px 2px;position:sticky;top:0;background:var(--bg);z-index:1;gap:6px;}",
+        "remove": ".call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:8px 0;position:sticky;top:0;background:var(--bg);z-index:1;gap:8px;}"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -182,19 +181,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v3.0.6: Joiner landing page */",
+        "remove": "/* v2.4: Joiner landing page */"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -205,10 +205,10 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"lobby-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>",
+        "remove": "<input class=\"lobby-input\" id=\"room-name\" placeholder=\"Room name\" maxlength=\"60\">"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -222,29 +222,37 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"recent-rooms-scroll\" id=\"recent-rooms-list\"></div>",
+        "remove": "<div id=\"recent-rooms-list\"></div>"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -277,23 +285,39 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"joiner-join-btn\" id=\"joiner-join-btn\" onclick=\"joinerProceed()\">Join Call</button>",
+        "remove": "<button class=\"joiner-join-btn\" onclick=\"joinerProceed()\">Join Call</button>"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -311,7 +335,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"call-transcript-btn\" id=\"strip-share-btn\" onclick=\"shareLink()\" title=\"Share\" style=\"display:none;\">",
+        "remove": "<button class=\"call-transcript-btn\" onclick=\"shareLink()\" title=\"Share\">"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -366,7 +390,7 @@ var LANGS=[",
+        "add": "var room={id:null,myLang:'',theirLang:'',role:null,name:''};",
+        "remove": "var room={id:null,myLang:'',theirLang:'',role:null,name:'',solo:false};"
+      },
+      {
+        "file": "bridge4.html",
+        "hunk": "@@ -386,15 +410,8 @@ var dgKeyVerified=false,dgKeyVerifyTimer=null;",
+        "add": "",
+        "remove": "var topBarHideTimer=null;"
+      }
+    ],
+    "patch_hash": "fdb02fb6d97abec8dd5d7433b022cc956430f63f5bbbf80ea33da467701d48eb"
+  },
+  {
+    "seq": 156,
+    "timestamp": "2026-04-28T23:49:17-07:00",
+    "commit_hash": "fda8ffabef024f45583ed863e8583d8382b84b71",
+    "commit_short": "fda8ffa",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "425d9040a45366684ce38b4d6e1046ffffda1578",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 157,
+    "timestamp": "2026-04-28T23:20:20-07:00",
+    "commit_hash": "425d9040a45366684ce38b4d6e1046ffffda1578",
+    "commit_short": "425d904",
+    "code_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "primary_filename": "N/A",
+    "changed_paths": [],
+    "description_delta_from_previous": "No code diff from previous commit.",
+    "functional_impacts": [],
+    "blob_refs": [],
+    "launch_ref": "N/A",
+    "note": "No prioritized behavior category detected from diff hunks.",
+    "previous_commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18",
+    "diff_evidence": [],
+    "patch_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  {
+    "seq": 158,
+    "timestamp": "2026-04-28T23:16:44-07:00",
+    "commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18",
+    "commit_short": "9562b49",
+    "code_fingerprint": "a3aed8ccb9a777a0c4a266a828ee6e10a86e40a27af83d9bb7c4cb4364d58ddc",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 10 hunk(s), +18/-22. bridge5.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.0.7 --> | - <!-- talkbridge · dcr · v3.0.6 --> || bridge5.html @@ -82,7 +82,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;} | - .no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;} || bridge5.html @@ -190,7 +191,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .thankyou-page.show{display:flex!important;} | - .thankyou-page.show{display:flex;}",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "9562b493dc73cbcf7078ce1158ccce866241ac18:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b",
+    "diff_evidence": [
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.0.7 -->",
+        "remove": "<!-- talkbridge · dcr · v3.0.6 -->"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -82,7 +82,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}#remote-mic-off.show{display:block!important;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -190,7 +191,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".thankyou-page.show{display:flex!important;}",
+        "remove": ".thankyou-page.show{display:flex;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -292,16 +293,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div style=\"display:flex;align-items:center;gap:6px;opacity:.6;margin-top:-8px;\"><span id=\"thankyou-host-pill\" style=\"font-size:22px;\"></span><span id=\"thankyou-title-host\" style=\"font-size:13px;color:rgba(255,255,255,.7);font-family:'Lora',serif;\"></span></div>",
+        "remove": "<button class=\"thankyou-btn\" onclick=\"copyLogText();toast('Log copied')\">📋 Copy log</button>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -494,7 +499,7 @@ async function sendChat(){",
+        "add": "new Promise(function(res){setTimeout(function(){res(null);},150);})",
+        "remove": "new Promise(function(res){setTimeout(function(){res(detectLang(text,src));},150);})"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -821,6 +826,7 @@ function handleRelay(d){",
+        "add": "if(d.type==='mic-state'){var rmo=document.getElementById('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}",
+        "remove": ""
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1005,7 +1011,7 @@ function onDGFinal(text){",
+        "add": "new Promise(function(res){setTimeout(function(){res(null);},150);})",
+        "remove": "new Promise(function(res){setTimeout(function(){res(detectLang(text,src));},150);})"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1224,6 +1230,7 @@ async function toggleMic(){",
+        "add": "relaySend({type:'mic-state',micOn:micOn});",
+        "remove": ""
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1250,6 +1257,10 @@ function showThankYou(msg){",
+        "add": "var hp=$('thankyou-host-pill'),ht=$('thankyou-title-host');",
+        "remove": ""
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1257,22 +1268,7 @@ function showThankYou(msg){",
+        "add": "showThankYou();",
+        "remove": "stopDeepgram();"
+      }
+    ],
+    "patch_hash": "a3aed8ccb9a777a0c4a266a828ee6e10a86e40a27af83d9bb7c4cb4364d58ddc"
+  },
+  {
+    "seq": 159,
+    "timestamp": "2026-04-28T22:46:25-07:00",
+    "commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b",
+    "commit_short": "76a9c93",
+    "code_fingerprint": "4207d74943cc176f1fe5563c6f4859a2356d680e43096672e22e9b076f081889",
+    "primary_filename": "bridge5.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge5.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 1 file(s), 43 hunk(s), +242/-290. bridge5.html @@ -1,5 +1,5 @@ | + <!-- talkbridge · dcr · v3.0.6 --> | - <!-- talkbridge · dcr · v3.8 --> || bridge5.html @@ -33,13 +33,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;} | - .lobby-link-row{display:flex;gap:8px;} || bridge5.html @@ -73,7 +71,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\" | + /* v3.0.6: video control buttons in transcript strip */ | - /* v3.8: video control buttons in transcript strip */",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "76a9c93a783e1ac0b80d939a3062007dd82e609b:bridge5.html"
+    ],
+    "launch_ref": "bridge5.html",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960",
+    "diff_evidence": [
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -1,5 +1,5 @@",
+        "add": "<!-- talkbridge · dcr · v3.0.6 -->",
+        "remove": "<!-- talkbridge · dcr · v3.8 -->"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -33,13 +33,11 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;}",
+        "remove": ".lobby-link-row{display:flex;gap:8px;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -73,7 +71,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v3.0.6: video control buttons in transcript strip */",
+        "remove": "/* v3.8: video control buttons in transcript strip */"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -84,10 +82,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}",
+        "remove": ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.78);z-index:2;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -185,19 +180,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "/* v3.0.6: Joiner landing page */",
+        "remove": "/* v3.8: Joiner landing page */"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -208,8 +204,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"lobby-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>",
+        "remove": "<button class=\"lobby-btn\" id=\"open-create-modal-btn\" onclick=\"openCreateRoomModal()\">＋ Create new room</button>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -226,45 +221,32 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"recent-rooms-scroll\" id=\"recent-rooms-list\"></div>",
+        "remove": "<div id=\"recent-rooms-list\" style=\"max-height:36dvh;overflow-y:auto;\"></div>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -272,7 +254,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"joining-label\">Joining call…</div>",
+        "remove": "<div class=\"joining-label\" id=\"joining-label\">Joining call…</div>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -292,7 +274,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "",
+        "remove": "<button class=\"log-btn\" onclick=\"exportRoomTr()\">Export</button>"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -306,35 +287,24 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<div class=\"thankyou-page\" id=\"thankyou-page\" style=\"position:fixed;inset:0;z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;background:#0a1a1a;\">",
+        "remove": "<div class=\"thankyou-page\" id=\"thankyou-page\">"
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -352,11 +322,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+        "add": "<button class=\"call-transcript-btn\" onclick=\"copyTr()\" title=\"Copy\">",
+        "remove": ""
+      },
+      {
+        "file": "bridge5.html",
+        "hunk": "@@ -403,7 +377,7 @@ var LANGS=[",
+        "add": "var room={id:null,myLang:'',theirLang:'',role:null,name:''};",
+        "remove": "var room={id:null,myLang:'',theirLang:'',role:null,name:'',solo:false};"
+      }
+    ],
+    "patch_hash": "4207d74943cc176f1fe5563c6f4859a2356d680e43096672e22e9b076f081889"
+  },
+  {
+    "seq": 160,
+    "timestamp": "2026-04-28T22:28:50-07:00",
+    "commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960",
+    "commit_short": "3ecf332",
+    "code_fingerprint": "e48c2780ab268b54f65b1b6d276c8cc93bcb4e945469791aaf5c07250458d211",
+    "primary_filename": ".bolt/config.json",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": ".bolt/config.json"
+      },
+      {
+        "status": "A",
+        "path": ".bolt/prompt"
+      },
+      {
+        "status": "A",
+        "path": ".github/workflows/static.yml"
+      },
+      {
+        "status": "A",
+        "path": ".gitignore"
+      },
+      {
+        "status": "A",
+        "path": "2vid.html"
+      },
+      {
+        "status": "A",
+        "path": "Boid-fun.html"
+      },
+      {
+        "status": "A",
+        "path": "FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md"
+      },
+      {
+        "status": "A",
+        "path": "GET_WELL_PATCH_PROMPT.md"
+      },
+      {
+        "status": "A",
+        "path": "Instructions.txt"
+      },
+      {
+        "status": "A",
+        "path": "MyPlaceToChill.html"
+      },
+      {
+        "status": "A",
+        "path": "QA_LIFECYCLE_SCRIPT.md"
+      },
+      {
+        "status": "A",
+        "path": "README.md"
+      },
+      {
+        "status": "A",
+        "path": "SECRETS.md"
+      },
+      {
+        "status": "A",
+        "path": "SESSION_INSTRUCTION_SET.md"
+      },
+      {
+        "status": "A",
+        "path": "TALK-SAY-PRD-v1.md"
+      },
+      {
+        "status": "A",
+        "path": "TALK-SAY-PRD.md"
+      },
+      {
+        "status": "A",
+        "path": "Talk-Say-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "UI-v2.html.html"
+      },
+      {
+        "status": "A",
+        "path": "Visual MAD v3.html"
+      },
+      {
+        "status": "A",
+        "path": "ai-jobs-kanban (3).html"
+      },
+      {
+        "status": "A",
+        "path": "ai-jobs-kanban.json"
+      },
+      {
+        "status": "A",
+        "path": "app.html"
+      },
+      {
+        "status": "A",
+        "path": "battle.html"
+      },
+      {
+        "status": "A",
+        "path": "biord.html"
+      },
+      {
+        "status": "A",
+        "path": "block.html"
+      },
+      {
+        "status": "A",
+        "path": "blue.html"
+      },
+      {
+        "status": "A",
+        "path": "boid perp-plus.html"
+      },
+      {
+        "status": "A",
+        "path": "boid-perp.html"
+      },
+      {
+        "status": "A",
+        "path": "boidfloid wb.html"
+      },
+      {
+        "status": "A",
+        "path": "boidfloid-pro.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (20).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (5).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (6).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge (7).html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-c.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-dcr.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-transcript-analysis.md"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge1-test-matrix.md"
+      },
+      {
+        "status": "A",
+        "path": "bridge1.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge2.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge3.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge4.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5a.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5b.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge5c.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge6.html"
+      },
+      {
+        "status": "A",
+        "path": "bridge8.html"
+      },
+      {
+        "status": "A",
+        "path": "buildit.html"
+      },
+      {
+        "status": "A",
+        "path": "casa.html"
+      },
+      {
+        "status": "A",
+        "path": "chat.html"
+      },
+      {
+        "status": "A",
+        "path": "clock.html"
+      },
+      {
+        "status": "A",
+        "path": "combined_oauth_server_for_repo.js"
+      },
+      {
+        "status": "A",
+        "path": "compound.html"
+      },
+      {
+        "status": "A",
+        "path": "convo.html"
+      },
+      {
+        "status": "A",
+        "path": "core.html"
+      },
+      {
+        "status": "A",
+        "path": "currency.html"
+      },
+      {
+        "status": "A",
+        "path": "dash.html"
+      },
+      {
+        "status": "A",
+        "path": "dev.html"
+      },
+      {
+        "status": "A",
+        "path": "dg.html"
+      },
+      {
+        "status": "A",
+        "path": "diag.html"
+      },
+      {
+        "status": "A",
+        "path": "do.html"
+      },
+      {
+        "status": "A",
+        "path": "dualtime.html"
+      },
+      {
+        "status": "A",
+        "path": "enhanced-fixed.js"
+      },
+      {
+        "status": "A",
+        "path": "enhanced-hitomezashi.html"
+      },
+      {
+        "status": "A",
+        "path": "enhanced.js"
+      },
+      {
+        "status": "A",
+        "path": "eslint.config.js"
+      },
+      {
+        "status": "A",
+        "path": "fastType/deleteme"
+      },
+      {
+        "status": "A",
+        "path": "fastType/fastText.common.wasm"
+      },
+      {
+        "status": "A",
+        "path": "fastType/lid.176.ftz"
+      },
+      {
+        "status": "A",
+        "path": "fetch-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "fetch.html"
+      },
+      {
+        "status": "A",
+        "path": "finapp.html"
+      },
+      {
+        "status": "A",
+        "path": "flags.png"
+      },
+      {
+        "status": "A",
+        "path": "fly.html"
+      },
+      {
+        "status": "A",
+        "path": "flyv1.html"
+      },
+      {
+        "status": "A",
+        "path": "flyv2.html"
+      },
+      {
+        "status": "A",
+        "path": "folder-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "folder.html"
+      },
+      {
+        "status": "A",
+        "path": "g.html"
+      },
+      {
+        "status": "A",
+        "path": "ga.html"
+      },
+      {
+        "status": "A",
+        "path": "game.html"
+      },
+      {
+        "status": "A",
+        "path": "gdrive-metadata-extraction.html"
+      },
+      {
+        "status": "A",
+        "path": "getit.html"
+      },
+      {
+        "status": "A",
+        "path": "gg.html"
+      },
+      {
+        "status": "A",
+        "path": "ggg.html"
+      },
+      {
+        "status": "A",
+        "path": "gggg.html"
+      },
+      {
+        "status": "A",
+        "path": "gh.html"
+      },
+      {
+        "status": "A",
+        "path": "gh.html.html"
+      },
+      {
+        "status": "A",
+        "path": "git.html"
+      },
+      {
+        "status": "A",
+        "path": "github.html"
+      },
+      {
+        "status": "A",
+        "path": "glate.html"
+      },
+      {
+        "status": "A",
+        "path": "goji.html"
+      },
+      {
+        "status": "A",
+        "path": "groove.html"
+      },
+      {
+        "status": "A",
+        "path": "groovy.html"
+      },
+      {
+        "status": "A",
+        "path": "gt.html"
+      },
+      {
+        "status": "A",
+        "path": "gtg.html"
+      },
+      {
+        "status": "A",
+        "path": "hexi.html"
+      },
+      {
+        "status": "A",
+        "path": "home.html"
+      },
+      {
+        "status": "A",
+        "path": "index copy.html"
+      },
+      {
+        "status": "A",
+        "path": "index.html"
+      },
+      {
+        "status": "A",
+        "path": "ithub.html"
+      },
+      {
+        "status": "A",
+        "path": "join.html"
+      },
+      {
+        "status": "A",
+        "path": "joy.html"
+      },
+      {
+        "status": "A",
+        "path": "kaleidoscope_visualizer_advanced.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban.json"
+      },
+      {
+        "status": "A",
+        "path": "kanban2.html"
+      },
+      {
+        "status": "A",
+        "path": "kanban3.html"
+      },
+      {
+        "status": "A",
+        "path": "landmark-bridge.html"
+      },
+      {
+        "status": "A",
+        "path": "layout.html"
+      },
+      {
+        "status": "A",
+        "path": "lim.html"
+      },
+      {
+        "status": "A",
+        "path": "liminal_breach_stable_classic_graphics.html"
+      },
+      {
+        "status": "A",
+        "path": "love.html"
+      },
+      {
+        "status": "A",
+        "path": "love2.html"
+      },
+      {
+        "status": "A",
+        "path": "loveit.html"
+      },
+      {
+        "status": "A",
+        "path": "magic+.html"
+      },
+      {
+        "status": "A",
+        "path": "magic.html"
+      },
+      {
+        "status": "A",
+        "path": "menu.html"
+      },
+      {
+        "status": "A",
+        "path": "metadata-sync-worker.js"
+      },
+      {
+        "status": "A",
+        "path": "metadata_extractor_lib.js"
+      },
+      {
+        "status": "A",
+        "path": "metric.html"
+      },
+      {
+        "status": "A",
+        "path": "mic.html"
+      },
+      {
+        "status": "A",
+        "path": "milkyway.html"
+      },
+      {
+        "status": "A",
+        "path": "mob.html"
+      },
+      {
+        "status": "A",
+        "path": "mobapp.html"
+      },
+      {
+        "status": "A",
+        "path": "mobweb (1) (2).html"
+      },
+      {
+        "status": "A",
+        "path": "mobweb.html"
+      },
+      {
+        "status": "A",
+        "path": "noon-dear.html"
+      },
+      {
+        "status": "A",
+        "path": "noon.html"
+      },
+      {
+        "status": "A",
+        "path": "notify.html"
+      },
+      {
+        "status": "A",
+        "path": "onedrive.html"
+      },
+      {
+        "status": "A",
+        "path": "orb.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-dev-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-hold.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-v0.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-gdrive-integrated.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-login.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-metadata-worker.js"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-sw.js"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v10.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v11.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v12.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v13.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14 copy.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14.html.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v14b.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v15.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v3a.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v5-old.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8-v5.html"
+      },
+      {
+        "status": "A",
+        "path": "orbital8.html"
+      },
+      {
+        "status": "A",
+        "path": "p.html"
+      },
+      {
+        "status": "A",
+        "path": "package-lock.json"
+      },
+      {
+        "status": "A",
+        "path": "package.json"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/logging.json"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/script-old.js"
+      },
+      {
+        "status": "A",
+        "path": "packs/global/script.js"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/download.jpeg"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/msg.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/blue/sound.mp3"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/joy/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "packs/local/love/delete.txt"
+      },
+      {
+        "status": "A",
+        "path": "partial.html"
+      },
+      {
+        "status": "A",
+        "path": "peace.html"
+      },
+      {
+        "status": "A",
+        "path": "pend.html"
+      },
+      {
+        "status": "A",
+        "path": "plan.html"
+      },
+      {
+        "status": "A",
+        "path": "playdoh.html"
+      },
+      {
+        "status": "A",
+        "path": "portal-create.html"
+      },
+      {
+        "status": "A",
+        "path": "portal.html"
+      },
+      {
+        "status": "A",
+        "path": "postcss.config.js"
+      },
+      {
+        "status": "A",
+        "path": "quilt.html"
+      },
+      {
+        "status": "A",
+        "path": "rec08.html"
+      },
+      {
+        "status": "A",
+        "path": "reco01.html"
+      },
+      {
+        "status": "A",
+        "path": "reco02.html"
+      },
+      {
+        "status": "A",
+        "path": "reco03.html"
+      },
+      {
+        "status": "A",
+        "path": "reco04.html"
+      },
+      {
+        "status": "A",
+        "path": "reco05.html"
+      },
+      {
+        "status": "A",
+        "path": "reco06.html"
+      },
+      {
+        "status": "A",
+        "path": "reco07.html"
+      },
+      {
+        "status": "A",
+        "path": "repoblast.html"
+      },
+      {
+        "status": "A",
+        "path": "repolist.html"
+      },
+      {
+        "status": "A",
+        "path": "restructure.txt"
+      },
+      {
+        "status": "A",
+        "path": "roll.html"
+      },
+      {
+        "status": "A",
+        "path": "rss.html"
+      },
+      {
+        "status": "A",
+        "path": "sacred.html"
+      },
+      {
+        "status": "A",
+        "path": "say-alpha.html"
+      },
+      {
+        "status": "A",
+        "path": "say.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v2.html.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "sayit.html"
+      },
+      {
+        "status": "A",
+        "path": "scribe.html"
+      },
+      {
+        "status": "A",
+        "path": "scrub.html"
+      },
+      {
+        "status": "A",
+        "path": "shad.html"
+      },
+      {
+        "status": "A",
+        "path": "shader.html"
+      },
+      {
+        "status": "A",
+        "path": "sigma.html"
+      },
+      {
+        "status": "A",
+        "path": "slideswipe.html"
+      },
+      {
+        "status": "A",
+        "path": "solar.html"
+      },
+      {
+        "status": "A",
+        "path": "spin.html"
+      },
+      {
+        "status": "A",
+        "path": "src/App.tsx"
+      },
+      {
+        "status": "A",
+        "path": "src/index.css"
+      },
+      {
+        "status": "A",
+        "path": "src/main.tsx"
+      },
+      {
+        "status": "A",
+        "path": "src/vite-env.d.ts"
+      },
+      {
+        "status": "A",
+        "path": "stars.html"
+      },
+      {
+        "status": "A",
+        "path": "stt-test.html"
+      },
+      {
+        "status": "A",
+        "path": "supabase/functions/venice-ai/index.ts"
+      },
+      {
+        "status": "A",
+        "path": "sw-enhanced.js"
+      },
+      {
+        "status": "A",
+        "path": "sy.html"
+      },
+      {
+        "status": "A",
+        "path": "synesthetic_experience_updated.html"
+      },
+      {
+        "status": "A",
+        "path": "tab.html"
+      },
+      {
+        "status": "A",
+        "path": "tag-example.html"
+      },
+      {
+        "status": "A",
+        "path": "tailwind.config.js"
+      },
+      {
+        "status": "A",
+        "path": "talk-notifications-sw.js"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-claude.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-gemini.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-prd-v1.7.pdf"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.5 (1).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.5 (2).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v1.6.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v3.2 (3).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-v3.2 (5).html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say-venice.html"
+      },
+      {
+        "status": "A",
+        "path": "talk-say.html"
+      },
+      {
+        "status": "A",
+        "path": "talk.html"
+      },
+      {
+        "status": "A",
+        "path": "talk.webmanifest"
+      },
+      {
+        "status": "A",
+        "path": "talk01.html"
+      },
+      {
+        "status": "A",
+        "path": "talkv2.html"
+      },
+      {
+        "status": "A",
+        "path": "tb-app.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-media.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-transcribe.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-translate.js"
+      },
+      {
+        "status": "A",
+        "path": "tb-transport.js"
+      },
+      {
+        "status": "A",
+        "path": "test-outline.md"
+      },
+      {
+        "status": "A",
+        "path": "test-pam (2).html"
+      },
+      {
+        "status": "A",
+        "path": "test-pam-objective-analysis-plan.md"
+      },
+      {
+        "status": "A",
+        "path": "test-pam.html"
+      },
+      {
+        "status": "A",
+        "path": "test-rollback.html"
+      },
+      {
+        "status": "A",
+        "path": "test.html"
+      },
+      {
+        "status": "A",
+        "path": "test01.html"
+      },
+      {
+        "status": "A",
+        "path": "test02.html"
+      },
+      {
+        "status": "A",
+        "path": "test03.html"
+      },
+      {
+        "status": "A",
+        "path": "testplan.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v4.html"
+      },
+      {
+        "status": "A",
+        "path": "thai-transcriber-v7 (3).html"
+      },
+      {
+        "status": "A",
+        "path": "tilt-balance-mobile-fixed-v3-1.html"
+      },
+      {
+        "status": "A",
+        "path": "time.html"
+      },
+      {
+        "status": "A",
+        "path": "tk.html"
+      },
+      {
+        "status": "A",
+        "path": "tksy.html"
+      },
+      {
+        "status": "A",
+        "path": "tracker.html"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.app.json"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.json"
+      },
+      {
+        "status": "A",
+        "path": "tsconfig.node.json"
+      },
+      {
+        "status": "A",
+        "path": "ugh.html"
+      },
+      {
+        "status": "A",
+        "path": "update_test_html_patch_prompt.txt"
+      },
+      {
+        "status": "A",
+        "path": "uri.html"
+      },
+      {
+        "status": "A",
+        "path": "v.html"
+      },
+      {
+        "status": "A",
+        "path": "venice.html"
+      },
+      {
+        "status": "A",
+        "path": "vite.config.ts"
+      },
+      {
+        "status": "A",
+        "path": "voice-c.html"
+      },
+      {
+        "status": "A",
+        "path": "voice.html"
+      },
+      {
+        "status": "A",
+        "path": "voicehelper.html"
+      },
+      {
+        "status": "A",
+        "path": "vsay.html"
+      },
+      {
+        "status": "A",
+        "path": "vvv.html"
+      },
+      {
+        "status": "A",
+        "path": "vvvv.html"
+      },
+      {
+        "status": "A",
+        "path": "week.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v1.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v2.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend-v3.html"
+      },
+      {
+        "status": "A",
+        "path": "weekend.html"
+      },
+      {
+        "status": "A",
+        "path": "x.html"
+      },
+      {
+        "status": "A",
+        "path": "xlate.html"
+      },
+      {
+        "status": "A",
+        "path": "xml.html"
+      },
+      {
+        "status": "A",
+        "path": "zoom.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed 287 file(s), 280 hunk(s), +343512/-0. .bolt/config.json @@ -0,0 +1,3 @@ | + { | - no removed line sample || .bolt/prompt @@ -0,0 +1,5 @@ | + For all designs I ask you to make, have them be beautiful, not cookie cutter. Make webpages that are fully featured and worthy for production. | - no removed line sample || .github/workflows/static.yml @@ -0,0 +1,43 @@ | + # Simple workflow for deploying static content to GitHub Pages | - no removed line sample",
+    "functional_impacts": [
+      "normalization",
+      "transcription",
+      "translation",
+      "joining/rejoining flow",
+      "call termination behavior",
+      "compose strip focus behavior",
+      "ui/ux flow changes",
+      "remediation/repair/fix behavior"
+    ],
+    "blob_refs": [
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/config.json",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/prompt",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.github/workflows/static.yml",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:.gitignore",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:2vid.html",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:Boid-fun.html",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:GET_WELL_PATCH_PROMPT.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:Instructions.txt",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:MyPlaceToChill.html",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:QA_LIFECYCLE_SCRIPT.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:README.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:SECRETS.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:SESSION_INSTRUCTION_SET.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:TALK-SAY-PRD-v1.md",
+      "3ecf3325193e3049bd0adc9853df6c976794f960:TALK-SAY-PRD.md"
+    ],
+    "launch_ref": ".bolt/config.json",
+    "note": "Diff-evidenced impacts: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "previous_commit_hash": null,
+    "diff_evidence": [
+      {
+        "file": ".bolt/config.json",
+        "hunk": "@@ -0,0 +1,3 @@",
+        "add": "{",
+        "remove": ""
+      },
+      {
+        "file": ".bolt/prompt",
+        "hunk": "@@ -0,0 +1,5 @@",
+        "add": "For all designs I ask you to make, have them be beautiful, not cookie cutter. Make webpages that are fully featured and worthy for production.",
+        "remove": ""
+      },
+      {
+        "file": ".github/workflows/static.yml",
+        "hunk": "@@ -0,0 +1,43 @@",
+        "add": "# Simple workflow for deploying static content to GitHub Pages",
+        "remove": ""
+      },
+      {
+        "file": ".gitignore",
+        "hunk": "@@ -0,0 +1,25 @@",
+        "add": "# Logs",
+        "remove": ""
+      },
+      {
+        "file": "2vid.html",
+        "hunk": "@@ -0,0 +1,1787 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "Boid-fun.html",
+        "hunk": "@@ -0,0 +1,264 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md",
+        "hunk": "@@ -0,0 +1,38 @@",
+        "add": "# Final Acceptance Run — Samsung Devices on Chrome Only",
+        "remove": ""
+      },
+      {
+        "file": "GET_WELL_PATCH_PROMPT.md",
+        "hunk": "@@ -0,0 +1,95 @@",
+        "add": "```prompt",
+        "remove": ""
+      },
+      {
+        "file": "Instructions.txt",
+        "hunk": "@@ -0,0 +1,2051 @@",
+        "add": "# Comprehensive Bolt Instructions: Orbital8 Unified Implementation",
+        "remove": ""
+      },
+      {
+        "file": "MyPlaceToChill.html",
+        "hunk": "@@ -0,0 +1,109 @@",
+        "add": "<!DOCTYPE html>",
+        "remove": ""
+      },
+      {
+        "file": "QA_LIFECYCLE_SCRIPT.md",
+        "hunk": "@@ -0,0 +1,133 @@",
+        "add": "# Talk Session End-to-End QA Script (Reference)",
+        "remove": ""
+      },
+      {
+        "file": "README.md",
+        "hunk": "@@ -0,0 +1 @@",
+        "add": "stuff",
+        "remove": ""
+      }
+    ],
+    "patch_hash": "e48c2780ab268b54f65b1b6d276c8cc93bcb4e945469791aaf5c07250458d211"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "axios": "^0.27.2",
     "express": "^4.18.1"
+  },
+  "scripts": {
+    "build:lineage": "node scripts/build-lineage-model.mjs"
   }
 }

--- a/repo.html
+++ b/repo.html
@@ -3,124 +3,52 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Bridge Timeline + Lineage Workbench</title>
+  <title>Bridge Timeline Explorer</title>
   <style>
     :root { --bg:#0f172a; --panel:#111827; --line:#334155; --text:#e2e8f0; --muted:#94a3b8; --brand:#38bdf8; }
     * { box-sizing:border-box; }
     body { margin:0; font-family:Inter,system-ui,sans-serif; background:var(--bg); color:var(--text); }
-    .app { display:grid; grid-template-columns:320px 1fr; height:100vh; }
+    .app { display:grid; grid-template-columns:380px 1fr; height:100vh; }
     .left { background:#020617; border-right:1px solid var(--line); overflow:auto; }
-    .right { overflow:auto; }
     .top { padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:#020617; z-index:10; }
-    .hamburger { background:transparent; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:6px 10px; cursor:pointer; }
-    .search { width:100%; margin-top:8px; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
+    .search { width:100%; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
     .list { padding:10px; display:flex; flex-direction:column; gap:6px; }
     .item { padding:8px; border:1px solid var(--line); border-radius:8px; cursor:pointer; background:#0b1220; }
     .item.active { border-color:var(--brand); }
-    .tabs { display:flex; gap:8px; padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--bg); z-index:5; }
+    .right { overflow:auto; }
+    .tabs { display:flex; gap:8px; padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--bg); }
     .tab { background:#1e293b; color:var(--text); border:1px solid var(--line); border-radius:999px; padding:7px 12px; cursor:pointer; }
     .tab.active { background:var(--brand); color:#001018; border-color:var(--brand); }
     .pane { display:none; padding:10px; }
     .pane.active { display:block; }
-    iframe { width:100%; height:70vh; border:1px solid var(--line); border-radius:10px; background:white; }
-    .grid2 { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
     .card { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:10px; margin-bottom:10px; }
+    iframe { width:100%; height:65vh; border:1px solid var(--line); border-radius:10px; background:white; }
+    .grid2 { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
     .muted{ color:var(--muted); font-size:.9rem; }
-    .hidden-left .left { display:none; }
-    .hidden-left.app { grid-template-columns:1fr; }
-    a{ color:var(--brand); }
+    code { color:#bae6fd; }
   </style>
 </head>
 <body>
-  <div class="app" id="app">
-    <aside class="left">
-      <div class="top">
-        <button class="hamburger" id="toggleNav">☰</button>
-        <input class="search" id="omni" placeholder="Omni search: file, tag, hash" />
-      </div>
-      <div class="list" id="variantList"></div>
-    </aside>
+  <div class="app">
+    <aside class="left"><div class="top"><input class="search" id="omni" placeholder="Search hash, path, impact, summary" /></div><div class="list" id="variantList"></div></aside>
     <main class="right">
-      <div class="tabs">
-        <button class="tab active" data-tab="analysis">Analysis Run</button>
-        <button class="tab" data-tab="results">Lineage Results</button>
-        <button class="tab" data-tab="explorer">Manual Explorer</button>
-        <button class="tab" data-tab="compare">Side-by-Side</button>
-      </div>
-
-      <section class="pane active" id="analysis">
-        <div class="card"><strong>Production + Progress</strong><div class="muted" id="progress">Loading bridge timeline…</div></div>
-        <div class="card" id="analysisLog"></div>
-      </section>
-
-      <section class="pane" id="results">
-        <div class="card"><button class="tab" id="exportModel">Export timeline JSON model</button></div>
-        <div class="card" id="resultsList"></div>
-      </section>
-
-      <section class="pane" id="explorer">
-        <div class="card" id="activeMeta"></div>
-        <iframe id="preview"></iframe>
-      </section>
-
-      <section class="pane" id="compare">
-        <div class="card grid2">
-          <div><select id="leftPick"></select><iframe id="leftFrame"></iframe></div>
-          <div><select id="rightPick"></select><iframe id="rightFrame"></iframe></div>
-        </div>
-      </section>
+      <div class="tabs"><button class="tab active" data-tab="explorer">Explorer</button><button class="tab" data-tab="compare">Side-by-Side</button></div>
+      <section class="pane active" id="explorer"><div class="card" id="activeMeta"></div><iframe id="preview"></iframe></section>
+      <section class="pane" id="compare"><div class="card grid2"><div><select id="leftPick"></select><iframe id="leftFrame"></iframe></div><div><select id="rightPick"></select><iframe id="rightFrame"></iframe></div></div></section>
     </main>
   </div>
 <script>
-let all=[]; let shown=[]; let current=null; let timelineModel=[];
-const $=id=>document.getElementById(id);
+let all=[]; let shown=[]; let current=null; const $=id=>document.getElementById(id);
 function esc(s){return String(s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
-function dt(x){return new Date(x||0).getTime()||0}
-function iso(x){const d=new Date(x||0); return Number.isNaN(d.getTime())?'1970-01-01T00:00:00.000Z':d.toISOString();}
-function inferFocus(tags){if(tags.includes('soft-delete')&&tags.includes('xml'))return 'Soft-delete + XML fix iteration.'; if(tags.includes('soft-delete'))return 'Soft-delete focused.'; if(tags.includes('xml'))return 'XML handling focused.'; if(tags.includes('patched'))return 'Patch stabilization attempt.'; if(tags.includes('restore'))return 'Rollback/restore exploration.'; return 'General iteration.';}
-async function loadBlobText(item){
-  if(item._blobText!==undefined) return item._blobText;
-  try{
-    const res=await fetch(item.blobUrl,{cache:'no-store'});
-    item._blobText=res.ok?await res.text():'';
-  }catch{ item._blobText=''; }
-  return item._blobText;
-}
-function summarizeDelta(prevText,nextText){
-  if(!prevText && nextText) return 'Initial version in timeline.';
-  if(prevText===nextText) return 'No textual delta from previous timeline item.';
-  const a=(prevText||'').split('\n'); const b=(nextText||'').split('\n');
-  let added=0, removed=0;
-  const prevSet=new Set(a); const nextSet=new Set(b);
-  for(const line of b){ if(!prevSet.has(line)) added++; }
-  for(const line of a){ if(!nextSet.has(line)) removed++; }
-  return `Changed from previous variant: +${added} / -${removed} unique lines.`;
-}
-async function buildTimelineModel(){
-  const sorted=[...shown].sort((a,b)=>dt(a.created)-dt(b.created)||dt(a.lastUpdated)-dt(b.lastUpdated));
-  const blobs=await Promise.all(sorted.map(loadBlobText));
-  timelineModel=sorted.map((item,idx)=>({
-    seq: idx+1,
-    timestamp: iso(item.lastUpdated||item.created),
-    commitid: item.commit,
-    filename: item.file,
-    description_delta_from_previous: summarizeDelta(blobs[idx-1]||'', blobs[idx]||''),
-    blob: item.blobUrl,
-    launch: item.launchUrl,
-    note: item.lineageNote||inferFocus(item.tags||[])
-  }));
-}
-function setCurrent(file){current=shown.find(x=>x.file===file)||shown[0]; if(!current)return; $('preview').src=current.launchUrl; $('activeMeta').innerHTML=`<strong>${esc(current.file)}</strong><br><span class='muted'>${esc(current.created)} | ${esc(current.commit.slice(0,10))}</span><div>${inferFocus(current.tags||[])}</div><div><a target='_blank' href='${esc(current.launchUrl)}'>Launch</a> · <a target='_blank' href='${esc(current.blobUrl)}'>Code blob</a></div>`; renderList();}
-function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.file===x.file?'active':''}' data-file='${esc(x.file)}'><strong>${esc(x.file)}</strong><div class='muted'>${esc((x.tags||[]).join(', '))}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrent(n.dataset.file)); }
-function renderResults(){ $('resultsList').innerHTML=timelineModel.map(row=>`<div class='card'><strong>${row.seq}. ${esc(row.filename)}</strong><div class='muted'>${esc(row.timestamp)} · ${esc(row.commitid.slice(0,12))}</div><div>${esc(row.description_delta_from_previous)}</div><div class='muted'>${esc(row.note)}</div></div>`).join(''); }
-function renderAnalysis(){ $('analysisLog').innerHTML=`<ol>${shown.map(x=>`<li><code>${esc(x.file)}</code> — ${esc(inferFocus(x.tags||[]))}</li>`).join('')}</ol>`; $('progress').textContent=`Completed: ${shown.length} bridge variants ordered and indexed.`; }
-function renderCompare(){ const opts=shown.map(x=>`<option value='${esc(x.file)}'>${esc(x.file)}</option>`).join(''); $('leftPick').innerHTML=opts; $('rightPick').innerHTML=opts; if(shown[0]) $('leftFrame').src=shown[0].launchUrl; if(shown[1]) $('rightFrame').src=shown[1].launchUrl; $('leftPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('leftFrame').src=f.launchUrl;}; $('rightPick').onchange=e=>{const f=shown.find(x=>x.file===e.target.value); if(f) $('rightFrame').src=f.launchUrl;}; }
-async function rerender(){ await buildTimelineModel(); renderList(); renderResults(); renderAnalysis(); renderCompare(); if(!current&&shown[0]) setCurrent(shown[0].file); }
-$('omni').oninput=e=>{ const q=e.target.value.toLowerCase().trim(); shown=all.filter(x=>[x.file,x.commit,(x.tags||[]).join(' ')].join(' ').toLowerCase().includes(q)); shown.sort((a,b)=>dt(a.created)-dt(b.created)); current=null; rerender(); };
-$('toggleNav').onclick=()=>$('app').classList.toggle('hidden-left');
-$('exportModel').onclick=()=>{ const out=JSON.stringify(timelineModel,null,2); const blob=new Blob([out],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='bridge-lineage-timeline-model.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url),1000); };
+function launchPath(e){return (e.launch_ref&&e.launch_ref!=='N/A'?e.launch_ref:e.primary_filename)||''}
+function setCurrentBySeq(seq){current=shown.find(x=>x.seq===seq)||shown[0]; if(current) $('preview').src=launchPath(current); renderList(); renderCurrent();}
+function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.seq===x.seq?'active':''}' data-seq='${x.seq}'><strong>#${x.seq} ${esc(x.commit_short)}</strong><div class='muted'>${esc(x.timestamp)} · ${esc(x.primary_filename||'')}</div><div class='muted'>${esc((x.functional_impacts||[]).join(', ')||'no impact tags')}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrentBySeq(Number(n.dataset.seq))); }
+function renderCurrent(){ if(!current) return; $('activeMeta').innerHTML=`<strong>Timeline Entry #${current.seq}</strong><div class='muted'>${esc(current.timestamp)}</div><div><code title='${esc(current.commit_hash)}'>${esc(current.commit_short)}</code> · <span class='muted'>full: ${esc(current.commit_hash)}</span></div><div><strong>code_fingerprint</strong>: <code>${esc(current.code_fingerprint)}</code></div><div><strong>description_delta_from_previous</strong>: ${esc(current.description_delta_from_previous)}</div><div><strong>functional_impacts</strong>: ${esc((current.functional_impacts||[]).join(', ')||'none')}</div><div><strong>diff_evidence</strong><pre>${esc(JSON.stringify(current.diff_evidence||[], null, 2))}</pre></div><div><a target='_blank' href='${esc(launchPath(current))}'>Launch</a> · <a target='_blank' href='${esc(current.blob_refs?.[0] ? `https://example.invalid/blob/${current.blob_refs[0]}` : '#')}'>Blob ref</a></div>`; }
+function renderCompare(){ const opts=shown.map(x=>`<option value='${x.seq}'>#${x.seq} ${esc(x.commit_short)} ${esc(x.primary_filename||'')}</option>`).join(''); $('leftPick').innerHTML=opts; $('rightPick').innerHTML=opts; if(shown[0]) $('leftFrame').src=launchPath(shown[0]); if(shown[1]) $('rightFrame').src=launchPath(shown[1]); $('leftPick').onchange=e=>{const item=shown.find(x=>x.seq===Number(e.target.value)); if(item) $('leftFrame').src=launchPath(item);}; $('rightPick').onchange=e=>{const item=shown.find(x=>x.seq===Number(e.target.value)); if(item) $('rightFrame').src=launchPath(item);}; }
+function applyFilter(q){ const n=q.toLowerCase().trim(); shown=all.filter(x=>[x.commit_hash,x.commit_short,x.primary_filename,x.description_delta_from_previous,(x.functional_impacts||[]).join(' '),JSON.stringify(x.changed_paths||[])].join(' ').toLowerCase().includes(n)); current=null; renderList(); renderCompare(); if(shown[0]) setCurrentBySeq(shown[0].seq); else $('activeMeta').innerHTML='<div class="muted">No matching entries.</div>'; }
+$('omni').oninput=e=>applyFilter(e.target.value);
 document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active')); t.classList.add('active'); document.querySelectorAll('.pane').forEach(p=>p.classList.remove('active')); $(t.dataset.tab).classList.add('active');});
-fetch('bridge-lineage.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{all=data.sort((a,b)=>dt(a.created)-dt(b.created)); shown=[...all]; rerender();}).catch(e=>{$('progress').textContent='Load failed: '+e.message;});
+fetch('bridge-lineage-timeline-model.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{ all=[...data].sort((a,b)=>a.seq-b.seq); shown=[...all]; renderCompare(); if(shown[0]) setCurrentBySeq(shown[0].seq); else $('activeMeta').textContent='Timeline model is empty.'; }).catch(e=>{$('activeMeta').textContent='Load failed: '+e.message;});
 </script>
 </body>
 </html>

--- a/scripts/build-lineage-model.mjs
+++ b/scripts/build-lineage-model.mjs
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const MODEL_PATH = 'bridge-lineage-timeline-model.json';
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 256 }).trimEnd();
+}
+
+function hashText(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function normalizePatch(text) {
+  return text.replace(/\r\n/g, '\n').split('\n').filter((line) => !line.startsWith('index ')).join('\n').trim();
+}
+
+function parsePatchEvidence(patch) {
+  const files = [];
+  const hunks = [];
+  let currentFile = null;
+  let currentHunk = null;
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('diff --git ')) {
+      const m = line.match(/ a\/(.+) b\/(.+)$/);
+      currentFile = m ? m[2] : null;
+      if (currentFile) files.push(currentFile);
+      currentHunk = null;
+      continue;
+    }
+    if (line.startsWith('@@')) {
+      currentHunk = { file: currentFile || 'unknown', header: line, adds: [], removes: [] };
+      hunks.push(currentHunk);
+      continue;
+    }
+    if (!currentHunk) continue;
+    if (line.startsWith('+') && !line.startsWith('+++')) currentHunk.adds.push(line.slice(1).trim());
+    if (line.startsWith('-') && !line.startsWith('---')) currentHunk.removes.push(line.slice(1).trim());
+  }
+
+  return { files, hunks };
+}
+
+function classifyImpacts(patch) {
+  const t = patch.toLowerCase();
+  const categories = [
+    ['normalization', /(normalize|normalization|canonical|sanitize|trim\(|\bslug\b)/],
+    ['transcription', /(transcrib|speech|stt|utterance|transcript)/],
+    ['translation', /(translate|translation|language|locale|thai|english|xlate)/],
+    ['joining/rejoining flow', /(join\b|rejoin|reconnect|participant|session|room|peer)/],
+    ['call termination behavior', /(hangup|terminate|end call|disconnect|teardown|call end)/],
+    ['compose strip focus behavior', /(compose|focus|caret|cursor|textarea|input\.focus|selectionstart)/],
+    ['ui/ux flow changes', /(button|tab|panel|modal|layout|screen|render|click|toggle|navbar)/],
+    ['remediation/repair/fix behavior', /(fix|bug|repair|rollback|recover|fallback|guard|hotfix|patch)/],
+  ];
+  return categories.filter(([, re]) => re.test(t)).map(([name]) => name);
+}
+
+function summarizeDelta(evidence) {
+  if (evidence.hunks.length === 0) return 'No code diff from previous commit.';
+  const addCount = evidence.hunks.reduce((n, h) => n + h.adds.length, 0);
+  const delCount = evidence.hunks.reduce((n, h) => n + h.removes.length, 0);
+  const hunks = evidence.hunks.slice(0, 3).map((h) => {
+    const add = h.adds.find(Boolean) || 'no added line sample';
+    const del = h.removes.find(Boolean) || 'no removed line sample';
+    return `${h.file} ${h.header} | + ${add} | - ${del}`;
+  });
+  return `Changed ${new Set(evidence.files).size} file(s), ${evidence.hunks.length} hunk(s), +${addCount}/-${delCount}. ${hunks.join(' || ')}`;
+}
+
+const commits = git(['log', '--date=iso-strict', '--pretty=format:%H%x09%h%x09%cI'])
+  .split('\n')
+  .filter(Boolean)
+  .map((line, idx) => {
+    const [full, short, timestamp] = line.split('\t');
+    return { seq: idx + 1, full, short, timestamp };
+  });
+
+const rows = commits.map((commit, idx) => {
+  const previous = commits[idx + 1]?.full ?? null;
+  const patch = previous ? git(['diff', `${previous}..${commit.full}`, '--', '.']) : git(['show', commit.full, '--pretty=format:', '--', '.']);
+  const evidence = parsePatchEvidence(patch);
+  const nameStatusRaw = previous ? git(['diff', '--name-status', `${previous}..${commit.full}`, '--', '.']) : git(['show', '--name-status', '--pretty=format:', commit.full, '--', '.']);
+
+  const changed_paths = nameStatusRaw.split('\n').filter(Boolean).map((line) => {
+    const parts = line.split('\t');
+    const status = parts[0];
+    if (status.startsWith('R')) return { status, from: parts[1], to: parts[2] };
+    return { status, path: parts[1] };
+  });
+
+  const primary_filename = changed_paths[0]?.to || changed_paths[0]?.path || 'N/A';
+  const impacts = classifyImpacts(patch);
+  const patchNormalized = normalizePatch(patch);
+
+  return {
+    seq: commit.seq,
+    timestamp: commit.timestamp,
+    commit_hash: commit.full,
+    commit_short: commit.short,
+    code_fingerprint: hashText(patchNormalized),
+    primary_filename,
+    changed_paths,
+    description_delta_from_previous: summarizeDelta(evidence),
+    functional_impacts: impacts,
+    blob_refs: changed_paths.slice(0, 16).map((entry) => (entry.to ? `${commit.full}:${entry.to}` : `${commit.full}:${entry.path}`)),
+    launch_ref: primary_filename,
+    note: impacts.length ? `Diff-evidenced impacts: ${impacts.join(', ')}.` : 'No prioritized behavior category detected from diff hunks.',
+    previous_commit_hash: previous,
+    diff_evidence: evidence.hunks.slice(0, 12).map((h) => ({ file: h.file, hunk: h.header, add: h.adds[0] || '', remove: h.removes[0] || '' })),
+    patch_hash: hashText(patchNormalized),
+  };
+});
+
+writeFileSync(MODEL_PATH, `${JSON.stringify(rows, null, 2)}\n`);
+console.log(`Wrote ${rows.length} entries to ${MODEL_PATH}`);


### PR DESCRIPTION
### Motivation
- Provide a machine-readable timeline/lineage model of the repository history to drive the Bridge Timeline Explorer UI. 
- Add a reproducible generator for that model so it can be rebuilt from git history. 
- Simplify and improve the repo explorer UI to consume the generated model and surface commit/diff evidence and impact metadata.

### Description
- Added `bridge-lineage-timeline-model.json`, a generated timeline model that aggregates commit metadata, diff evidence, changed paths, and classified functional impacts for each commit.
- Added `scripts/build-lineage-model.mjs`, a Node script that walks git history, normalizes patches, parses diff hunks, classifies impacts (normalization, transcription, translation, joining/rejoining flow, etc.), computes fingerprints, and emits the JSON model.
- Updated `package.json` to add a `build:lineage` script that runs the new generator (`node scripts/build-lineage-model.mjs`).
- Updated `repo.html` to simplify the layout and JavaScript: it now loads `bridge-lineage-timeline-model.json`, renders a compact explorer and side-by-side compare panes, adds search/filter behavior, and shows detailed per-entry metadata (commit, fingerprint, diff evidence, functional impacts).

### Testing
- Executed the new generator with `node scripts/build-lineage-model.mjs` (and via `npm run build:lineage`); the script completed and wrote `bridge-lineage-timeline-model.json` successfully.
- Verified `repo.html` loads the produced `bridge-lineage-timeline-model.json` and the explorer/compare panes render without runtime errors in a local static serve (smoke check; no unit tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb8e639c0832d9d4c39de7d1ca8cc)