### PR TITLE
Introduce Newport Beach-like destination finder UI (React) and add static HTML demo

### DIFF
--- a/newport-beach-finder.html
+++ b/newport-beach-finder.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Newport Beach-Like Destination Finder</title>
+    <style>
+      :root { font-family: Arial, sans-serif; }
+      body { margin: 0; background: #f2f9ff; color: #0f172a; }
+      .container { max-width: 980px; margin: 0 auto; padding: 24px; }
+      .card { background: #fff; border: 1px solid #dbe7f4; border-radius: 14px; padding: 16px; margin-top: 14px; }
+      .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }
+      .tag { background: #dff2ff; color: #0c4a6e; border-radius: 999px; padding: 4px 10px; font-size: 12px; font-weight: bold; }
+      .row { display: flex; justify-content: space-between; gap: 12px; align-items: center; }
+      h1 { margin-bottom: 6px; }
+      p { margin: 8px 0; }
+      input { padding: 8px 10px; border-radius: 8px; border: 1px solid #9ca3af; }
+      .meta { font-size: 14px; color: #475569; }
+      .tempbox { background: #f8fafc; border-radius: 10px; padding: 10px; margin-top: 12px; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>Newport Beach-Like Destination Finder</h1>
+      <p>Pick a date to see similar coastal locations and estimated temperatures.</p>
+
+      <section class="card">
+        <label for="tripDate"><strong>Select a date:</strong></label><br />
+        <input id="tripDate" type="date" />
+        <p id="dateNote" class="meta">No date selected. Using the current month.</p>
+      </section>
+
+      <section id="results" class="grid"></section>
+    </main>
+
+    <script>
+      const baseline = { avgHigh: 73, avgLow: 57 };
+
+      const places = [
+        { name: 'Santa Barbara, CA', region: 'United States', avgHigh: 72, avgLow: 54, humidity: 'medium', vibe: 'Mediterranean-style coastline with polished beach culture.' },
+        { name: 'Coronado, CA', region: 'United States', avgHigh: 71, avgLow: 58, humidity: 'medium', vibe: 'Resort-like beaches and relaxed upscale feel.' },
+        { name: 'La Jolla, CA', region: 'United States', avgHigh: 70, avgLow: 57, humidity: 'medium', vibe: 'Scenic cliffs, coastal dining, and village atmosphere.' },
+        { name: 'Laguna Beach, CA', region: 'United States', avgHigh: 72, avgLow: 56, humidity: 'medium', vibe: 'Coves, galleries, and similar Orange County lifestyle.' },
+        { name: 'Carmel-by-the-Sea, CA', region: 'United States', avgHigh: 65, avgLow: 52, humidity: 'medium', vibe: 'Boutique seaside town with artsy charm.' },
+        { name: 'Cascais, Portugal', region: 'Portugal', avgHigh: 72, avgLow: 59, humidity: 'medium', vibe: 'Elegant Atlantic coastal town with marina promenades.' },
+        { name: 'Noosa Heads, Australia', region: 'Australia', avgHigh: 78, avgLow: 63, humidity: 'high', vibe: 'Stylish beach town with surf and dining.' },
+        { name: 'Biarritz, France', region: 'France', avgHigh: 70, avgLow: 56, humidity: 'medium', vibe: 'Refined beach destination known for surf culture.' }
+      ];
+
+      function seasonalOffset(monthIndex) {
+        return [0, 0, 2, 4, 6, 8, 9, 9, 7, 4, 2, 0][monthIndex] || 0;
+      }
+
+      function computeSuggestions(dateValue) {
+        const month = dateValue ? new Date(dateValue + 'T00:00:00').getMonth() : new Date().getMonth();
+        const offset = seasonalOffset(month);
+
+        return places
+          .map((place) => {
+            const score = 100 - (Math.abs(place.avgHigh - baseline.avgHigh) * 2 + Math.abs(place.avgLow - baseline.avgLow) * 1.5);
+            return {
+              ...place,
+              score: Math.max(0, Math.round(score)),
+              estHigh: place.avgHigh + offset,
+              estLow: place.avgLow + Math.max(0, offset - 2)
+            };
+          })
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 6);
+      }
+
+      function render() {
+        const dateValue = document.getElementById('tripDate').value;
+        const note = document.getElementById('dateNote');
+        const resultsEl = document.getElementById('results');
+
+        note.textContent = dateValue ? `Showing estimates for ${dateValue}.` : 'No date selected. Using the current month.';
+
+        const suggestions = computeSuggestions(dateValue);
+        resultsEl.innerHTML = suggestions
+          .map((place) => `
+            <article class="card">
+              <div class="row">
+                <h3>${place.name}</h3>
+                <span class="tag">Match: ${place.score}%</span>
+              </div>
+              <p class="meta">${place.region}</p>
+              <p>${place.vibe}</p>
+              <div class="tempbox">
+                <div><strong>Estimated High:</strong> ${place.estHigh}°F</div>
+                <div><strong>Estimated Low:</strong> ${place.estLow}°F</div>
+                <div><strong>Humidity:</strong> ${place.humidity}</div>
+              </div>
+            </article>
+          `)
+          .join('');
+      }
+
+      document.getElementById('tripDate').addEventListener('input', render);
+      render();
+    </script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,139 +1,176 @@
-import React, { useCallback, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 
-type KeyControl = {
-  label: string;
-  key: string;
-  keyCode: number;
-  code: string;
-  wide?: boolean;
+type CoastalPlace = {
+  name: string;
+  region: string;
+  avgHigh: number;
+  avgLow: number;
+  humidity: 'low' | 'medium' | 'high';
+  vibe: string;
 };
 
-const controlRows: KeyControl[][] = [
-  [
-    { label: 'Esc', key: 'Escape', keyCode: 27, code: 'Escape' },
-    { label: 'Enter', key: 'Enter', keyCode: 13, code: 'Enter' },
-  ],
-  [
-    { label: '↑', key: 'ArrowUp', keyCode: 38, code: 'ArrowUp' },
-    { label: 'W', key: 'w', keyCode: 87, code: 'KeyW' },
-    { label: 'Space', key: ' ', keyCode: 32, code: 'Space', wide: true },
-  ],
-  [
-    { label: '←', key: 'ArrowLeft', keyCode: 37, code: 'ArrowLeft' },
-    { label: '↓', key: 'ArrowDown', keyCode: 40, code: 'ArrowDown' },
-    { label: '→', key: 'ArrowRight', keyCode: 39, code: 'ArrowRight' },
-  ],
-  [
-    { label: 'A', key: 'a', keyCode: 65, code: 'KeyA' },
-    { label: 'S', key: 's', keyCode: 83, code: 'KeyS' },
-    { label: 'D', key: 'd', keyCode: 68, code: 'KeyD' },
-    { label: 'Shift', key: 'Shift', keyCode: 16, code: 'ShiftLeft' },
-  ],
+const newportBeachBaseline: CoastalPlace = {
+  name: 'Newport Beach, CA',
+  region: 'United States',
+  avgHigh: 73,
+  avgLow: 57,
+  humidity: 'medium',
+  vibe: 'Upscale beach city with marinas, coastal shopping, and calm ocean weather.',
+};
+
+const similarPlaces: CoastalPlace[] = [
+  {
+    name: 'Santa Barbara, CA',
+    region: 'United States',
+    avgHigh: 72,
+    avgLow: 54,
+    humidity: 'medium',
+    vibe: 'Mediterranean-style coastline with a polished downtown and beach culture.',
+  },
+  {
+    name: 'Coronado, CA',
+    region: 'United States',
+    avgHigh: 71,
+    avgLow: 58,
+    humidity: 'medium',
+    vibe: 'Clean beaches, resort vibe, and relaxed upscale feel.',
+  },
+  {
+    name: 'La Jolla, CA',
+    region: 'United States',
+    avgHigh: 70,
+    avgLow: 57,
+    humidity: 'medium',
+    vibe: 'Scenic cliffs, coastal dining, and walkable village atmosphere.',
+  },
+  {
+    name: 'Carmel-by-the-Sea, CA',
+    region: 'United States',
+    avgHigh: 65,
+    avgLow: 52,
+    humidity: 'medium',
+    vibe: 'Boutique seaside town with cool ocean breezes and artsy charm.',
+  },
+  {
+    name: 'Laguna Beach, CA',
+    region: 'United States',
+    avgHigh: 72,
+    avgLow: 56,
+    humidity: 'medium',
+    vibe: 'Coves, galleries, and a similar Orange County coastal lifestyle.',
+  },
+  {
+    name: 'Noosa Heads, Australia',
+    region: 'Australia',
+    avgHigh: 78,
+    avgLow: 63,
+    humidity: 'high',
+    vibe: 'Stylish beach town with surf breaks, restaurants, and bay walks.',
+  },
+  {
+    name: 'Cascais, Portugal',
+    region: 'Portugal',
+    avgHigh: 72,
+    avgLow: 59,
+    humidity: 'medium',
+    vibe: 'Elegant Atlantic coastal town with marinas and sunny promenades.',
+  },
+  {
+    name: 'Biarritz, France',
+    region: 'France',
+    avgHigh: 70,
+    avgLow: 56,
+    humidity: 'medium',
+    vibe: 'Refined beach destination known for surfing and oceanfront architecture.',
+  },
 ];
 
+function toSeasonalOffset(monthIndex: number): number {
+  const seasonalCurve = [0, 0, 2, 4, 6, 8, 9, 9, 7, 4, 2, 0];
+  return seasonalCurve[monthIndex] ?? 0;
+}
+
 function App() {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set());
+  const [selectedDate, setSelectedDate] = useState<string>('');
 
-  const buildKeyboardEvent = useCallback((type: 'keydown' | 'keyup', control: KeyControl) => {
-    return new KeyboardEvent(type, {
-      key: control.key,
-      code: control.code,
-      keyCode: control.keyCode,
-      which: control.keyCode,
-      bubbles: true,
-      cancelable: true,
-    });
-  }, []);
+  const monthIndex = selectedDate ? new Date(`${selectedDate}T00:00:00`).getMonth() : new Date().getMonth();
 
-  const fireKey = useCallback(
-    (type: 'keydown' | 'keyup', control: KeyControl) => {
-      window.dispatchEvent(buildKeyboardEvent(type, control));
-      document.dispatchEvent(buildKeyboardEvent(type, control));
-      const frameWindow = iframeRef.current?.contentWindow;
-      frameWindow?.focus();
-    },
-    [buildKeyboardEvent],
-  );
+  const suggestions = useMemo(() => {
+    const offset = toSeasonalOffset(monthIndex);
 
-  const press = useCallback(
-    (control: KeyControl) => {
-      setActiveKeys((prev) => new Set(prev).add(control.code));
-      fireKey('keydown', control);
-    },
-    [fireKey],
-  );
+    return similarPlaces
+      .map((place) => {
+        const estHigh = place.avgHigh + offset;
+        const estLow = place.avgLow + Math.max(offset - 2, 0);
+        const similarityScore =
+          100 -
+          (Math.abs(place.avgHigh - newportBeachBaseline.avgHigh) * 2 +
+            Math.abs(place.avgLow - newportBeachBaseline.avgLow) * 1.5);
 
-  const release = useCallback(
-    (control: KeyControl) => {
-      setActiveKeys((prev) => {
-        const next = new Set(prev);
-        next.delete(control.code);
-        return next;
-      });
-      fireKey('keyup', control);
-    },
-    [fireKey],
-  );
+        return {
+          ...place,
+          estHigh,
+          estLow,
+          score: Math.round(Math.max(similarityScore, 0)),
+        };
+      })
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 6);
+  }, [monthIndex]);
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white flex flex-col">
-      <header className="px-4 py-3 bg-slate-900 border-b border-slate-800">
-        <h1 className="text-lg font-semibold">NimbusFlight Touch Wrapper</h1>
-        <p className="text-sm text-slate-300">Tap and hold buttons to emulate keyboard controls.</p>
-      </header>
+    <div className="min-h-screen bg-sky-50 text-slate-900">
+      <main className="mx-auto max-w-5xl px-4 py-8">
+        <h1 className="text-3xl font-bold">Newport Beach-Like Destination Finder</h1>
+        <p className="mt-2 text-slate-700">
+          Pick a calendar date and get coastal locations with a similar vibe to Newport Beach plus estimated
+          temperatures.
+        </p>
 
-      <main className="flex-1 grid grid-rows-[1fr_auto]">
-        <iframe
-          ref={iframeRef}
-          title="NimbusFlight"
-          src="https://nimbusflight.vercel.app/"
-          className="w-full h-full border-0 bg-black"
-          allow="fullscreen"
-        />
+        <section className="mt-6 rounded-2xl border border-sky-200 bg-white p-4 shadow-sm">
+          <label htmlFor="trip-date" className="block text-sm font-semibold text-slate-700">
+            Select a date
+          </label>
+          <input
+            id="trip-date"
+            type="date"
+            value={selectedDate}
+            onChange={(event) => setSelectedDate(event.target.value)}
+            className="mt-2 rounded-lg border border-slate-300 px-3 py-2"
+          />
+          <p className="mt-2 text-sm text-slate-600">
+            {selectedDate
+              ? `Showing estimates for ${selectedDate}.`
+              : 'No date picked yet. Using the current month for default estimates.'}
+          </p>
+        </section>
 
-        <section className="p-4 bg-slate-900 border-t border-slate-800">
-          <div className="grid gap-2 max-w-2xl mx-auto">
-            {controlRows.map((row, rowIndex) => (
-              <div key={rowIndex} className="flex gap-2 justify-center">
-                {row.map((control) => {
-                  const isActive = activeKeys.has(control.code);
-                  return (
-                    <button
-                      key={control.code}
-                      type="button"
-                      className={`select-none rounded-xl border px-4 py-3 font-semibold transition ${
-                        control.wide ? 'min-w-28' : 'min-w-16'
-                      } ${
-                        isActive
-                          ? 'bg-cyan-500 border-cyan-300 text-slate-950'
-                          : 'bg-slate-800 border-slate-700 hover:bg-slate-700'
-                      }`}
-                      onMouseDown={() => press(control)}
-                      onMouseUp={() => release(control)}
-                      onMouseLeave={() => release(control)}
-                      onTouchStart={(event) => {
-                        event.preventDefault();
-                        press(control);
-                      }}
-                      onTouchEnd={(event) => {
-                        event.preventDefault();
-                        release(control);
-                      }}
-                    >
-                      {control.label}
-                    </button>
-                  );
-                })}
+        <section className="mt-6 grid gap-4 md:grid-cols-2">
+          {suggestions.map((place) => (
+            <article key={place.name} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold">{place.name}</h2>
+                <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-bold text-sky-900">
+                  Match: {place.score}%
+                </span>
               </div>
-            ))}
-          </div>
+              <p className="mt-1 text-sm text-slate-600">{place.region}</p>
+              <p className="mt-3 text-sm text-slate-700">{place.vibe}</p>
+              <div className="mt-4 rounded-lg bg-slate-100 p-3 text-sm">
+                <p>
+                  <strong>Estimated High:</strong> {place.estHigh}°F
+                </p>
+                <p>
+                  <strong>Estimated Low:</strong> {place.estLow}°F
+                </p>
+                <p>
+                  <strong>Humidity Profile:</strong> {place.humidity}
+                </p>
+              </div>
+            </article>
+          ))}
         </section>
       </main>
-
-      <footer className="px-4 py-2 text-xs text-slate-400 bg-slate-900 border-t border-slate-800">
-        Tip: tap inside the game once after load so it can capture input.
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a simple interactive tool to suggest coastal destinations similar to Newport Beach with estimated seasonal temperatures based on a selected date.
- Replace an earlier keyboard-control/iframe wrapper UI with a focused travel-suggestion interface in the main application.
- Include a standalone static demo HTML file to preview the feature outside the React app.

### Description
- Replaced the previous keyboard control wrapper component with a new destination finder in `src/App.tsx` that exposes a date picker and a list of suggested coastal places. 
- Introduced `CoastalPlace` type, `newportBeachBaseline`, `similarPlaces` dataset, and `toSeasonalOffset` to compute seasonal adjustments and per-place estimated highs/lows and similarity scores. 
- Added UI state `selectedDate`, memoized `suggestions` computed from the baseline and seasonal offset, and a responsive layout showing top matches with scores and humidity/profile info. 
- Added a standalone `newport-beach-finder.html` static demo that implements the same suggestion logic for quick previewing without the React app.

### Testing
- Ran the project TypeScript type check and local build (`tsc` / `yarn build`) and confirmed no type errors and a successful build. 
- Executed the test suite (`yarn test`) and lint (`yarn lint`) locally; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffe56d3508832d97bcab2254e40592)