### PR TITLE
Refine bridge-only lineage and fix explorer links

### DIFF
--- a/bridge-lineage-timeline-model.json
+++ b/bridge-lineage-timeline-model.json
@@ -1,308 +1,2040 @@
 [
   {
     "seq": 1,
-    "timestamp": "2026-05-09T17:10:38-07:00",
-    "commit_hash": "231c2f3b38ef2b1dc5a7a70aa3bbf8ef4e3796d8",
-    "commit_short": "231c2f3",
-    "code_fingerprint": "23bef3715abbf55ff3994df5b74f5cfb3f7b64c136ab27eaa268e484320860c7",
-    "primary_filename": "bridge-lineage-timeline-model.json",
+    "timestamp": "2026-05-03T21:46:07-07:00",
+    "timestamp_pt": "May 03, 2026, 21:46:07 PDT",
+    "commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b",
+    "commit_short": "ec23f33",
+    "commit_message": "Fix attachment links and add inline attachment delete",
+    "code_fingerprint": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "bridge-lineage-timeline-model.json"
+        "status": "M",
+        "path": "bridge-patched.html"
       },
       {
         "status": "M",
-        "path": "package.json"
-      },
-      {
-        "status": "M",
-        "path": "repo.html"
-      },
-      {
-        "status": "A",
-        "path": "scripts/build-lineage-model.mjs"
+        "path": "bridge8-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 4 file(s) (+5340/-88); key paths: bridge-lineage-timeline-model.json, package.json, repo.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html, bridge8-patched.html (+22/-2).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html",
+        "bridge8-patched.html"
+      ],
+      "added_lines": 22,
+      "removed_lines": 2,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2206,6 +2206,16 @@ function renderMd(txt){",
+          "added_preview": [
+            "function delAttachment(trId){",
+            "  for(var i=0;i<transcript.length;i++){"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2217,7 +2227,7 @@ function trHtml(e){",
+          "added_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}"
+          ],
+          "removed_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+          ]
+        },
+        {
+          "file": "bridge8-patched.html",
+          "hunk": "@@ -2206,6 +2206,16 @@ function renderMd(txt){",
+          "added_preview": [
+            "function delAttachment(trId){",
+            "  for(var i=0;i<transcript.length;i++){"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge8-patched.html",
+          "hunk": "@@ -2217,7 +2227,7 @@ function trHtml(e){",
+          "added_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}"
+          ],
+          "removed_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203",
     "blob_refs": [
-      "231c2f3b38ef2b1dc5a7a70aa3bbf8ef4e3796d8:bridge-lineage-timeline-model.json",
-      "231c2f3b38ef2b1dc5a7a70aa3bbf8ef4e3796d8:package.json",
-      "231c2f3b38ef2b1dc5a7a70aa3bbf8ef4e3796d8:repo.html",
-      "231c2f3b38ef2b1dc5a7a70aa3bbf8ef4e3796d8:scripts/build-lineage-model.mjs"
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge-patched.html",
+      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge8-patched.html"
     ],
-    "launch_ref": "bridge-lineage-timeline-model.json",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": null
   },
   {
     "seq": 2,
-    "timestamp": "2026-05-09T15:27:15-07:00",
-    "commit_hash": "65d16ac8128f601c40cdc528195175c487a34c17",
-    "commit_short": "65d16ac",
-    "code_fingerprint": "a0f72cde786551d68c4636458f992d96d638536db521176d7148fa540433f245",
-    "primary_filename": "resolve.html",
+    "timestamp": "2026-05-04T09:32:31-07:00",
+    "timestamp_pt": "May 04, 2026, 09:32:31 PDT",
+    "commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3",
+    "commit_short": "a4a043c",
+    "commit_message": "Update bridge-patched.html",
+    "code_fingerprint": "2b76adc5f600e7d2e1e7fe483857f42461b0d12b45e10eb1dfbc6f1033d7a71d",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "resolve.html"
+        "status": "M",
+        "path": "bridge-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+184/-0); key paths: resolve.html. Behavior: adds normalization logic; modifies compose focus behavior; updates UI/UX flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html (+3/-19).",
     "functional_impacts": [
-      "normalization",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html"
+      ],
+      "added_lines": 3,
+      "removed_lines": 19,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1600,7 +1600,7 @@ function saveRecent(){",
+          "added_preview": [
+            "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+          ],
+          "removed_preview": [
+            "function delRecent(id){var rows=getRecent();rows=rows.map(function(r){return r.id===id?Object.assign({},r,{deletedAt:Date.now()}):r});setRecent(rows);renderRecent()}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1624,17 +1624,11 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+          "added_preview": [
+            "  l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+          ],
+          "removed_preview": [
+            "  var active=rows.filter(function(r){return !r.deletedAt});",
+            "  var deleted=rows.filter(function(r){return !!r.deletedAt});"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2206,16 +2200,6 @@ function renderMd(txt){",
+          "added_preview": [],
+          "removed_preview": [
+            "function delAttachment(trId){",
+            "  for(var i=0;i<transcript.length;i++){"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2227,7 +2211,7 @@ function trHtml(e){",
+          "added_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+          ],
+          "removed_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;var trId=e.id||(e.ts+'_'+e.who);attachHtml='<div style=\"margin-top:6px;display:flex;align-items:center;gap:8px;\"><a href=\"'+esc(att.dataUrl)+'\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg> <span style=\"text-decoration:underline;\">'+esc(att.name||'file')+'</span></a>'+(e.who==='me'?'<button type=\"button\" onclick=\"delAttachment('+JSON.stringify(trId)+')\" style=\"background:none;border:none;color:var(--red);cursor:pointer;font-size:14px;line-height:1;padding:0;\">✕</button>':'')+'</div>';}"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "2b76adc5f600e7d2e1e7fe483857f42461b0d12b45e10eb1dfbc6f1033d7a71d",
     "blob_refs": [
-      "65d16ac8128f601c40cdc528195175c487a34c17:resolve.html"
+      "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3:bridge-patched.html"
     ],
-    "launch_ref": "resolve.html",
-    "note": "Inferred impacts from patch hunks: normalization, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b"
   },
   {
     "seq": 3,
-    "timestamp": "2026-05-09T14:50:31-07:00",
-    "commit_hash": "5a90f5d9276733808541ffd6fc3ecd0635eb4637",
-    "commit_short": "5a90f5d",
-    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
-    "primary_filename": "nimbus.html",
+    "timestamp": "2026-05-04T10:26:21-07:00",
+    "timestamp_pt": "May 04, 2026, 10:26:21 PDT",
+    "commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520",
+    "commit_short": "f4dfad8",
+    "commit_message": "Update bridge-patched.html",
+    "code_fingerprint": "25aba266e7ee98b75eebea0c6986bf920b84b75cee7157324f21ba1293777212",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "nimbus.html"
+        "status": "M",
+        "path": "bridge-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+243/-0); key paths: nimbus.html. Behavior: updates translation/language flow; modifies compose focus behavior; updates UI/UX flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html (+22/-1).",
     "functional_impacts": [
-      "translation",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html"
+      ],
+      "added_lines": 22,
+      "removed_lines": 1,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -779,6 +779,7 @@ function handleChatFile(ev){",
+          "added_preview": [
+            "    _attCache[entry.id]={name:file.name,dataUrl:dataUrl,type:file.type};"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -842,6 +843,7 @@ function handleChatMsg(d){",
+          "added_preview": [
+            "  if(entry.attachment&&entry.attachment.dataUrl)_attCache[entry.id]=entry.attachment;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -853,6 +855,7 @@ var LS={setup:'setup',call:'call'};",
+          "added_preview": [
+            "function attModalOpenById(id){var att=_attCache[id];if(att)attModalOpen(att);}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -870,6 +873,13 @@ function attModalClose(){",
+          "added_preview": [
+            "function removeTrEntry(id){",
+            "  transcript=transcript.filter(function(e){return e.id!==id;});"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -907,6 +917,7 @@ var ICO={",
+          "added_preview": [
+            "var _attCache={}; // entryId -> {name,dataUrl,type}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2211,7 +2222,17 @@ function trHtml(e){",
+          "added_preview": [
+            "  var attachHtml='';",
+            "  if(e.attachment&&e.attachment.dataUrl){"
+          ],
+          "removed_preview": [
+            "  var attachHtml='';if(e.attachment&&e.attachment.dataUrl){var att=e.attachment;attachHtml='<div style=\"margin-top:6px;\"><a href=\"#\" onclick=\"attModalOpen('+JSON.stringify({name:att.name||'file',dataUrl:att.dataUrl,type:att.type||''})+');return false;\" style=\"color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;\"><svg width=\\\"12\\\" height=\\\"12\\\" viewBox=\\\"0 0 24 24\\\" fill=\\\"none\\\" stroke=\\\"currentColor\\\" stroke-width=\\\"2\\\"><path d=\\\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\\\"/></svg> <span style=\\\"text-decoration:underline;\\\">[view]</span> '+esc(att.name||'file')+'</a></div>';}"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "25aba266e7ee98b75eebea0c6986bf920b84b75cee7157324f21ba1293777212",
     "blob_refs": [
-      "5a90f5d9276733808541ffd6fc3ecd0635eb4637:nimbus.html"
+      "f4dfad85040fdfe1d9137271cc466d27c65aa520:bridge-patched.html"
     ],
-    "launch_ref": "nimbus.html",
-    "note": "Inferred impacts from patch hunks: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3"
   },
   {
     "seq": 4,
-    "timestamp": "2026-05-09T14:50:05-07:00",
-    "commit_hash": "5348f24c6b0b0b106375ee14add3cfc196c9adee",
-    "commit_short": "5348f24",
-    "code_fingerprint": "b1615988de51055a663b4918410c94d2804ce9b702194ae060861b4a780402ef",
-    "primary_filename": "nimbus.html",
+    "timestamp": "2026-05-04T11:00:46-07:00",
+    "timestamp_pt": "May 04, 2026, 11:00:46 PDT",
+    "commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c",
+    "commit_short": "6724b52",
+    "commit_message": "Update bridge-patched.html",
+    "code_fingerprint": "833d54ab460d0cb1bf10d00b1cfe1b79be204f928b9436d5d8ff3b41f665663f",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
-        "status": "D",
-        "path": "nimbus.html"
-      },
-      {
         "status": "M",
-        "path": "repo.html"
+        "path": "bridge-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+38/-246); key paths: nimbus.html, repo.html. Behavior: changes joining/rejoining behavior; modifies compose focus behavior; updates UI/UX flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html (+96/-36).",
     "functional_impacts": [
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html"
+      ],
+      "added_lines": 96,
+      "removed_lines": 36,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -155,7 +155,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;}"
+          ],
+          "removed_preview": [
+            ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -175,6 +175,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-ico-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:8px 10px;cursor:pointer;line-height:0;display:inline-flex;align-items:center;justify-content:center;transition:background .12s;flex-shrink:0;}",
+            ".pb-ico-chip:hover{background:var(--teal);border-color:var(--teal);color:#fff;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -184,6 +187,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-bbl-ts{font-size:10px;color:#9a9592;flex:1;font-variant-numeric:tabular-nums;}",
+            ".pb-book-row{display:flex;align-items:center;padding:10px;border:1px solid #e0dbd6;border-radius:10px;margin-bottom:6px;background:#fff;gap:8px;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -565,6 +571,14 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "<div id=\"pb-books-modal\" style=\"position:fixed;inset:0;background:#fdfaf7;z-index:45;display:none;flex-direction:column;font-family:'DM Sans',sans-serif;overflow:hidden;\">",
+            "  <div style=\"display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -762,8 +776,9 @@ function chatInputEvt(){",
+          "added_preview": [
+            "  $('chat-send-btn').disabled=!raw.trim()||raw==='/'||raw==='//';",
+            "  if(raw==='//'){pbOpenCmdDrawer();return;}"
+          ],
+          "removed_preview": [
+            "  $('chat-send-btn').disabled=!raw.trim()||raw==='/';",
+            "  if(raw.length>=1&&raw[0]==='/'){pbOpenSearchDrawer(raw.slice(1));return;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -792,7 +807,7 @@ function handleChatFile(ev){",
+          "added_preview": [
+            "  if(!text||text==='/'||text==='//') return;"
+          ],
+          "removed_preview": [
+            "  if(!text||text==='/') return;"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -893,6 +908,7 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+          "added_preview": [
+            "var PB_BOOKS_KEY='pb_books_registry'; // [{id,name,createdAt,isDefault}]"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -914,10 +930,11 @@ var ICO={",
+          "added_preview": [
+            "  use:'<svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><polyline points=\"9 18 15 12 9 6\"/></svg>',",
+            "var _btCache={};  // cardId -> {text,lang}"
+          ],
+          "removed_preview": [
+            "  use:'<svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\"><line x1=\"5\" y1=\"12\" x2=\"19\" y2=\"12\"/><polyline points=\"12 5 19 12 12 19\"/></svg>',"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1005,6 +1022,21 @@ function pbChevRowHtml(card){",
+          "added_preview": [
+            "function pbGetBooks(){try{return JSON.parse(localStorage.getItem(PB_BOOKS_KEY)||'null')||[{id:'default',name:'Default',createdAt:0,isDefault:true}];}catch(_){return [{id:'default',name:'Default',createdAt:0,isDefault:true}];}}",
+            "function pbSaveBooks(a){try{localStorage.setItem(PB_BOOKS_KEY,JSON.stringify(a));}catch(_){}}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1026,23 +1058,16 @@ function pbApplyImport(data,opts){",
+          "added_preview": [
+            "function pbExport(name){",
+            "  var fn=(name||('phrases-'+Date.now()))+'.json';"
+          ],
+          "removed_preview": [
+            "function pbExport(){",
+            "  a.download='talkbridge-phrasebook-'+Date.now()+'.json';a.click();"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1088,14 +1113,13 @@ function pbOpenCmdDrawer(){",
+          "added_preview": [
+            "    if(si){si.value=q||'';si.focus();pbRunSearch();}"
+          ],
+          "removed_preview": [
+            "  if(!isCallActive()){pbCloseDrawer();return;}",
+            "    if(si){si.value=q||'';si.focus();if(q)pbRunSearch();}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1103,15 +1127,7 @@ function pbCloseDrawer(){",
+          "added_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>';"
+          ],
+          "removed_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\">📖 Phrasebook</span>'",
+            "    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1140,6 +1156,40 @@ function pbTogUrlRow(){",
+          "added_preview": [
+            "function pbTogUrlRow2(){",
+            "  var r=document.getElementById('pb-url-row2');if(!r)return;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1153,12 +1203,12 @@ function pbFetchUrl(){",
+          "added_preview": [
+            "  var cards=pbGetCards().slice().sort(function(a,b){return (b.createdAt||0)-(a.createdAt||0);});",
+            "  host.innerHTML=cards.slice(0,40).map(function(c){return pbBubbleHtml(c,'search');}).join('');"
+          ],
+          "removed_preview": [
+            "  var cards=pbGetCards();",
+            "  host.innerHTML=cards.slice(0,20).map(function(c){return pbBubbleHtml(c,'search');}).join('');"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1202,9 +1252,11 @@ function pbBubbleHtml(card,ctx){",
+          "added_preview": [
+            "  var _hdrDate=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';",
+            "  var _hdrTime=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';"
+          ],
+          "removed_preview": [
+            "  var tagBadge=tags.length?'<span class=\"pb-tag-ct\">#'+tags.length+'</span>':'';",
+            "    +'<div class=\"pb-bbl-hdr\">'+vBadge+'<span class=\"pb-bbl-pair\">'+pbEsc(sf+' '+src.toUpperCase())+' \\u2192 '+pbEsc(tf+' '+tgt.toUpperCase())+'</span>'+tagBadge+'</div>'"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1293,7 +1345,8 @@ function pbRemoveClarify(id,idx){",
+          "added_preview": [
+            "  if(result)_btCache[id]={text:result,lang:btLang};",
+            "  var resultHtml=result?('<div style=\"display:flex;align-items:flex-start;gap:6px;margin:6px 0;\"><span style=\"font-style:italic;color:#555;font-size:13px;flex:1;\">'+pbEsc(result)+'</span><button class=\"pb-bt-tts\" onclick=\"pbPlayBT(\\''+id+'\\')\" title=\"Play\">'+PB_ICON_TTS+'</button></div>'):('<div style=\"color:#aaa;font-size:12px;\">No result yet.</div>');"
+          ],
+          "removed_preview": [
+            "var resultHtml=result?('<div style=\"display:flex;align-items:flex-start;gap:6px;margin:6px 0;\"><span style=\"font-style:italic;color:#555;font-size:13px;flex:1;\">'+pbEsc(result)+'</span><button class=\"pb-bt-tts\" onclick=\"speakText('+JSON.stringify(result)+','+JSON.stringify(btLang)+')\" title=\"Play\">'+PB_ICON_TTS+'</button></div>'):('<div style=\"color:#aaa;font-size:12px;\">No result yet.</div>');"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1304,6 +1357,7 @@ var resultHtml=result?('<div style=\"display:flex;align-items:flex-start;gap:6px;",
+          "added_preview": [
+            "function pbPlayBT(id){var e=_btCache[id];if(e&&e.text)speakText(e.text,e.lang);}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1356,7 +1410,10 @@ function pbReRenderBubbleHeader(id){",
+          "added_preview": [
+            "  var _hd=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';",
+            "  var _ht=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';"
+          ],
+          "removed_preview": [
+            "  hdr.innerHTML=vBadge+'<span class=\"pb-bbl-pair\">'+pbEsc(sf+' '+srcLang.toUpperCase())+' → '+pbEsc(tf+' '+tgtLang.toUpperCase())+'</span>'+tagBadge;"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1409,11 +1466,14 @@ function pbTriggerImport(){document.getElementById('pb-file-input').click();}",
+          "added_preview": [
+            "  var def=file.name.replace(/\\.json$/i,'')||new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'});",
+            "  var name=prompt('Name for this phrasebook?',def);if(name===null)return;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2240,13 +2300,13 @@ function trHtml(e){",
+          "added_preview": [
+            "    +'<button class=\"tr-use-ico\" type=\"button\" data-use-text=\"'+esc(leftText)+'\" title=\"'+esc(L('use_word',leftLang))+'\">'+esc(L('use_word',leftLang))+'</button>'",
+            "    +'<button class=\"tr-use-ico\" type=\"button\" data-use-text=\"'+esc(rightText)+'\" title=\"'+esc(L('use_word',rightLang))+'\">'+esc(L('use_word',rightLang))+'</button>'"
+          ],
+          "removed_preview": [
+            "    +'<button class=\"tr-use-ico\" type=\"button\" data-use-text=\"'+esc(leftText)+'\" title=\"'+esc(L('use_word',leftLang))+'\"><svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"5\" y1=\"12\" x2=\"19\" y2=\"12\"/><polyline points=\"12 5 19 12 12 19\"/></svg> '+esc(L('use_word',leftLang))+'</button>'",
+            "    +'<button class=\"tr-use-ico\" type=\"button\" data-use-text=\"'+esc(rightText)+'\" title=\"'+esc(L('use_word',rightLang))+'\"><svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"5\" y1=\"12\" x2=\"19\" y2=\"12\"/><polyline points=\"12 5 19 12 12 19\"/></svg> '+esc(L('use_word',rightLang))+'</button>'"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "833d54ab460d0cb1bf10d00b1cfe1b79be204f928b9436d5d8ff3b41f665663f",
     "blob_refs": [
-      "5348f24c6b0b0b106375ee14add3cfc196c9adee:nimbus.html",
-      "5348f24c6b0b0b106375ee14add3cfc196c9adee:repo.html"
+      "6724b523bfd833fbea25db11abefdf7830d3c04c:bridge-patched.html"
     ],
-    "launch_ref": "nimbus.html",
-    "note": "Inferred impacts from patch hunks: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520"
   },
   {
     "seq": 5,
-    "timestamp": "2026-05-09T14:45:09-07:00",
-    "commit_hash": "4f12657f7173ee95208e143fada0846fa9782ed6",
-    "commit_short": "4f12657",
-    "code_fingerprint": "80b49d84adf49106494c5f87cba50d3b08ece68a8e917fac36c7fd5af13b98c1",
-    "primary_filename": "nimbus.html",
+    "timestamp": "2026-05-04T13:47:19-07:00",
+    "timestamp_pt": "May 04, 2026, 13:47:19 PDT",
+    "commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e",
+    "commit_short": "a80eaee",
+    "commit_message": "Update bridge-patched.html",
+    "code_fingerprint": "9132d29934b04d375ad0629cd78c8e84cb26ede56b2d41663f5dadb5241acae2",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "nimbus.html"
+        "status": "M",
+        "path": "bridge-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+243/-0); key paths: nimbus.html. Behavior: updates translation/language flow; modifies compose focus behavior; updates UI/UX flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html (+122/-30).",
     "functional_impacts": [
-      "translation",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html"
+      ],
+      "added_lines": 122,
+      "removed_lines": 30,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -37,7 +37,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}.recent-item.deleted-room{opacity:.85;border-left:3px solid #c0392b;}.recent-act.restore{color:#2e7d4f;}"
+          ],
+          "removed_preview": [
+            ".recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -155,12 +155,20 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}",
+            ".chat-compose-ta::-webkit-scrollbar{display:none;}"
+          ],
+          "removed_preview": [
+            ".chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:\"DM Sans\",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -201,8 +209,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [],
+          "removed_preview": [
+            ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:3px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;}",
+            ".pb-use-btn:hover{background:#2e8b8b;color:#fff;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -306,6 +312,18 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "",
+            "/* ─── Call PiP overlay ─────────────────────────────────── */"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -319,7 +337,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;line-height:1.4;display:inline-flex;align-items:center;justify-content:center;}"
+          ],
+          "removed_preview": [
+            ".pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 7px;font-size:11px;font-weight:700;cursor:pointer;font-family:\"DM Sans\",sans-serif;white-space:nowrap;line-height:0;display:inline-flex;align-items:center;justify-content:center;}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -506,6 +524,24 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "<!-- PiP overlay -->",
+            "<div id=\"pip-overlay\">"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1127,7 +1163,7 @@ function pbCloseDrawer(){",
+          "added_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';"
+          ],
+          "removed_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>';"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1137,17 +1173,14 @@ function pbSearchDrawerHtml(){",
+          "added_preview": [
+            "    +'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'",
+            "    +'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'"
+          ],
+          "removed_preview": [
+            "    +'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+' new</button>'",
+            "    +'<button class=\"pb-cr-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenOverlay()\" title=\"Open phrasebook\">'+ICO.book+' open</button>'"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1163,9 +1196,10 @@ function pbTogUrlRow2(){",
+          "added_preview": [
+            "  var ni=document.getElementById('pb-url-name2');",
+            "  var name=(ni&&ni.value||'').trim();"
+          ],
+          "removed_preview": [
+            "  if(!url){toast('Enter a URL');return;}",
+            "  var def=new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'});"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1175,27 +1209,37 @@ function pbFetchUrl2(){",
+          "added_preview": [
+            "  var pair=pbActivePair();",
+            "  var pairStr=pair?(pair.src+'-'+pair.tgt+'-'):'';"
+          ],
+          "removed_preview": [
+            "  var def='phrases-'+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[/:, ]+/g,'-');",
+            "  var def='phrases-backup-'+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[/:, ]+/g,'-');"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1259,11 +1303,11 @@ function pbBubbleHtml(card,ctx){",
+          "added_preview": [
+            "    +'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'src\\')\" title=\"'+pbEsc(useL)+'\">'+pbEsc(useL)+'</button>'",
+            "    +'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'tgt\\')\" title=\"'+pbEsc(useR)+'\">'+pbEsc(useR)+'</button>'"
+          ],
+          "removed_preview": [
+            "    +'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'src\\')\" title=\"'+pbEsc(useL)+'\">'+ICO.use+'</button>'",
+            "    +'<div class=\"pb-bbl-acts\"><button class=\"pb-use-btn\" onclick=\"pbUseText(\\''+id+'\\',\\'tgt\\')\" title=\"'+pbEsc(useR)+'\">'+ICO.use+'</button>'"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1671,7 +1715,22 @@ function saveRecent(){",
+          "added_preview": [
+            "function delRecent(id){",
+            "  var rooms=getRecent();"
+          ],
+          "removed_preview": [
+            "function delRecent(id){setRecent(getRecent().filter(function(r){return r.id!==id}));clearTrS(id);renderRecent()}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1696,10 +1755,23 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+          "added_preview": [
+            "  l.innerHTML=rows.map(function(r){",
+            "    var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;"
+          ],
+          "removed_preview": [
+            "  l.innerHTML=rows.map(function(r){var t=new Date(r.ts).toLocaleString();var h=!!loadTr(r.id).length;var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';return '<div class=\"recent-item\"><div class=\"recent-item-top\"><button class=\"recent-open jr\" data-id=\"'+esc(r.id)+'\">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'+(flags?'<span style=\"font-size:16px;flex-shrink:0;\">'+flags+'</span>':'')+'</div><div class=\"recent-actions\"><button class=\"recent-act jr\" data-id=\"'+esc(r.id)+'\">▶ Reopen</button>'+(h?'<button class=\"recent-act jv\" data-id=\"'+esc(r.id)+'\">📄 Transcript</button>':'')+'<button class=\"recent-act danger jd\" data-id=\"'+esc(r.id)+'\">✕ Delete</button></div></div>'}).join('');"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -2563,13 +2635,33 @@ $('local-video').addEventListener('click',swapVideos);",
+          "added_preview": [
+            "var _pipActive=false;",
+            "function pipEnter(){"
+          ],
+          "removed_preview": [
+            "    // Phase 2: popstate respects role — joiner cannot end up in creator lobby",
+            "    hangUp();"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "9132d29934b04d375ad0629cd78c8e84cb26ede56b2d41663f5dadb5241acae2",
     "blob_refs": [
-      "4f12657f7173ee95208e143fada0846fa9782ed6:nimbus.html"
+      "a80eaee0241626ab570b35470651a92f8bde8c2e:bridge-patched.html"
     ],
-    "launch_ref": "nimbus.html",
-    "note": "Inferred impacts from patch hunks: translation, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c"
   },
   {
     "seq": 6,
-    "timestamp": "2026-05-09T14:02:18-07:00",
-    "commit_hash": "9e477053a08bb3c1d1fc512fd6d66310685ea181",
-    "commit_short": "9e47705",
-    "code_fingerprint": "612f3626099d5ae2ceb85e94e908f5c00b14984a5f8fd58c8d7e586729af9f3b",
-    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "timestamp": "2026-05-04T13:56:09-07:00",
+    "timestamp_pt": "May 04, 2026, 13:56:09 PDT",
+    "commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5",
+    "commit_short": "41c63d3",
+    "commit_message": "Update bridge-patched.html",
+    "code_fingerprint": "5e18ba7d8a3a137c9c622607becce4dd4d435131e261109d46d7c44596982469",
+    "primary_filename": "bridge-patched.html",
     "changed_paths": [
       {
         "status": "M",
-        "path": "nimbusflight-touch-wrapper.html"
+        "path": "bridge-patched.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-4); key paths: nimbusflight-touch-wrapper.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
+    "description_delta_from_previous": "Changed bridge-patched.html (+58/-21).",
     "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched.html"
+      ],
+      "added_lines": 58,
+      "removed_lines": 21,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -196,6 +196,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".room-trash-details{margin-top:6px;}",
+            ".room-trash-details summary{font-size:11px;color:var(--text-muted);padding:4px 2px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:5px;user-select:none;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -432,7 +435,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "      <button class=\"log-btn\" onclick=\"closeLog()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button>"
+          ],
+          "removed_preview": [
+            "      <button class=\"log-btn\" onclick=\"closeLog()\">✕ Close</button>"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -443,7 +446,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "      <button class=\"log-btn\" onclick=\"closeRoomTr()\"><svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg> Close</button>"
+          ],
+          "removed_preview": [
+            "      <button class=\"log-btn\" onclick=\"closeRoomTr()\">✕ Close</button>"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1064,9 +1067,13 @@ function pbOpenBooksModal(){",
+          "added_preview": [
+            "    var ts=b.createdAt?new Date(b.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';",
+            "    var cnt=b.cardCount?(' · '+b.cardCount+' phrases'):'';"
+          ],
+          "removed_preview": [
+            "    var del=b.isDefault?''",
+            "      :'<button onclick=\"pbDeleteBook(\\''+b.id+'\\')\" style=\"background:none;border:none;cursor:pointer;color:#c0392b;padding:2px 6px;line-height:0;\">'+ICO.trash+'</button>';"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1398,7 +1405,7 @@ function pbBtPanelHtml(card){",
+          "added_preview": [
+            "    +'<button class=\"pb-bt-run\" onclick=\"pbRunBT(\\''+id+'\\')\"><svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><polyline points=\"1 4 1 10 7 10\"/><path d=\"M3.51 15a9 9 0 1 0 .49-4.2\"/></svg> Back-translate</button>'"
+          ],
+          "removed_preview": [
+            "    +'<button class=\"pb-bt-run\" onclick=\"pbRunBT(\\''+id+'\\')\">↩ Run back-translate</button>'"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1443,7 +1450,7 @@ function pbReRenderCardPanel(type,id){",
+          "added_preview": [
+            "  if(type==='bt'){var btn3=document.getElementById('pbfb-'+id);if(btn3){var bt=card.backtranslate||{};btn3.innerHTML='<svg width=\"11\" height=\"11\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><polyline points=\"1 4 1 10 7 10\"/><path d=\"M3.51 15a9 9 0 1 0 .49-4.2\"/></svg> Verify'+(bt.resultText?'&nbsp;<svg width=\"10\" height=\"10\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><polyline points=\"20 6 9 17 4 12\"/></svg>':'');}}"
+          ],
+          "removed_preview": [
+            "  if(type==='bt'){var btn3=document.getElementById('pbfb-'+id);if(btn3){var bt=card.backtranslate||{};btn3.textContent='↩ Verify'+(bt.resultText?' ✓':'');}}"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1554,10 +1561,21 @@ function pbConfirmImport(){",
+          "added_preview": [
+            "  var importName=(_pbImportData._importName||'').trim();",
+            "  // Register named book in registry"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1738,7 +1756,7 @@ async function reuseRoom(id){",
+          "added_preview": [
+            "  $('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name||'';"
+          ],
+          "removed_preview": [
+            "  $('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name?'📋 '+rec.name:'';"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1754,19 +1772,38 @@ function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toas",
+          "added_preview": [
+            "  var live=rows.filter(function(r){return !r.deletedAt;});",
+            "  var dead=rows.filter(function(r){return !!r.deletedAt;});"
+          ],
+          "removed_preview": [
+            "  w.style.display=rows.length?'':'none';",
+            "  l.innerHTML=rows.map(function(r){"
+          ]
+        },
+        {
+          "file": "bridge-patched.html",
+          "hunk": "@@ -1840,7 +1877,7 @@ async function createRoom(){",
+          "added_preview": [
+            "  var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name||'';"
+          ],
+          "removed_preview": [
+            "  var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name?'📋 '+room.name:'';"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "5e18ba7d8a3a137c9c622607becce4dd4d435131e261109d46d7c44596982469",
     "blob_refs": [
-      "9e477053a08bb3c1d1fc512fd6d66310685ea181:nimbusflight-touch-wrapper.html"
+      "41c63d354dfb4d2bb64311eed99e5acd6261d3f5:bridge-patched.html"
     ],
-    "launch_ref": "nimbusflight-touch-wrapper.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "2d2b4d297266b1617865602303990dca5ef58557"
+    "launch_ref": "bridge-patched.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e"
   },
   {
     "seq": 7,
-    "timestamp": "2026-05-09T14:01:52-07:00",
-    "commit_hash": "2d2b4d297266b1617865602303990dca5ef58557",
-    "commit_short": "2d2b4d2",
-    "code_fingerprint": "54bcdd93cc6eb804779881f395304f2e0befb20d2fab8f9bf6f9cc3c2f5fac49",
-    "primary_filename": "bridge-lineage.json",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-lineage.json"
-      },
-      {
-        "status": "M",
-        "path": "nimbusflight-touch-wrapper.html"
-      },
-      {
-        "status": "M",
-        "path": "repo.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 3 file(s) (+466/-198); key paths: bridge-lineage.json, nimbusflight-touch-wrapper.html, repo.html. Behavior: adds normalization logic; changes joining/rejoining behavior; modifies compose focus behavior.",
-    "functional_impacts": [
-      "normalization",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "2d2b4d297266b1617865602303990dca5ef58557:bridge-lineage.json",
-      "2d2b4d297266b1617865602303990dca5ef58557:nimbusflight-touch-wrapper.html",
-      "2d2b4d297266b1617865602303990dca5ef58557:repo.html"
-    ],
-    "launch_ref": "bridge-lineage.json",
-    "note": "Inferred impacts from patch hunks: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a"
-  },
-  {
-    "seq": 8,
-    "timestamp": "2026-05-09T13:01:20-07:00",
-    "commit_hash": "0a781ffc74981891c79d98304dfe1a0509ca3d3a",
-    "commit_short": "0a781ff",
-    "code_fingerprint": "612f3626099d5ae2ceb85e94e908f5c00b14984a5f8fd58c8d7e586729af9f3b",
-    "primary_filename": "nimbusflight-touch-wrapper.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "nimbusflight-touch-wrapper.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-4); key paths: nimbusflight-touch-wrapper.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "0a781ffc74981891c79d98304dfe1a0509ca3d3a:nimbusflight-touch-wrapper.html"
-    ],
-    "launch_ref": "nimbusflight-touch-wrapper.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf"
-  },
-  {
-    "seq": 9,
-    "timestamp": "2026-05-08T22:20:04-07:00",
-    "commit_hash": "e12a9758445ead5f47ca4d2502b3cee824be2aaf",
-    "commit_short": "e12a975",
-    "code_fingerprint": "d2040e6fba35fd9296b449aa117041debf1c3fd4eb88f07f8c8eb83ec45dbd04",
-    "primary_filename": "nimbusflight-touch-wrapper.html",
+    "timestamp": "2026-05-04T20:02:14-07:00",
+    "timestamp_pt": "May 04, 2026, 20:02:14 PDT",
+    "commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc",
+    "commit_short": "8dc8a82",
+    "commit_message": "Create bridge-patched-v1.html",
+    "code_fingerprint": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64",
+    "primary_filename": "bridge-patched-v1.html",
     "changed_paths": [
       {
         "status": "A",
-        "path": "nimbusflight-touch-wrapper.html"
+        "path": "bridge-patched-v1.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+154/-0); key paths: nimbusflight-touch-wrapper.html. Behavior: modifies compose focus behavior; updates UI/UX flow; applies remediation/fix logic.",
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+2747/-0).",
     "functional_impacts": [
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior",
+      "time display/search behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 2747,
+      "removed_lines": 0,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -0,0 +1,2747 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.3.0 — phrasebook v2+ -->"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64",
     "blob_refs": [
-      "e12a9758445ead5f47ca4d2502b3cee824be2aaf:nimbusflight-touch-wrapper.html"
+      "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc:bridge-patched-v1.html"
     ],
-    "launch_ref": "nimbusflight-touch-wrapper.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279"
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5"
   },
   {
-    "seq": 10,
-    "timestamp": "2026-05-08T22:16:39-07:00",
-    "commit_hash": "04d1fa01bbdbe4045613e84151ef98bf5e4d4279",
-    "commit_short": "04d1fa0",
-    "code_fingerprint": "169860154c91d28771c21bd43824192428257c2af2a5f1b40cfc521393431db5",
-    "primary_filename": "src/App.tsx",
+    "seq": 8,
+    "timestamp": "2026-05-04T21:19:27-07:00",
+    "timestamp_pt": "May 04, 2026, 21:19:27 PDT",
+    "commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93",
+    "commit_short": "6de44b0",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "f6e03326ad84a4c00e5017633b4c997268d8fd75aa91ea8cbd0b1c8e7139830f",
+    "primary_filename": "bridge-patched-v1.html",
     "changed_paths": [
       {
         "status": "M",
-        "path": "src/App.tsx"
+        "path": "bridge-patched-v1.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+133/-3); key paths: src/App.tsx. Behavior: modifies compose focus behavior; updates UI/UX flow; applies remediation/fix logic.",
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+68/-37).",
     "functional_impacts": [
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 68,
+      "removed_lines": 37,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -176,7 +176,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "#pb-drawer-content{flex:1;display:flex;flex-direction:column;overflow:hidden;}"
+          ],
+          "removed_preview": [
+            "#pb-drawer-content{flex:1;overflow-y:auto;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -190,7 +190,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-search-results{overflow-y:auto;padding:8px 10px;flex:1;}"
+          ],
+          "removed_preview": [
+            ".pb-search-results{overflow-y:auto;padding:8px 10px;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -243,7 +243,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;padding:6px 8px;border-radius:8px;line-height:0;display:inline-flex;align-items:center;}",
+            ".pb-ov-act:hover{background:#eeede9;color:#1a1714;}"
+          ],
+          "removed_preview": [
+            ".pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;font-size:20px;padding:6px 8px;border-radius:8px;line-height:1;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -366,6 +367,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".pb-strip-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;transition:color .12s;}",
+            ".pb-strip-btn:hover{color:var(--teal-bright);}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -521,7 +525,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "    <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-attach-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg></button><button class=\"pb-strip-btn\" id=\"pb-strip-btn\" onclick=\"pbToggleDrawer()\" title=\"Phrases\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 19.5A2.5 2.5 0 0 1 6.5 17H20\"/><path d=\"M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z\"/></svg></button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\" onfocus=\"composeFocusMute()\"></textarea>"
+          ],
+          "removed_preview": [
+            "    <input type=\"file\" id=\"chat-file-input\" accept=\".pdf,.html,.txt,text/*,application/pdf\" style=\"display:none\" onchange=\"handleChatFile(event)\"><button class=\"chat-attach-btn\" onclick=\"document.getElementById('chat-file-input').click()\" title=\"Attach file\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg></button><textarea class=\"chat-compose-ta\" id=\"chat-input\" placeholder=\"type here to chat · / for phrases\" rows=\"1\" oninput=\"chatInputEvt()\" onkeydown=\"chatKeydown(event)\" onfocus=\"composeFocusMute()\"></textarea>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -561,17 +565,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "    <button class=\"pb-ov-back\" onclick=\"pbCloseOverlay()\" title=\"Back\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\"><polyline points=\"15 18 9 12 15 6\"/></svg></button>",
+            "    <div class=\"pb-ov-title\">Phrasebook</div>"
+          ],
+          "removed_preview": [
+            "    <button class=\"pb-ov-back\" onclick=\"pbCloseOverlay()\">←</button>",
+            "    <div class=\"pb-ov-title\">📖 Phrasebook</div>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -822,10 +830,9 @@ function chatInputEvt(){",
+          "added_preview": [
+            "  $('chat-send-btn').disabled=!raw.trim();",
+            "  // Filter search drawer live if open"
+          ],
+          "removed_preview": [
+            "  $('chat-send-btn').disabled=!raw.trim()||raw==='/'||raw==='//';",
+            "  if(raw==='//'){pbOpenCmdDrawer();return;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -853,7 +860,7 @@ function handleChatFile(ev){",
+          "added_preview": [
+            "  if(!text)return;"
+          ],
+          "removed_preview": [
+            "  if(!text||text==='/'||text==='//') return;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1156,6 +1163,12 @@ function pbSearch(q,cards){",
+          "added_preview": [
+            "function pbToggleDrawer(){",
+            "  if(_pbDrawerMode==='search'){pbCloseDrawer();return;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1167,14 +1180,17 @@ function pbOpenSearchDrawer(q){",
+          "added_preview": [
+            "  var btn=document.getElementById('pb-strip-btn');if(btn)btn.classList.add('active');",
+            "    if(si){si.value=q||'';pbRunSearch();si.focus();}"
+          ],
+          "removed_preview": [
+            "    if(si){si.value=q||'';si.focus();pbRunSearch();}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1182,20 +1198,26 @@ function pbCmdDrawerHtml(){",
+          "added_preview": [
+            "  return '<div class=\"pb-drawer-hdr\" style=\"flex-shrink:0;\">'    +'<input id=\"pb-search-input\" class=\"pb-search-inp\" placeholder=\"Search phrases…\" oninput=\"pbRunSearch()\" onkeydown=\"pbSearchKD(event)\">'    +badge    +'<button class=\"pb-ov-act\" onclick=\"pbOpenOverlay()\" title=\"Manage phrasebook\" style=\"color:var(--text-dim);padding:4px 6px;\">'+ICO.book+'</button>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer()\" style=\"line-height:0;\">'+ICO.x+'</button></div>'    +'<div id=\"pb-search-results\" class=\"pb-search-results\"></div>';",
+            "}"
+          ],
+          "removed_preview": [
+            "  return '<div class=\"pb-drawer-hdr\">'",
+            "    +'<input id=\"pb-search-input\" class=\"pb-search-inp\" placeholder=\"Search phrases… (-word to exclude)\" oninput=\"pbRunSearch()\" onkeydown=\"pbSearchKD(event)\">'"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1225,9 +1247,10 @@ function pbFetchUrl2(){",
+          "added_preview": [
+            "  var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\\/:, ]+/g,'-');",
+            "  var name=prompt('Export filename:',def);if(name===null)return;"
+          ],
+          "removed_preview": [
+            "  var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\\/: ,]+/g,'-');",
+            "  var name=prompt('Export filename?',def);if(name===null)return;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1239,7 +1262,7 @@ function pbResetConfirm(){",
+          "added_preview": [
+            "    pbAutoSeed();pbRenderOverlayFilter();pbRenderOverlay();document.getElementById('pb-overlay').style.display='flex';"
+          ],
+          "removed_preview": [
+            "    pbAutoSeed();if(document.getElementById('pb-overlay').style.display==='flex'){pbRenderOverlayFilter();pbRenderOverlay();}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1259,7 +1282,10 @@ function pbFetchUrl(){",
+          "added_preview": [
+            "  var si=document.getElementById('pb-search-input');",
+            "  // Also pick up any text the user has typed in compose"
+          ],
+          "removed_preview": [
+            "  var si=document.getElementById('pb-search-input');var q=si?si.value:'';"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1289,6 +1315,7 @@ function pbUseText(id,side){",
+          "added_preview": [
+            "  pbCloseOverlay();"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1581,11 +1608,14 @@ function pbConfirmImport(){",
+          "added_preview": [
+            "  pbRenderOverlayFilter();pbRenderOverlay();",
+            "  document.getElementById('pb-overlay').style.display='flex';"
+          ],
+          "removed_preview": [
+            "  if(document.getElementById('pb-overlay').style.display==='flex'){pbRenderOverlayFilter();pbRenderOverlay();}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1605,7 +1635,7 @@ function pbOpenNewCard(opts){",
+          "added_preview": [
+            "function pbCloseNewCard(){document.getElementById('pb-new-card-sheet').classList.remove('open');if(document.getElementById('pb-overlay').style.display!=='flex'){document.getElementById('pb-overlay').style.display='flex';pbRenderOverlayFilter();pbRenderOverlay();}}"
+          ],
+          "removed_preview": [
+            "function pbCloseNewCard(){document.getElementById('pb-new-card-sheet').classList.remove('open');}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1624,7 +1654,8 @@ function pbSaveNewCard(){",
+          "added_preview": [
+            "  pbRenderOverlayFilter();pbRenderOverlay();",
+            "  document.getElementById('pb-overlay').style.display='flex';"
+          ],
+          "removed_preview": [
+            "  if(document.getElementById('pb-overlay').style.display==='flex'){pbRenderOverlayFilter();pbRenderOverlay();}"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "f6e03326ad84a4c00e5017633b4c997268d8fd75aa91ea8cbd0b1c8e7139830f",
     "blob_refs": [
-      "04d1fa01bbdbe4045613e84151ef98bf5e4d4279:src/App.tsx"
+      "6de44b0e9f25115de07a8113d1c538c575ef1e93:bridge-patched-v1.html"
     ],
-    "launch_ref": "src/App.tsx",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d"
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc"
+  },
+  {
+    "seq": 9,
+    "timestamp": "2026-05-04T22:07:00-07:00",
+    "timestamp_pt": "May 04, 2026, 22:07:00 PDT",
+    "commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672",
+    "commit_short": "ef895c7",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+2/-1).",
+    "functional_impacts": [],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 2,
+      "removed_lines": 1,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -984,7 +984,8 @@ var ICO={",
+          "added_preview": [
+            "  clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>',",
+            "  x:'<svg width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg>'"
+          ],
+          "removed_preview": [
+            "  clip:'<svg width=\"15\" height=\"15\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48\"/></svg>'"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb",
+    "blob_refs": [
+      "ef895c75a7f8a2bf580efb5db957f0b6feec6672:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93"
+  },
+  {
+    "seq": 10,
+    "timestamp": "2026-05-04T22:28:46-07:00",
+    "timestamp_pt": "May 04, 2026, 22:28:46 PDT",
+    "commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3",
+    "commit_short": "7abbeea",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "3dab03c6d9d6459fd1f5be91270671eb57dc274e0838c7433c03b415ce242f13",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+67/-9).",
+    "functional_impacts": [
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 67,
+      "removed_lines": 9,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -579,7 +579,21 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            "  <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">",
+            "    <div style=\"font-size:11px;font-weight:700;color:#9a9592;letter-spacing:.4px;text-transform:uppercase;\">Import standard phrasebook</div>"
+          ],
+          "removed_preview": [
+            "  <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:5px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\"><input id=\"pb-ov-url-name\" style=\"border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;width:100%;box-sizing:border-box;\" placeholder=\"Phrasebook name (required)\"><div style=\"display:flex;gap:6px;\"><input id=\"pb-ov-url-inp\" style=\"flex:1;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 10px;font-size:13px;font-family:'DM Sans',sans-serif;outline:none;background:#fff;color:#1a1714;\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key==='Enter')pbFetchUrlOverlay()\"><button onclick=\"pbFetchUrlOverlay()\" style=\"background:#2e8b8b;color:#fff;border:none;border-radius:8px;padding:6px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:'DM Sans',sans-serif;\">Go</button></div></div>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -960,6 +974,30 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+          "added_preview": [
+            "var PB_URL_LANGS=[",
+            "  {pb:'en',label:'English',flag:'🇺🇸'},"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1205,20 +1243,40 @@ function pbTogUrlFromOverlay(){",
+          "added_preview": [
+            "  if(!vis){",
+            "    var opts=PB_URL_LANGS.map(function(l){return '<option value=\"'+l.pb+'\">'+l.flag+' '+l.label+'</option>';}).join('');"
+          ],
+          "removed_preview": [
+            "  if(!vis){var ni=document.getElementById('pb-ov-url-name');if(ni)ni.focus();}",
+            "  var ni=document.getElementById('pb-ov-url-name');var ui=document.getElementById('pb-ov-url-inp');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1484,7 +1542,7 @@ function pbReRenderCardPanel(type,id){",
+          "added_preview": [
+            "      if(btn2){var cc=(card.clarifyChain||[]).length;btn2.innerHTML=ICO.chat+(cc?'<span style=\"font-size:9px;margin-left:2px;\">'+cc+'</span>':'');}"
+          ],
+          "removed_preview": [
+            "  if(type==='clarify'){var btn2=document.getElementById('pbfc-'+id);if(btn2){var cc=(card.clarifyChain||[]).length;btn2.textContent='💬 Clarify'+(cc?' ('+cc+')':'');}}"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "3dab03c6d9d6459fd1f5be91270671eb57dc274e0838c7433c03b415ce242f13",
+    "blob_refs": [
+      "7abbeea38ad2f527b6d154743de7b8c4a598d6b3:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672"
   },
   {
     "seq": 11,
-    "timestamp": "2026-05-08T21:43:01-07:00",
-    "commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d",
-    "commit_short": "957d823",
+    "timestamp": "2026-05-04T23:43:57-07:00",
+    "timestamp_pt": "May 04, 2026, 23:43:57 PDT",
+    "commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f",
+    "commit_short": "21d7f60",
+    "commit_message": "Create bridge-patched-v2.html",
+    "code_fingerprint": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f",
+    "primary_filename": "bridge-patched-v2.html",
+    "changed_paths": [
+      {
+        "status": "A",
+        "path": "bridge-patched-v2.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v2.html (+2856/-0).",
+    "functional_impacts": [
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior",
+      "time display/search behavior"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v2.html"
+      ],
+      "added_lines": 2856,
+      "removed_lines": 0,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -0,0 +1,2856 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.3.0 — phrasebook v2+ -->"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f",
+    "blob_refs": [
+      "21d7f60ed8a12a9a47d6fa252c640220aab1021f:bridge-patched-v2.html"
+    ],
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3"
+  },
+  {
+    "seq": 12,
+    "timestamp": "2026-05-04T23:49:17-07:00",
+    "timestamp_pt": "May 04, 2026, 23:49:17 PDT",
+    "commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8",
+    "commit_short": "4d647b6",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+42/-23).",
+    "functional_impacts": [
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior",
+      "time display/search behavior"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 42,
+      "removed_lines": 23,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1239,6 +1239,15 @@ function pbSearchDrawerHtml(){",
+          "added_preview": [
+            "var _PB_BASE='https://github.acmeproducts.com/stuff/phrase/';",
+            "function pbBuildUrl(){"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1263,20 +1272,18 @@ function pbBuildPbUrl(){",
+          "added_preview": [
+            "  var src2=(document.getElementById('pb-url-src')||{}).value||'en';",
+            "  var tgt2=(document.getElementById('pb-url-tgt')||{}).value||'th';"
+          ],
+          "removed_preview": [
+            "  var custom=(document.getElementById('pb-ov-url-custom')||{value:''}).value.trim();",
+            "  var preview=(document.getElementById('pb-ov-url-preview')||{value:''}).value.trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1411,9 +1418,9 @@ function pbBubbleHtml(card,ctx){",
+          "added_preview": [
+            "    +'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'",
+            "    +'<button class=\"pb-fbt'+(cs.clarifyOpen?' on':'')+'\" id=\"pbfc-'+id+'\" onclick=\"pbTogClarify(\\''+id+'\\')\" title=\"Clarify\">'+ICO.chat+' Clarify'+(cc?' ('+cc+')':'')+'</button>'"
+          ],
+          "removed_preview": [
+            "    +'<button class=\"pb-fbt'+(cs.tagsOpen?' on':'')+'\" id=\"pbft-'+id+'\" onclick=\"pbTogTags(\\''+id+'\\')\" title=\"Tags\">'+ICO.tag+(tags.length?'<span style=\\\"font-size:9px;margin-left:2px;\\\">'+tags.length+'</span>':'')+'</button>'",
+            "    +'<button class=\"pb-fbt'+(cs.clarifyOpen?' on':'')+'\" id=\"pbfc-'+id+'\" onclick=\"pbTogClarify(\\''+id+'\\')\" title=\"Notes\">'+ICO.chat+(cc?'<span style=\\\"font-size:9px;margin-left:2px;\\\">'+cc+'</span>':'')+'</button>'"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1460,14 +1467,16 @@ function pbTagSugg(id){",
+          "added_preview": [
+            "    var ts=item.timestamp?new Date(item.timestamp).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';",
+            "    return'<div class=\"pb-clarify-item\"><div class=\"pb-clarify-meta\" style=\"display:flex;align-items:center;gap:5px;\">'"
+          ],
+          "removed_preview": [
+            "    return'<div class=\"pb-clarify-item\"><div class=\"pb-clarify-meta\">'",
+            "      +'<button onclick=\"pbRemoveClarify(\\''+id+'\\','+i+')\" style=\"background:none;border:none;cursor:pointer;color:#aaa;font-size:11px;\">×</button>'"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1529,21 +1538,31 @@ function pbTogBt(id){var cs=_pbCS(id);cs.btOpen=!cs.btOpen;pbSyncPanel('bt',id);",
+          "added_preview": [
+            "  var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';",
+            "  var panel=document.getElementById(panelId+id);"
+          ],
+          "removed_preview": [
+            "  var panel=document.getElementById('pb'+(type==='bt'?'bt':type==='tags'?'tags':'clarify')+'-'+id);",
+            "  var btn=document.getElementById('pbf'+(type==='tags'?'t':type==='clarify'?'c':'b')+'-'+id);"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5",
+    "blob_refs": [
+      "4d647b6374df3fc15faae99330a71f6a5ef38ea8:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f"
+  },
+  {
+    "seq": 13,
+    "timestamp": "2026-05-04T23:59:08-07:00",
+    "timestamp_pt": "May 04, 2026, 23:59:08 PDT",
+    "commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260",
+    "commit_short": "95b15d6",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+3/-1).",
+    "functional_impacts": [],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 3,
+      "removed_lines": 1,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1518,7 +1518,9 @@ function pbRunBT(id){",
+          "added_preview": [
+            "    // Strip phonetic romanization appended by MyMemory e.g. \"สวัสดี (Sa-wat-dee)\"",
+            "    var clean=(result||'').replace(/\\s*\\([^)]*[a-zA-Z][^)]*\\)\\s*$/,'').trim()||result||'';"
+          ],
+          "removed_preview": [
+            "    card.backtranslate.resultText=result||'';card.backtranslate.updatedAt=pbNow();"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852",
+    "blob_refs": [
+      "95b15d65a00ed741cfd8b3820b38800635058260:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8"
+  },
+  {
+    "seq": 14,
+    "timestamp": "2026-05-05T00:15:36-07:00",
+    "timestamp_pt": "May 05, 2026, 24:15:36 PDT",
+    "commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b",
+    "commit_short": "f1ae66b",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "0fdaeec1feb2d5432076bc2b9876dba16fdb4403f9e3d7ade65e0fc0de84704d",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+10/-126).",
+    "functional_impacts": [
+      "logic-flow changes",
+      "ui/ux flow changes",
+      "interaction behavior"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 10,
+      "removed_lines": 126,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ""
+          ],
+          "removed_preview": [
+            ".pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);}",
+            ".pb-url-inp{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:8px;padding:6px 10px;font-size:13px;font-family:\"DM Sans\",sans-serif;outline:none;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [],
+          "removed_preview": [
+            "    <button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -579,21 +575,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [],
+          "removed_preview": [
+            "  <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">",
+            "    <div style=\"font-size:11px;font-weight:700;color:#9a9592;letter-spacing:.4px;text-transform:uppercase;\">Import standard phrasebook</div>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -974,29 +955,6 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+          "added_preview": [],
+          "removed_preview": [
+            "var PB_URL_LANGS=[",
+            "  {pb:'en',label:'English',flag:'🇺🇸'},"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1232,7 +1190,7 @@ function pbCloseDrawer(){",
+          "added_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>';"
+          ],
+          "removed_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1248,68 +1206,11 @@ function pbBuildUrl(){",
+          "added_preview": [
+            "",
+            ""
+          ],
+          "removed_preview": [
+            "function pbTogUrlFromOverlay(){",
+            "  var row=document.getElementById('pb-ov-url-row');if(!row)return;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1332,21 +1233,7 @@ function pbResetConfirm(){",
+          "added_preview": [
+            ""
+          ],
+          "removed_preview": [
+            "function pbFetchUrl(){",
+            "  var i=document.getElementById('pb-url-inp');var url=(i&&i.value||'').trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1588,11 +1475,8 @@ var _pbFilter='all';",
+          "added_preview": [
+            "  var pair=pbActivePair();",
+            "  _pbFilter=(pair&&pair.src&&pair.tgt)?(pair.src+'|'+pair.tgt):'all';"
+          ],
+          "removed_preview": [
+            "  if(isCallActive()&&room.myLang&&room.theirLang){",
+            "    _pbFilter=room.myLang+'|'+room.theirLang;"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "0fdaeec1feb2d5432076bc2b9876dba16fdb4403f9e3d7ade65e0fc0de84704d",
+    "blob_refs": [
+      "f1ae66bc58a4cb758b13ec589152c64a75b89d7b:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260"
+  },
+  {
+    "seq": 15,
+    "timestamp": "2026-05-07T04:07:07-07:00",
+    "timestamp_pt": "May 07, 2026, 04:07:07 PDT",
+    "commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf",
+    "commit_short": "5e99786",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "fcd71a2d022af86504b80778800145e5b06f35feb11d963e033764d71eae8eb6",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+97/-13).",
+    "functional_impacts": [
+      "logic-flow changes"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 97,
+      "removed_lines": 13,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -645,6 +645,56 @@ var LANGS=[",
+          "added_preview": [
+            "",
+            "// ─── AUDIO WORKLET — single-file Blob URL, falls back to ScriptProcessor ────"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -702,6 +752,12 @@ function normalizeText(raw,mode){",
+          "added_preview": [
+            "  if(mode==='speech'){",
+            "    // Strip XLIFF/TMX markup tags from MyMemory translation memory output"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1678,7 +1734,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ],
+          "removed_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2259,6 +2315,7 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ')",
+          "added_preview": [
+            "  text=applyNorthernThaiMap(text);if(!text)return;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2297,28 +2354,55 @@ function startDeepgram(){",
+          "added_preview": [
+            "  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=false&endpointing=400';",
+            "    log('dg_open',{lang:langCode},'ok');"
+          ],
+          "removed_preview": [
+            "  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';",
+            "    dgActive=true;log('dg_open',{lang:langCode},'ok');"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "fcd71a2d022af86504b80778800145e5b06f35feb11d963e033764d71eae8eb6",
+    "blob_refs": [
+      "5e997868914a25463fb3e065cc5dcd7312e3ddaf:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b"
+  },
+  {
+    "seq": 16,
+    "timestamp": "2026-05-07T04:54:29-07:00",
+    "timestamp_pt": "May 07, 2026, 04:54:29 PDT",
+    "commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a",
+    "commit_short": "87a480c",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "3cf092a76a23a2b1f2d203c294e3365839b0c7bc7fb0a00923c16867a3996757",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+10/-7).",
+    "functional_impacts": [
+      "logic-flow changes"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 10,
+      "removed_lines": 7,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -869,12 +869,13 @@ function _detectLangAsync(text){",
+          "added_preview": [
+            "var _pbMutedMic=false;",
+            "  if(micOn&&!micMutedByUser){_pbMutedMic=true;toggleMic();toast('Mic muted while composing');}"
+          ],
+          "removed_preview": [
+            "  if(micOn&&!micMutedByUser){",
+            "    toggleMic();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1244,6 +1245,7 @@ function pbCloseDrawer(){",
+          "added_preview": [
+            "  _pbRestoreMic();"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1322,8 +1324,9 @@ function pbUseText(id,side){",
+          "added_preview": [
+            "    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();}",
+            "  pbCloseDrawer();   // restores mic via _pbRestoreMic before focus"
+          ],
+          "removed_preview": [
+            "    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}",
+            "  pbCloseDrawer();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2738,7 +2741,7 @@ function cleanUp(){",
+          "added_preview": [
+            "  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();"
+          ],
+          "removed_preview": [
+            "  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;syncMic();syncCam();renderRecent();"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "3cf092a76a23a2b1f2d203c294e3365839b0c7bc7fb0a00923c16867a3996757",
+    "blob_refs": [
+      "87a480cc2dbc1c46ff5029be551a40f335b7703a:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf"
+  },
+  {
+    "seq": 17,
+    "timestamp": "2026-05-07T05:39:32-07:00",
+    "timestamp_pt": "May 07, 2026, 05:39:32 PDT",
+    "commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914",
+    "commit_short": "91dc5b7",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+3/-6).",
+    "functional_impacts": [],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 3,
+      "removed_lines": 6,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -750,14 +750,10 @@ function getMicConstraints(){",
+          "added_preview": [
+            "  // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes",
+            "  s=s.replace(/<\\/?[a-zA-Z][^>]*>/g,'');"
+          ],
+          "removed_preview": [
+            "  if(mode==='speech'){",
+            "    // Strip XLIFF/TMX markup tags from MyMemory translation memory output"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1764,6 +1760,7 @@ function translate(text,from,to){",
+          "added_preview": [
+            "          t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
+    "blob_refs": [
+      "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a"
+  },
+  {
+    "seq": 18,
+    "timestamp": "2026-05-07T05:59:21-07:00",
+    "timestamp_pt": "May 07, 2026, 05:59:21 PDT",
+    "commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c",
+    "commit_short": "f8eaade",
+    "commit_message": "Fix subtitle update rendering regression in bridge-patched-v1",
+    "code_fingerprint": "f0f812d415bb28267d74b6c39ff438b86c2dc5380332ad49cba24ee1cca24d21",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+14/-2).",
+    "functional_impacts": [
+      "logic-flow changes"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 14,
+      "removed_lines": 2,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2439,7 +2439,7 @@ function addTr(who,src,tr,sL,tL,ss){",
+          "added_preview": [
+            "  var entry={id:(ss?('sp-'+who+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ],
+          "removed_preview": [
+            "  var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2449,7 +2449,9 @@ function patchTr(who,ss,newTr,sL,tL){",
+          "added_preview": [
+            "      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();",
+            "      var eid=transcript[i].id;"
+          ],
+          "removed_preview": [
+            "      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();renderTr();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2515,6 +2517,16 @@ function appendTrDom(entry){",
+          "added_preview": [
+            "function replaceTrDomById(id,entry){",
+            "  var b=$('transcript-body');if(!b||!id)return;"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "f0f812d415bb28267d74b6c39ff438b86c2dc5380332ad49cba24ee1cca24d21",
+    "blob_refs": [
+      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914"
+  },
+  {
+    "seq": 19,
+    "timestamp": "2026-05-07T16:36:40-07:00",
+    "timestamp_pt": "May 07, 2026, 16:36:40 PDT",
+    "commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6",
+    "commit_short": "d9c0759",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "5d10afedad87d904251124ea1f642942a31a0fd097d42c29722d6c04c0d96339",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+20/-20).",
+    "functional_impacts": [
+      "logic-flow changes"
+    ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 20,
+      "removed_lines": 20,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+          ],
+          "removed_preview": [
+            ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -728,7 +728,7 @@ var pc=null,videoStream=null,remoteStream=null;",
+          "added_preview": [
+            "var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+          ],
+          "removed_preview": [
+            "var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -750,10 +750,14 @@ function getMicConstraints(){",
+          "added_preview": [
+            "  if(mode==='speech'){",
+            "    // Strip XLIFF/TMX markup tags from MyMemory translation memory output"
+          ],
+          "removed_preview": [
+            "  // Strip XLIFF/TMX tags from MyMemory TM output (e.g. สอง<bx id=\"2\"/>) — all modes",
+            "  s=s.replace(/<\\/?[a-zA-Z][^>]*>/g,'');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -826,13 +830,13 @@ var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];",
+          "added_preview": [
+            "  var s=document.createElement('script');s.src='/fastType/fastText.common.js';",
+            "      ft.loadModel('/fastType/lid.176.ftz').then(function(){"
+          ],
+          "removed_preview": [
+            "  var s=document.createElement('script');s.src='/fastText/fasttext.js';",
+            "      ft.loadModel('/fastText/models/lid.176.ftz').then(function(){"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -865,13 +869,10 @@ function _detectLangAsync(text){",
+          "added_preview": [
+            "  if(micOn&&!micMutedByUser){toggleMic();}",
+            "  else if(!micOn){toast('Mic is muted — tap mic button to speak');}"
+          ],
+          "removed_preview": [
+            "var _pbMutedMic=false;",
+            "  if(micOn&&!micMutedByUser){_pbMutedMic=true;toggleMic();toast('Mic muted while composing');}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1241,7 +1242,6 @@ function pbCloseDrawer(){",
+          "added_preview": [],
+          "removed_preview": [
+            "  _pbRestoreMic();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1320,9 +1320,8 @@ function pbUseText(id,side){",
+          "added_preview": [
+            "    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}",
+            "  pbCloseDrawer();"
+          ],
+          "removed_preview": [
+            "    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();}",
+            "  pbCloseDrawer();   // restores mic via _pbRestoreMic before focus"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1760,7 +1759,6 @@ function translate(text,from,to){",
+          "added_preview": [],
+          "removed_preview": [
+            "          t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2047,6 +2045,7 @@ function handleRelay(d){",
+          "added_preview": [
+            "  if(d.type==='mic-state'){var rmo=$('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2439,7 +2438,7 @@ function addTr(who,src,tr,sL,tL,ss){",
+          "added_preview": [
+            "  var entry={id:(ss?('sp-'+(who==='me'?'m'+_ssNonce:'p')+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ],
+          "removed_preview": [
+            "  var entry={id:(ss?('sp-'+who+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2450,8 +2449,7 @@ function patchTr(who,ss,newTr,sL,tL){",
+          "added_preview": [
+            "      replaceTrDomById(transcript[i].id,transcript[i]);"
+          ],
+          "removed_preview": [
+            "      var eid=transcript[i].id;",
+            "      replaceTrDomById(eid,transcript[i]);"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2598,6 +2596,7 @@ async function toggleMic(){",
+          "added_preview": [
+            "      relaySend({type:'mic-state',micOn:false});"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2631,6 +2630,7 @@ async function toggleMic(){",
+          "added_preview": [
+            "        relaySend({type:'mic-state',micOn:true});"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2750,7 +2750,7 @@ function cleanUp(){",
+          "added_preview": [
+            "  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;syncMic();syncCam();renderRecent();"
+          ],
+          "removed_preview": [
+            "  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "5d10afedad87d904251124ea1f642942a31a0fd097d42c29722d6c04c0d96339",
+    "blob_refs": [
+      "d9c07596d0c39e42d23d86b4bc59525a97f467c6:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c"
+  },
+  {
+    "seq": 20,
+    "timestamp": "2026-05-07T16:54:34-07:00",
+    "timestamp_pt": "May 07, 2026, 16:54:34 PDT",
+    "commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71",
+    "commit_short": "a31e6cb",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "fc94b679d29be48e88ab0c8f6c4f49de2fa479b962f69db193179e0ed632432e",
+    "primary_filename": "bridge-patched-v1.html",
+    "changed_paths": [
+      {
+        "status": "M",
+        "path": "bridge-patched-v1.html"
+      }
+    ],
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+1/-0).",
+    "functional_impacts": [],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 1,
+      "removed_lines": 0,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2314,6 +2314,7 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ')",
+          "added_preview": [
+            "  text=text.replace(/([\\u0E34-\\u0E37\\u0E40-\\u0E44]) ([\\u0E00-\\u0E7F])/g,'$1$2').replace(/([\\u0E00-\\u0E7F]) ([\\u0E30-\\u0E37\\u0E47-\\u0E4E])/g,'$1$2');"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "fc94b679d29be48e88ab0c8f6c4f49de2fa479b962f69db193179e0ed632432e",
+    "blob_refs": [
+      "a31e6cb586f30e974094da7fde554cc2863c2f71:bridge-patched-v1.html"
+    ],
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6"
+  },
+  {
+    "seq": 21,
+    "timestamp": "2026-05-07T17:27:29-07:00",
+    "timestamp_pt": "May 07, 2026, 17:27:29 PDT",
+    "commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b",
+    "commit_short": "93446bd",
+    "commit_message": "Fix bridge v1 normalization and speed up chat/audio translation",
     "code_fingerprint": "3f11b66f9e8ea713b17086aa18e0a0982939b308f63dcfd81542163bc8388ef4",
     "primary_filename": "bridge-patched-v1.html",
     "changed_paths": [
@@ -311,96 +2043,501 @@
         "path": "bridge-patched-v1.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-18); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+18/-18).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "remediation/repair/fix behavior"
+      "logic-flow changes"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 18,
+      "removed_lines": 18,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -750,8 +750,9 @@ function getMicConstraints(){",
+          "added_preview": [
+            "  if(s.normalize)s=s.normalize('NFC');",
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF\\u2060]/g,'');"
+          ],
+          "removed_preview": [
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -926,7 +927,7 @@ async function sendChat(){",
+          "added_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}"
+          ],
+          "removed_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+          "added_preview": [
+            "function cleanTranslationText(t){",
+            "  if(!t)return'';"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1732,7 +1738,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);"
+          ],
+          "removed_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1742,7 +1748,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});"
+          ],
+          "removed_preview": [
+            "          return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1759,6 +1765,7 @@ function translate(text,from,to){",
+          "added_preview": [
+            "          t=cleanTranslationText(t);"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2320,20 +2327,13 @@ function onDGFinal(text){",
+          "added_preview": [
+            "  var srcText=normalizeText(text,'speech')||text;",
+            "  relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});"
+          ],
+          "removed_preview": [
+            "  Promise.race([",
+            "    _detectLangAsync(text),"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "3f11b66f9e8ea713b17086aa18e0a0982939b308f63dcfd81542163bc8388ef4",
     "blob_refs": [
-      "957d823fcf173239bcaf937deb2f5c67fb144f1d:bridge-patched-v1.html"
+      "93446bdabd881e40f5c5b709ea713c70af37068b:bridge-patched-v1.html"
     ],
     "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, remediation/repair/fix behavior.",
-    "previous_commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de"
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71"
   },
   {
-    "seq": 12,
-    "timestamp": "2026-05-07T23:41:40-07:00",
-    "commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de",
-    "commit_short": "116ce14",
-    "code_fingerprint": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053",
-    "primary_filename": "bridge-try.html",
+    "seq": 22,
+    "timestamp": "2026-05-07T20:58:47-07:00",
+    "timestamp_pt": "May 07, 2026, 20:58:47 PDT",
+    "commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284",
+    "commit_short": "e87a36c",
+    "commit_message": "Update bridge-patched-v1.html",
+    "code_fingerprint": "f08da5e8f546bbc8629ddf5a0add81a55cb658600d84670498540a15c2256d45",
+    "primary_filename": "bridge-patched-v1.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "bridge-try.html"
+        "status": "M",
+        "path": "bridge-patched-v1.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+2778/-0); key paths: bridge-try.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+19/-19).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "logic-flow changes"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 19,
+      "removed_lines": 19,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -750,9 +750,8 @@ function getMicConstraints(){",
+          "added_preview": [
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');"
+          ],
+          "removed_preview": [
+            "  if(s.normalize)s=s.normalize('NFC');",
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF\\u2060]/g,'');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -832,7 +831,7 @@ var FT_CONF=0.5;",
+          "added_preview": [
+            "  s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'error');toast('Language detection unavailable');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};"
+          ],
+          "removed_preview": [
+            "  s.onerror=function(){_ftLoadFailed=true;_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -927,7 +926,7 @@ async function sendChat(){",
+          "added_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}"
+          ],
+          "removed_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1723,11 +1722,6 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+          "added_preview": [],
+          "removed_preview": [
+            "function cleanTranslationText(t){",
+            "  if(!t)return'';"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1738,7 +1732,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ],
+          "removed_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1748,7 +1742,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});"
+          ],
+          "removed_preview": [
+            "          return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1765,7 +1759,6 @@ function translate(text,from,to){",
+          "added_preview": [],
+          "removed_preview": [
+            "          t=cleanTranslationText(t);"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2327,13 +2320,20 @@ function onDGFinal(text){",
+          "added_preview": [
+            "  Promise.race([",
+            "    _detectLangAsync(text),"
+          ],
+          "removed_preview": [
+            "  var srcText=normalizeText(text,'speech')||text;",
+            "  relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "f08da5e8f546bbc8629ddf5a0add81a55cb658600d84670498540a15c2256d45",
     "blob_refs": [
-      "116ce1466570b35b822be41ef99ad9d2044784de:bridge-try.html"
+      "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284:bridge-patched-v1.html"
     ],
-    "launch_ref": "bridge-try.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd"
+    "launch_ref": "bridge-patched-v1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b"
   },
   {
-    "seq": 13,
-    "timestamp": "2026-05-07T22:47:29-07:00",
-    "commit_hash": "a0c2917e740ed58bf537566e9333caf191eddbfd",
-    "commit_short": "a0c2917",
-    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
-    "primary_filename": "bridge-lineage.json",
+    "seq": 23,
+    "timestamp": "2026-05-07T22:09:04-07:00",
+    "timestamp_pt": "May 07, 2026, 22:09:04 PDT",
+    "commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae",
+    "commit_short": "6109bca",
+    "commit_message": "Add files via upload",
+    "code_fingerprint": "144ffa0b61fce70e8a5724ecb47680bebfb1d9b34808c59a27465d6e94d916c3",
+    "primary_filename": "bridge-patched-v2.html",
     "changed_paths": [
       {
-        "status": "A",
-        "path": "bridge-lineage.json"
-      },
-      {
-        "status": "A",
-        "path": "repo.html"
+        "status": "M",
+        "path": "bridge-patched-v2.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+197/-0); key paths: bridge-lineage.json, repo.html. Behavior: adds normalization logic; changes joining/rejoining behavior; modifies compose focus behavior.",
+    "description_delta_from_previous": "Changed bridge-patched-v2.html (+134/-151).",
     "functional_impacts": [
-      "normalization",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v2.html"
+      ],
+      "added_lines": 134,
+      "removed_lines": 151,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -78,7 +78,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+          ],
+          "removed_preview": [
+            ".no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:\"DM Sans\",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:\"DM Sans\",sans-serif;display:none;}.reconnect-banner.show{display:block;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -347,10 +347,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [
+            ""
+          ],
+          "removed_preview": [
+            ".pb-url-row{display:flex;gap:6px;padding:6px 10px 8px;border-top:1px solid rgba(255,255,255,.06);}",
+            ".pb-url-inp{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:8px;padding:6px 10px;font-size:13px;font-family:\"DM Sans\",sans-serif;outline:none;}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -569,7 +566,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [],
+          "removed_preview": [
+            "    <button class=\"pb-ov-act\" onclick=\"pbTogUrlFromOverlay()\" title=\"Import from URL\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71\"/><path d=\"M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71\"/></svg></button>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -579,21 +575,6 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:\"DM Sans\"",
+          "added_preview": [],
+          "removed_preview": [
+            "  <div id=\"pb-ov-url-row\" style=\"display:none;flex-direction:column;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;\">",
+            "    <div style=\"font-size:11px;font-weight:700;color:#9a9592;letter-spacing:.4px;text-transform:uppercase;\">Import standard phrasebook</div>"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -664,6 +645,56 @@ var LANGS=[",
+          "added_preview": [
+            "",
+            "// ─── AUDIO WORKLET — single-file Blob URL, falls back to ScriptProcessor ────"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -697,7 +728,7 @@ var pc=null,videoStream=null,remoteStream=null;",
+          "added_preview": [
+            "var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+          ],
+          "removed_preview": [
+            "var localSubSeq=0,transcript=[],trCache=new Map(),TR_CACHE_MAX=500;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -721,6 +752,12 @@ function normalizeText(raw,mode){",
+          "added_preview": [
+            "  if(mode==='speech'){",
+            "    // Strip XLIFF/TMX markup tags from MyMemory translation memory output"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -793,13 +830,13 @@ var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];",
+          "added_preview": [
+            "  var _ftBase=location.href.replace(/\\/[^\\/]*$/,'/');var s=document.createElement('script');s.src=_ftBase+'fastType/fastText.common.js';",
+            "  s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'error');toast('Language detection unavailable');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};"
+          ],
+          "removed_preview": [
+            "  var s=document.createElement('script');s.src='/fastText/fasttext.js';",
+            "  s.onerror=function(){_ftLoadFailed=true;_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -834,10 +871,8 @@ function _detectLangAsync(text){",
+          "added_preview": [
+            "  if(micOn&&!micMutedByUser){toggleMic();}",
+            "  else if(!micOn){toast('Mic is muted — tap mic button to speak');}"
+          ],
+          "removed_preview": [
+            "  if(micOn&&!micMutedByUser){",
+            "    toggleMic();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -974,29 +1009,6 @@ function norm(s){return(s||'').replace(/\\s+/g,' ').trim()}",
+          "added_preview": [],
+          "removed_preview": [
+            "var PB_URL_LANGS=[",
+            "  {pb:'en',label:'English',flag:'🇺🇸'},"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1232,7 +1244,7 @@ function pbCloseDrawer(){",
+          "added_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>';"
+          ],
+          "removed_preview": [
+            "  return '<div class=\"pb-drawer-hdr\"><span class=\"pb-drawer-title\" style=\"font-size:11px;color:var(--text-muted);\">Phrasebook (//) management</span>'    +'<button class=\"pb-drawer-x\" onclick=\"pbCloseDrawer();pbClearComposeSlash()\">×</button></div>'    +'<div class=\"pb-cmd-chips\" style=\"justify-content:flex-start;\">'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenBooksModal()\" title=\"Open / switch phrasebook\">'+ICO.book+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbOpenNewCard({})\" title=\"New phrase\">'+ICO.plus+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbTriggerImport()\" title=\"Import file\">'+ICO.upload+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbTogUrlRow2()\" title=\"Import from URL\">'+ICO.link+'</button>'    +'<button class=\"pb-ico-chip\" onclick=\"pbCloseDrawer();pbClearCompose();pbExportPrompt()\" title=\"Export\">'+ICO.download+'</button>'    +'<button class=\"pb-ico-chip danger\" onclick=\"pbCloseDrawer();pbClearCompose();pbResetConfirm()\" title=\"Reset phrasebook\">'+ICO.warn+'</button>'    +'</div>'    +'<div id=\"pb-url-row2\" class=\"pb-url-row\" style=\"display:none;flex-direction:column;gap:5px;\">'    +'<input id=\"pb-url-name2\" class=\"pb-url-inp\" placeholder=\"Name for this phrasebook\">'    +'<div style=\"display:flex;gap:6px;\">'    +'<input id=\"pb-url-inp2\" class=\"pb-url-inp\" placeholder=\"https://.../phrasebook.json\" onkeydown=\"if(event.key===\\'Enter\\')pbFetchUrl2()\">'    +'</div>'    +'<button class=\"pb-url-go\" onclick=\"pbFetchUrl2()\">Go</button>'    +'</div>'    +'</div>';"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1248,68 +1260,11 @@ function pbBuildUrl(){",
+          "added_preview": [
+            "",
+            ""
+          ],
+          "removed_preview": [
+            "function pbTogUrlFromOverlay(){",
+            "  var row=document.getElementById('pb-ov-url-row');if(!row)return;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1332,21 +1287,7 @@ function pbResetConfirm(){",
+          "added_preview": [
+            ""
+          ],
+          "removed_preview": [
+            "function pbFetchUrl(){",
+            "  var i=document.getElementById('pb-url-inp');var url=(i&&i.value||'').trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1518,7 +1459,9 @@ function pbRunBT(id){",
+          "added_preview": [
+            "    // Strip phonetic romanization appended by MyMemory e.g. \"สวัสดี (Sa-wat-dee)\"",
+            "    var clean=(result||'').replace(/\\s*\\([^)]*[a-zA-Z][^)]*\\)\\s*$/,'').trim()||result||'';"
+          ],
+          "removed_preview": [
+            "    card.backtranslate.resultText=result||'';card.backtranslate.updatedAt=pbNow();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1586,11 +1529,8 @@ var _pbFilter='all';",
+          "added_preview": [
+            "  var pair=pbActivePair();",
+            "  _pbFilter=(pair&&pair.src&&pair.tgt)?(pair.src+'|'+pair.tgt):'all';"
+          ],
+          "removed_preview": [
+            "  if(isCallActive()&&room.myLang&&room.theirLang){",
+            "    _pbFilter=room.myLang+'|'+room.theirLang;"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -1792,7 +1732,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ],
+          "removed_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2105,6 +2045,7 @@ function handleRelay(d){",
+          "added_preview": [
+            "  if(d.type==='mic-state'){var rmo=$('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2373,6 +2314,8 @@ function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\\s+/g,' ')",
+          "added_preview": [
+            "  text=text.replace(/([\\u0E34-\\u0E37\\u0E40-\\u0E44]) ([\\u0E00-\\u0E7F])/g,'$1$2').replace(/([\\u0E00-\\u0E7F]) ([\\u0E30-\\u0E37\\u0E47-\\u0E4E])/g,'$1$2');",
+            "  text=applyNorthernThaiMap(text);if(!text)return;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2411,28 +2354,55 @@ function startDeepgram(){",
+          "added_preview": [
+            "  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=false&endpointing=400';",
+            "    log('dg_open',{lang:langCode},'ok');"
+          ],
+          "removed_preview": [
+            "  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';",
+            "    dgActive=true;log('dg_open',{lang:langCode},'ok');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2469,7 +2439,7 @@ function addTr(who,src,tr,sL,tL,ss){",
+          "added_preview": [
+            "  var entry={id:(ss?('sp-'+(who==='me'?'m'+_ssNonce:'p')+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ],
+          "removed_preview": [
+            "  var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2479,7 +2449,8 @@ function patchTr(who,ss,newTr,sL,tL){",
+          "added_preview": [
+            "      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();",
+            "      replaceTrDomById(transcript[i].id,transcript[i]);"
+          ],
+          "removed_preview": [
+            "      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();renderTr();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2545,6 +2516,16 @@ function appendTrDom(entry){",
+          "added_preview": [
+            "function replaceTrDomById(id,entry){",
+            "  var b=$('transcript-body');if(!b||!id)return;"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2616,6 +2597,7 @@ async function toggleMic(){",
+          "added_preview": [
+            "      relaySend({type:'mic-state',micOn:false});"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v2.html",
+          "hunk": "@@ -2649,6 +2631,7 @@ async function toggleMic(){",
+          "added_preview": [
+            "        relaySend({type:'mic-state',micOn:true});"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "144ffa0b61fce70e8a5724ecb47680bebfb1d9b34808c59a27465d6e94d916c3",
     "blob_refs": [
-      "a0c2917e740ed58bf537566e9333caf191eddbfd:bridge-lineage.json",
-      "a0c2917e740ed58bf537566e9333caf191eddbfd:repo.html"
+      "6109bca5ada37a1d39fa84ed47c608564e1b6dae:bridge-patched-v2.html"
     ],
-    "launch_ref": "bridge-lineage.json",
-    "note": "Inferred impacts from patch hunks: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c"
+    "launch_ref": "bridge-patched-v2.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284"
   },
   {
-    "seq": 14,
+    "seq": 24,
     "timestamp": "2026-05-07T22:46:50-07:00",
+    "timestamp_pt": "May 07, 2026, 22:46:50 PDT",
     "commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c",
     "commit_short": "7375fa6",
-    "code_fingerprint": "03fb4737a6e8fcf4008b10f97e1a47ee01fd809b59593722c5d4adf3a1b3fa6a",
-    "primary_filename": "bridge-lineage.json",
+    "commit_message": "Restore working bridge normalization snapshots and neighboring versions",
+    "code_fingerprint": "cf55cb6fbe92ee72c0316ea2b53b781068a27d1b2c6536e1aa88d60b79674252",
+    "primary_filename": "bridge-restore-minus-1.html",
     "changed_paths": [
-      {
-        "status": "D",
-        "path": "bridge-lineage.json"
-      },
       {
         "status": "A",
         "path": "bridge-restore-minus-1.html"
@@ -428,191 +2565,161 @@
       {
         "status": "A",
         "path": "bridge-restore.html"
-      },
-      {
-        "status": "D",
-        "path": "repo.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 9 file(s) (+10811/-197); key paths: bridge-lineage.json, bridge-restore-minus-1.html, bridge-restore-minus-2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-restore-minus-1.html, bridge-restore-minus-2.html, bridge-restore-minus-3.html, bridge-restore-plus-1.html, bridge-restore-plus-2.html, bridge-restore-plus-3.html, bridge-restore.html (+10811/-0).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-restore-minus-1.html",
+        "bridge-restore-minus-2.html",
+        "bridge-restore-minus-3.html",
+        "bridge-restore-plus-1.html",
+        "bridge-restore-plus-2.html",
+        "bridge-restore-plus-3.html",
+        "bridge-restore.html"
+      ],
+      "added_lines": 10811,
+      "removed_lines": 0,
+      "tagged_hunks": [
+        {
+          "file": "bridge-restore-minus-1.html",
+          "hunk": "@@ -0,0 +1,1508 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore-minus-2.html",
+          "hunk": "@@ -0,0 +1,1541 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore-minus-3.html",
+          "hunk": "@@ -0,0 +1,1536 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore-plus-1.html",
+          "hunk": "@@ -0,0 +1,1563 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore-plus-2.html",
+          "hunk": "@@ -0,0 +1,1563 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore-plus-3.html",
+          "hunk": "@@ -0,0 +1,1589 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-restore.html",
+          "hunk": "@@ -0,0 +1,1511 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.1.0 -->"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "cf55cb6fbe92ee72c0316ea2b53b781068a27d1b2c6536e1aa88d60b79674252",
     "blob_refs": [
-      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-lineage.json",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-1.html",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-2.html",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-minus-3.html",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-1.html",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-2.html",
       "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore-plus-3.html",
-      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore.html",
-      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:repo.html"
+      "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c:bridge-restore.html"
     ],
-    "launch_ref": "bridge-lineage.json",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2"
-  },
-  {
-    "seq": 15,
-    "timestamp": "2026-05-07T22:34:37-07:00",
-    "commit_hash": "15aeb257bc1c9204f5d94a697cb776306491c9f2",
-    "commit_short": "15aeb25",
-    "code_fingerprint": "ab8a2995a8494bb23f3587080a82fe5f9739276913c6f0abd8ca3614077b8b67",
-    "primary_filename": "bridge-lineage.json",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge-lineage.json"
-      },
-      {
-        "status": "A",
-        "path": "repo.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+197/-0); key paths: bridge-lineage.json, repo.html. Behavior: adds normalization logic; changes joining/rejoining behavior; modifies compose focus behavior.",
-    "functional_impacts": [
-      "normalization",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "15aeb257bc1c9204f5d94a697cb776306491c9f2:bridge-lineage.json",
-      "15aeb257bc1c9204f5d94a697cb776306491c9f2:repo.html"
-    ],
-    "launch_ref": "bridge-lineage.json",
-    "note": "Inferred impacts from patch hunks: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
+    "launch_ref": "bridge-restore-minus-1.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
     "previous_commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae"
   },
   {
-    "seq": 16,
-    "timestamp": "2026-05-07T22:09:04-07:00",
-    "commit_hash": "6109bca5ada37a1d39fa84ed47c608564e1b6dae",
-    "commit_short": "6109bca",
-    "code_fingerprint": "144ffa0b61fce70e8a5724ecb47680bebfb1d9b34808c59a27465d6e94d916c3",
-    "primary_filename": "bridge-patched-v2.html",
+    "seq": 25,
+    "timestamp": "2026-05-07T23:41:40-07:00",
+    "timestamp_pt": "May 07, 2026, 23:41:40 PDT",
+    "commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de",
+    "commit_short": "116ce14",
+    "commit_message": "Create bridge-try.html",
+    "code_fingerprint": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053",
+    "primary_filename": "bridge-try.html",
     "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+134/-151); key paths: bridge-patched-v2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "6109bca5ada37a1d39fa84ed47c608564e1b6dae:bridge-patched-v2.html"
-    ],
-    "launch_ref": "bridge-patched-v2.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca"
-  },
-  {
-    "seq": 17,
-    "timestamp": "2026-05-07T22:08:30-07:00",
-    "commit_hash": "feb3e3beb6081d6e2ad75ae595113339885bcbca",
-    "commit_short": "feb3e3b",
-    "code_fingerprint": "733365fc27e8286cd6fabd95f084b95f257ff8b691f180dbf297b824daeffaa1",
-    "primary_filename": "fastType/fastText.common.js",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "fastType/fastText.common.js"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+26/-35); key paths: fastType/fastText.common.js.",
-    "functional_impacts": [
-      "transcription",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "feb3e3beb6081d6e2ad75ae595113339885bcbca:fastType/fastText.common.js"
-    ],
-    "launch_ref": "fastType/fastText.common.js",
-    "note": "Inferred impacts from patch hunks: transcription, ui/ux flow changes.",
-    "previous_commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284"
-  },
-  {
-    "seq": 18,
-    "timestamp": "2026-05-07T20:58:47-07:00",
-    "commit_hash": "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284",
-    "commit_short": "e87a36c",
-    "code_fingerprint": "1d3b3095ce26ec85ce95284a29621958f72e6b3e35743250d45bb364c328edd6",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1/-1); key paths: bridge-patched-v1.html. Behavior: updates translation/language flow.",
-    "functional_impacts": [
-      "translation"
-    ],
-    "blob_refs": [
-      "e87a36ca8c5ad90db7e6983c4fe89b533b8e6284:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: translation.",
-    "previous_commit_hash": "8f276b4265914eecab61413aa43aac42ec028517"
-  },
-  {
-    "seq": 19,
-    "timestamp": "2026-05-07T20:54:12-07:00",
-    "commit_hash": "8f276b4265914eecab61413aa43aac42ec028517",
-    "commit_short": "8f276b4",
-    "code_fingerprint": "63e25e0d524392b7ad5fa6f926f1969b6b57407e8b5e4628692f92d0ee8daee0",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      },
       {
         "status": "A",
-        "path": "fastType/fastText.common.js"
+        "path": "bridge-try.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+8772/-18); key paths: bridge-patched-v1.html, fastType/fastText.common.js. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-try.html (+2778/-0).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
+      "logic-flow changes",
       "ui/ux flow changes",
-      "remediation/repair/fix behavior"
+      "interaction behavior",
+      "time display/search behavior"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-try.html"
+      ],
+      "added_lines": 2778,
+      "removed_lines": 0,
+      "tagged_hunks": [
+        {
+          "file": "bridge-try.html",
+          "hunk": "@@ -0,0 +1,2778 @@",
+          "added_preview": [
+            "<!DOCTYPE html>",
+            "<!-- talkbridge · dcr · v3.3.0 — phrasebook v2+ -->"
+          ],
+          "removed_preview": []
+        }
+      ]
+    },
+    "patch_hash": "e65ca958c7b90f9c1e9ebf768734d66f253b74a809b2546b156df7de6d57d053",
     "blob_refs": [
-      "8f276b4265914eecab61413aa43aac42ec028517:bridge-patched-v1.html",
-      "8f276b4265914eecab61413aa43aac42ec028517:fastType/fastText.common.js"
+      "116ce1466570b35b822be41ef99ad9d2044784de:bridge-try.html"
     ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b"
+    "launch_ref": "bridge-try.html",
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "7375fa6de5dcedf64333d6a18c5bdd992bb11b9c"
   },
   {
-    "seq": 20,
-    "timestamp": "2026-05-07T17:27:29-07:00",
-    "commit_hash": "93446bdabd881e40f5c5b709ea713c70af37068b",
-    "commit_short": "93446bd",
+    "seq": 26,
+    "timestamp": "2026-05-08T21:43:01-07:00",
+    "timestamp_pt": "May 08, 2026, 21:43:01 PDT",
+    "commit_hash": "957d823fcf173239bcaf937deb2f5c67fb144f1d",
+    "commit_short": "957d823",
+    "commit_message": "Merge pull request #425 from acmeproducts/codex/fix-normalization-for-chat-and-audio",
     "code_fingerprint": "3f11b66f9e8ea713b17086aa18e0a0982939b308f63dcfd81542163bc8388ef4",
     "primary_filename": "bridge-patched-v1.html",
     "changed_paths": [
@@ -621,3837 +2728,95 @@
         "path": "bridge-patched-v1.html"
       }
     ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-18); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
+    "description_delta_from_previous": "Changed bridge-patched-v1.html (+18/-18).",
     "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "remediation/repair/fix behavior"
+      "logic-flow changes"
     ],
+    "diff_evidence": {
+      "files_changed": [
+        "bridge-patched-v1.html"
+      ],
+      "added_lines": 18,
+      "removed_lines": 18,
+      "tagged_hunks": [
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -750,8 +750,9 @@ function getMicConstraints(){",
+          "added_preview": [
+            "  if(s.normalize)s=s.normalize('NFC');",
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF\\u2060]/g,'');"
+          ],
+          "removed_preview": [
+            "  s=s.replace(/[\\u200B-\\u200D\\uFEFF]/g,'');"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -926,7 +927,7 @@ async function sendChat(){",
+          "added_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,1);if(tr)tgtText=normalizeText(tr,'chat');if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}}catch(_){}"
+          ],
+          "removed_preview": [
+            "    try{var tr=await translateWithRetry(srcText,src,tgt,2);if(tr)tgtText=normalizeText(tr,'chat');}catch(_){}"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1722,6 +1723,11 @@ function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)",
+          "added_preview": [
+            "function cleanTranslationText(t){",
+            "  if(!t)return'';"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1732,7 +1738,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);"
+          ],
+          "removed_preview": [
+            "          if(t&&t.indexOf('MYMEMORY')<0){t=t.replace(/<\\/?[a-zA-Z][^>]*>/g,'').trim();"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1742,7 +1748,7 @@ function translateWithRetry(text,from,to,retries){",
+          "added_preview": [
+            "          return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});"
+          ],
+          "removed_preview": [
+            "          return new Promise(function(res){setTimeout(res,1000*Math.pow(2,retries-n));}).then(function(){return attempt(n-1);});"
+          ]
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -1759,6 +1765,7 @@ function translate(text,from,to){",
+          "added_preview": [
+            "          t=cleanTranslationText(t);"
+          ],
+          "removed_preview": []
+        },
+        {
+          "file": "bridge-patched-v1.html",
+          "hunk": "@@ -2320,20 +2327,13 @@ function onDGFinal(text){",
+          "added_preview": [
+            "  var srcText=normalizeText(text,'speech')||text;",
+            "  relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});"
+          ],
+          "removed_preview": [
+            "  Promise.race([",
+            "    _detectLangAsync(text),"
+          ]
+        }
+      ]
+    },
+    "patch_hash": "3f11b66f9e8ea713b17086aa18e0a0982939b308f63dcfd81542163bc8388ef4",
     "blob_refs": [
-      "93446bdabd881e40f5c5b709ea713c70af37068b:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, remediation/repair/fix behavior.",
-    "previous_commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71"
-  },
-  {
-    "seq": 21,
-    "timestamp": "2026-05-07T16:54:34-07:00",
-    "commit_hash": "a31e6cb586f30e974094da7fde554cc2863c2f71",
-    "commit_short": "a31e6cb",
-    "code_fingerprint": "fc94b679d29be48e88ab0c8f6c4f49de2fa479b962f69db193179e0ed632432e",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1/-0); key paths: bridge-patched-v1.html.",
-    "functional_impacts": [],
-    "blob_refs": [
-      "a31e6cb586f30e974094da7fde554cc2863c2f71:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "No prioritized behavior category detected from patch hunks.",
-    "previous_commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6"
-  },
-  {
-    "seq": 22,
-    "timestamp": "2026-05-07T16:36:40-07:00",
-    "commit_hash": "d9c07596d0c39e42d23d86b4bc59525a97f467c6",
-    "commit_short": "d9c0759",
-    "code_fingerprint": "5d10afedad87d904251124ea1f642942a31a0fd097d42c29722d6c04c0d96339",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+20/-20); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "d9c07596d0c39e42d23d86b4bc59525a97f467c6:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086"
-  },
-  {
-    "seq": 23,
-    "timestamp": "2026-05-07T05:59:35-07:00",
-    "commit_hash": "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086",
-    "commit_short": "c61dcf8",
-    "code_fingerprint": "05fc8d512115f7830b119f12c997ef403a2d199480de588cc63f140655a56b6d",
-    "primary_filename": "folder-v2.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+46/-148); key paths: folder-v2.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "c61dcf8a0aab11cbe3aaf3601cf55796de2b2086:folder-v2.html"
-    ],
-    "launch_ref": "folder-v2.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c"
-  },
-  {
-    "seq": 24,
-    "timestamp": "2026-05-07T05:59:21-07:00",
-    "commit_hash": "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c",
-    "commit_short": "f8eaade",
-    "code_fingerprint": "d3b866aa03f230c8d7da6b0d8f86bc4235d82a8f296e90f64f19341aea1ee7cc",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      },
-      {
-        "status": "M",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+162/-48); key paths: bridge-patched-v1.html, folder-v2.html. Behavior: adjusts transcription handling; updates translation/language flow; modifies compose focus behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:bridge-patched-v1.html",
-      "f8eaadef15f72a6369c3d7b7991cf4c34a1cbc7c:folder-v2.html"
+      "957d823fcf173239bcaf937deb2f5c67fb144f1d:bridge-patched-v1.html"
     ],
     "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd"
-  },
-  {
-    "seq": 25,
-    "timestamp": "2026-05-07T05:50:32-07:00",
-    "commit_hash": "d24f8c0d2dab442b98ec0b2ef6346862eee042bd",
-    "commit_short": "d24f8c0",
-    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-6); key paths: bridge-patched-v1.html. Behavior: adds normalization logic.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation"
-    ],
-    "blob_refs": [
-      "d24f8c0d2dab442b98ec0b2ef6346862eee042bd:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation.",
-    "previous_commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654"
-  },
-  {
-    "seq": 26,
-    "timestamp": "2026-05-07T05:50:19-07:00",
-    "commit_hash": "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654",
-    "commit_short": "8d959e5",
-    "code_fingerprint": "71323a864b85bb45df3703a318bc53c10b2937713a17ad10fc60679f87f59964",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      },
-      {
-        "status": "M",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+52/-151); key paths: bridge-patched-v1.html, folder-v2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:bridge-patched-v1.html",
-      "8d959e5cc4ac3848d2f3ca0bc41dbd9184190654:folder-v2.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914"
-  },
-  {
-    "seq": 27,
-    "timestamp": "2026-05-07T05:39:32-07:00",
-    "commit_hash": "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914",
-    "commit_short": "91dc5b7",
-    "code_fingerprint": "d6a6dba980ab3b6a4046597d9362076005f52f92cd758881db8975401ff1d539",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-6); key paths: bridge-patched-v1.html. Behavior: adds normalization logic.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation"
-    ],
-    "blob_refs": [
-      "91dc5b79d2fe6e8b93bc549d87ac7b56e240e914:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation.",
-    "previous_commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a"
-  },
-  {
-    "seq": 28,
-    "timestamp": "2026-05-07T04:54:29-07:00",
-    "commit_hash": "87a480cc2dbc1c46ff5029be551a40f335b7703a",
-    "commit_short": "87a480c",
-    "code_fingerprint": "3cf092a76a23a2b1f2d203c294e3365839b0c7bc7fb0a00923c16867a3996757",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+10/-7); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; modifies compose focus behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "87a480cc2dbc1c46ff5029be551a40f335b7703a:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d"
-  },
-  {
-    "seq": 29,
-    "timestamp": "2026-05-07T04:27:03-07:00",
-    "commit_hash": "42feeb2dcb0aa771fd2fe82bb5191515dd95814d",
-    "commit_short": "42feeb2",
-    "code_fingerprint": "d4a4b91416b9f5a5ece980c6b7ca38b7b3a8c213e25271e1ac7175ea26431967",
-    "primary_filename": "talkbridge-northern-thai-bridge-plugin.js",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "talkbridge-northern-thai-bridge-plugin.js"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+646/-0); key paths: talkbridge-northern-thai-bridge-plugin.js. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "42feeb2dcb0aa771fd2fe82bb5191515dd95814d:talkbridge-northern-thai-bridge-plugin.js"
-    ],
-    "launch_ref": "talkbridge-northern-thai-bridge-plugin.js",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf"
-  },
-  {
-    "seq": 30,
-    "timestamp": "2026-05-07T04:07:07-07:00",
-    "commit_hash": "5e997868914a25463fb3e065cc5dcd7312e3ddaf",
-    "commit_short": "5e99786",
-    "code_fingerprint": "fcd71a2d022af86504b80778800145e5b06f35feb11d963e033764d71eae8eb6",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+97/-13); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "5e997868914a25463fb3e065cc5dcd7312e3ddaf:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, remediation/repair/fix behavior.",
-    "previous_commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b"
-  },
-  {
-    "seq": 31,
-    "timestamp": "2026-05-05T00:15:36-07:00",
-    "commit_hash": "f1ae66bc58a4cb758b13ec589152c64a75b89d7b",
-    "commit_short": "f1ae66b",
-    "code_fingerprint": "0fdaeec1feb2d5432076bc2b9876dba16fdb4403f9e3d7ade65e0fc0de84704d",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+10/-126); key paths: bridge-patched-v1.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "f1ae66bc58a4cb758b13ec589152c64a75b89d7b:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260"
-  },
-  {
-    "seq": 32,
-    "timestamp": "2026-05-04T23:59:08-07:00",
-    "commit_hash": "95b15d65a00ed741cfd8b3820b38800635058260",
-    "commit_short": "95b15d6",
-    "code_fingerprint": "040f80915af16e076a2b67ffe5d400dba496345a69de11a2187afa7c1aa7d852",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-1); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "translation"
-    ],
-    "blob_refs": [
-      "95b15d65a00ed741cfd8b3820b38800635058260:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation.",
-    "previous_commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8"
-  },
-  {
-    "seq": 33,
-    "timestamp": "2026-05-04T23:49:17-07:00",
-    "commit_hash": "4d647b6374df3fc15faae99330a71f6a5ef38ea8",
-    "commit_short": "4d647b6",
-    "code_fingerprint": "519b94bf11ecdedda51fc272c18e1d00b7d1e4c4c752fbbd7787b49e97bdf8a5",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+42/-23); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "4d647b6374df3fc15faae99330a71f6a5ef38ea8:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f"
-  },
-  {
-    "seq": 34,
-    "timestamp": "2026-05-04T23:43:57-07:00",
-    "commit_hash": "21d7f60ed8a12a9a47d6fa252c640220aab1021f",
-    "commit_short": "21d7f60",
-    "code_fingerprint": "fc262553a122c969c1e27ba1c39ebb314c775aa8f0c4ade89b968a564ee2b14f",
-    "primary_filename": "bridge-patched-v2.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge-patched-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+2856/-0); key paths: bridge-patched-v2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "21d7f60ed8a12a9a47d6fa252c640220aab1021f:bridge-patched-v2.html"
-    ],
-    "launch_ref": "bridge-patched-v2.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3"
-  },
-  {
-    "seq": 35,
-    "timestamp": "2026-05-04T22:28:46-07:00",
-    "commit_hash": "7abbeea38ad2f527b6d154743de7b8c4a598d6b3",
-    "commit_short": "7abbeea",
-    "code_fingerprint": "3dab03c6d9d6459fd1f5be91270671eb57dc274e0838c7433c03b415ce242f13",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+67/-9); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "7abbeea38ad2f527b6d154743de7b8c4a598d6b3:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672"
-  },
-  {
-    "seq": 36,
-    "timestamp": "2026-05-04T22:07:00-07:00",
-    "commit_hash": "ef895c75a7f8a2bf580efb5db957f0b6feec6672",
-    "commit_short": "ef895c7",
-    "code_fingerprint": "b5fa4aa2a7b9d5cb242accb27accaec13852a1b0c680b82b05d773a791ffa3cb",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+2/-1); key paths: bridge-patched-v1.html.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "ef895c75a7f8a2bf580efb5db957f0b6feec6672:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93"
-  },
-  {
-    "seq": 37,
-    "timestamp": "2026-05-04T21:19:27-07:00",
-    "commit_hash": "6de44b0e9f25115de07a8113d1c538c575ef1e93",
-    "commit_short": "6de44b0",
-    "code_fingerprint": "f6e03326ad84a4c00e5017633b4c997268d8fd75aa91ea8cbd0b1c8e7139830f",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+68/-37); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "6de44b0e9f25115de07a8113d1c538c575ef1e93:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc"
-  },
-  {
-    "seq": 38,
-    "timestamp": "2026-05-04T20:02:14-07:00",
-    "commit_hash": "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc",
-    "commit_short": "8dc8a82",
-    "code_fingerprint": "fe635665fbb3210b36de55d9fd27f023f1ae8b0bfa6101beddf8d81647d74d64",
-    "primary_filename": "bridge-patched-v1.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge-patched-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+2747/-0); key paths: bridge-patched-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "8dc8a82cc3c22b24d51cff1238601e8ab62e15fc:bridge-patched-v1.html"
-    ],
-    "launch_ref": "bridge-patched-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5"
-  },
-  {
-    "seq": 39,
-    "timestamp": "2026-05-04T13:56:09-07:00",
-    "commit_hash": "41c63d354dfb4d2bb64311eed99e5acd6261d3f5",
-    "commit_short": "41c63d3",
-    "code_fingerprint": "5e18ba7d8a3a137c9c622607becce4dd4d435131e261109d46d7c44596982469",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+58/-21); key paths: bridge-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "41c63d354dfb4d2bb64311eed99e5acd6261d3f5:bridge-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e"
-  },
-  {
-    "seq": 40,
-    "timestamp": "2026-05-04T13:47:19-07:00",
-    "commit_hash": "a80eaee0241626ab570b35470651a92f8bde8c2e",
-    "commit_short": "a80eaee",
-    "code_fingerprint": "9132d29934b04d375ad0629cd78c8e84cb26ede56b2d41663f5dadb5241acae2",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+122/-30); key paths: bridge-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "a80eaee0241626ab570b35470651a92f8bde8c2e:bridge-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c"
-  },
-  {
-    "seq": 41,
-    "timestamp": "2026-05-04T11:00:46-07:00",
-    "commit_hash": "6724b523bfd833fbea25db11abefdf7830d3c04c",
-    "commit_short": "6724b52",
-    "code_fingerprint": "833d54ab460d0cb1bf10d00b1cfe1b79be204f928b9436d5d8ff3b41f665663f",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+96/-36); key paths: bridge-patched.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "6724b523bfd833fbea25db11abefdf7830d3c04c:bridge-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520"
-  },
-  {
-    "seq": 42,
-    "timestamp": "2026-05-04T10:26:21-07:00",
-    "commit_hash": "f4dfad85040fdfe1d9137271cc466d27c65aa520",
-    "commit_short": "f4dfad8",
-    "code_fingerprint": "25aba266e7ee98b75eebea0c6986bf920b84b75cee7157324f21ba1293777212",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+22/-1); key paths: bridge-patched.html. Behavior: adjusts transcription handling; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "transcription",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "f4dfad85040fdfe1d9137271cc466d27c65aa520:bridge-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: transcription, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3"
-  },
-  {
-    "seq": 43,
-    "timestamp": "2026-05-04T09:32:31-07:00",
-    "commit_hash": "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3",
-    "commit_short": "a4a043c",
-    "code_fingerprint": "2b76adc5f600e7d2e1e7fe483857f42461b0d12b45e10eb1dfbc6f1033d7a71d",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+3/-19); key paths: bridge-patched.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "a4a043c4eb748d43c71b8761f1a9a5cbf907d5e3:bridge-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94"
-  },
-  {
-    "seq": 44,
-    "timestamp": "2026-05-03T23:09:22-07:00",
-    "commit_hash": "b05216b41efea4d90e62805b2edcf9890fdafd94",
-    "commit_short": "b05216b",
-    "code_fingerprint": "398de758631f8ced6866be9ce7621704d1e3b492639d2e6142ebded7cdbfec41",
-    "primary_filename": "getit.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "getit.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+359/-158); key paths: getit.html. Behavior: updates translation/language flow; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "translation",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "b05216b41efea4d90e62805b2edcf9890fdafd94:getit.html"
-    ],
-    "launch_ref": "getit.html",
-    "note": "Inferred impacts from patch hunks: translation, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b"
-  },
-  {
-    "seq": 45,
-    "timestamp": "2026-05-03T21:46:07-07:00",
-    "commit_hash": "ec23f33df1f5c78a72e9e59708a499190aafee8b",
-    "commit_short": "ec23f33",
-    "code_fingerprint": "350d986fb5e79f032a791358203c69069c8df52f97f0d8e8876ed1b5955a3203",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+22/-2); key paths: bridge-patched.html, bridge8-patched.html. Behavior: adjusts transcription handling; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "transcription",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge-patched.html",
-      "ec23f33df1f5c78a72e9e59708a499190aafee8b:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: transcription, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1"
-  },
-  {
-    "seq": 46,
-    "timestamp": "2026-05-03T19:09:25-07:00",
-    "commit_hash": "ee75f51efd1fdf5e8945775d120b15408d22c2c1",
-    "commit_short": "ee75f51",
-    "code_fingerprint": "6fe4903026e014fea8736fb1b1131427012f50ab43b26550b82898999f600c15",
-    "primary_filename": "folder-v2.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+19/-10); key paths: folder-v2.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "ee75f51efd1fdf5e8945775d120b15408d22c2c1:folder-v2.html"
-    ],
-    "launch_ref": "folder-v2.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed"
-  },
-  {
-    "seq": 47,
-    "timestamp": "2026-05-03T18:13:13-07:00",
-    "commit_hash": "5946aea35f2a5fa282b878b9c05e76091107e8ed",
-    "commit_short": "5946aea",
-    "code_fingerprint": "9c1a46bbde95e7a1b290173323a5cd066751fce43ce8ff0bf9e5c2bcb17a7cca",
-    "primary_filename": "recover.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "recover.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+224/-0); key paths: recover.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "5946aea35f2a5fa282b878b9c05e76091107e8ed:recover.html"
-    ],
-    "launch_ref": "recover.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30"
-  },
-  {
-    "seq": 48,
-    "timestamp": "2026-05-03T17:20:24-07:00",
-    "commit_hash": "98c907ede4ff297b8fdbe82e44bf554dfd4edd30",
-    "commit_short": "98c907e",
-    "code_fingerprint": "b62632a7cec64c7b305ca92be9f6fe5dcb74af8e6ef684e47535ab3a8b9c9739",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v1.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v2.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 4 file(s) (+2531/-6); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-patched.html",
-      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v1.html",
-      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge-v2.html",
-      "98c907ede4ff297b8fdbe82e44bf554dfd4edd30:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0"
-  },
-  {
-    "seq": 49,
-    "timestamp": "2026-05-03T17:20:12-07:00",
-    "commit_hash": "3ff2166082df241f5cda8d67bca4cb821a66edc0",
-    "commit_short": "3ff2166",
-    "code_fingerprint": "cedf08e8d4d8c9587ac9c31e73bafe2906fabbfb6cf338c23cf55e268eba8c6a",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "D",
-        "path": "bridge-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v1.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v2.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 5 file(s) (+33/-2558); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-patched.html",
-      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v1.html",
-      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge-v2.html",
-      "3ff2166082df241f5cda8d67bca4cb821a66edc0:bridge8-patched.html",
-      "3ff2166082df241f5cda8d67bca4cb821a66edc0:folder-v2.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c"
-  },
-  {
-    "seq": 50,
-    "timestamp": "2026-05-03T17:19:34-07:00",
-    "commit_hash": "224cf5398cda7683909e5a6781bf49b81b8d090c",
-    "commit_short": "224cf53",
-    "code_fingerprint": "b62632a7cec64c7b305ca92be9f6fe5dcb74af8e6ef684e47535ab3a8b9c9739",
-    "primary_filename": "bridge-patched.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v1.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge-v2.html"
-      },
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 4 file(s) (+2531/-6); key paths: bridge-patched.html, bridge-v1.html, bridge-v2.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-patched.html",
-      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v1.html",
-      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge-v2.html",
-      "224cf5398cda7683909e5a6781bf49b81b8d090c:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2"
-  },
-  {
-    "seq": 51,
-    "timestamp": "2026-05-03T15:55:49-07:00",
-    "commit_hash": "2544c6fe6660ffa86d63b4982be6d71b234575f2",
-    "commit_short": "2544c6f",
-    "code_fingerprint": "563535e56879f8e89329d09a78a6810702d4bad217c7b300b04f41b8fc41bb29",
-    "primary_filename": "folder-v2.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "folder-v2.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1476/-0); key paths: folder-v2.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "2544c6fe6660ffa86d63b4982be6d71b234575f2:folder-v2.html"
-    ],
-    "launch_ref": "folder-v2.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b"
-  },
-  {
-    "seq": 52,
-    "timestamp": "2026-05-03T14:43:39-07:00",
-    "commit_hash": "f9decf22f5d1994d4434a8c24f873d5b628b3a2b",
-    "commit_short": "f9decf2",
-    "code_fingerprint": "9bac947ecca9f3b8b7e1181c450c932f1508bc4bcda669e6743ac24505c63314",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+178/-39); key paths: bridge8-patched.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "f9decf22f5d1994d4434a8c24f873d5b628b3a2b:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87"
-  },
-  {
-    "seq": 53,
-    "timestamp": "2026-05-03T00:42:36-07:00",
-    "commit_hash": "2c5fa2def30b9629989e35cc5aaa3effb1750d87",
-    "commit_short": "2c5fa2d",
-    "code_fingerprint": "f231ae3379df4226b0def2f9763a648c3a59e0caefbaf5db997174c424ed3dea",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+20/-15); key paths: bridge8-patched.html. Behavior: adds normalization logic; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "2c5fa2def30b9629989e35cc5aaa3effb1750d87:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e"
-  },
-  {
-    "seq": 54,
-    "timestamp": "2026-05-03T00:21:52-07:00",
-    "commit_hash": "f961596e94dc0f16e26732f86e50841b4db0db6e",
-    "commit_short": "f961596",
-    "code_fingerprint": "3bb02a94f49ec8e585ad5be6305559b118e273fd328e641c97b955089501c3c2",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+707/-66); key paths: bridge8-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "f961596e94dc0f16e26732f86e50841b4db0db6e:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c"
-  },
-  {
-    "seq": 55,
-    "timestamp": "2026-05-02T17:04:00-07:00",
-    "commit_hash": "3ce547b137b09576fa3d234229474df5bc92691c",
-    "commit_short": "3ce547b",
-    "code_fingerprint": "8fc2bc008fdfc875c04617b33c12d26c419e49f0e45e12ea52974720c69f2178",
-    "primary_filename": "bridge8-v1.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge8-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-v1.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "3ce547b137b09576fa3d234229474df5bc92691c:bridge8-v1.html"
-    ],
-    "launch_ref": "bridge8-v1.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572"
-  },
-  {
-    "seq": 56,
-    "timestamp": "2026-05-02T12:44:43-07:00",
-    "commit_hash": "4495e0c7e62d4542847618ca264e396097ba5572",
-    "commit_short": "4495e0c",
-    "code_fingerprint": "e3aa54e71676ce96d12c0e748652272e5bf5132f43014e1b4d1789652d72d5ac",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-26); key paths: folder.html.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "4495e0c7e62d4542847618ca264e396097ba5572:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404"
-  },
-  {
-    "seq": 57,
-    "timestamp": "2026-05-02T00:10:47-07:00",
-    "commit_hash": "de27f935331846f56c5e0c1a1291bd236e44a404",
-    "commit_short": "de27f93",
-    "code_fingerprint": "6ee48be3814e4bc8ffd3de0d1a2390d65b6cfdf1f289cce8bfd3328f95830552",
-    "primary_filename": "getit.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "getit.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+345/-250); key paths: getit.html. Behavior: adds normalization logic; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "de27f935331846f56c5e0c1a1291bd236e44a404:getit.html"
-    ],
-    "launch_ref": "getit.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d"
-  },
-  {
-    "seq": 58,
-    "timestamp": "2026-05-01T23:49:39-07:00",
-    "commit_hash": "fdb1c11f37574daa2b6c7427215a746eca88949d",
-    "commit_short": "fdb1c11",
-    "code_fingerprint": "bdc69d07932b794bd9eeb0a0778c6b9b5d597df9111b42db77795f44afb1e4b6",
-    "primary_filename": "getit.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "getit.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+245/-500); key paths: getit.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "fdb1c11f37574daa2b6c7427215a746eca88949d:getit.html"
-    ],
-    "launch_ref": "getit.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "2c54df1402f657652073de165d75e94185d0291c"
-  },
-  {
-    "seq": 59,
-    "timestamp": "2026-05-01T23:15:36-07:00",
-    "commit_hash": "2c54df1402f657652073de165d75e94185d0291c",
-    "commit_short": "2c54df1",
-    "code_fingerprint": "593d413f59413ff1e3ad488dea422b9dc248b53de4f1b7c5d25dc4c9adeb51a0",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-13); key paths: folder.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "2c54df1402f657652073de165d75e94185d0291c:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e"
-  },
-  {
-    "seq": 60,
-    "timestamp": "2026-05-01T22:47:50-07:00",
-    "commit_hash": "921ae437c597745ecc3e4ae697c897dd7b133c2e",
-    "commit_short": "921ae43",
-    "code_fingerprint": "05a6e61acf2365fd7738dddf0a17a992ade68382c3a4f0e16690759cc25760ad",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-46); key paths: folder.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "921ae437c597745ecc3e4ae697c897dd7b133c2e:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d"
-  },
-  {
-    "seq": 61,
-    "timestamp": "2026-05-01T22:47:35-07:00",
-    "commit_hash": "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d",
-    "commit_short": "8df99b4",
-    "code_fingerprint": "6079eb9ea772114f64b6ba5c32d82afe409e5a740d680aafc77365d14e078051",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+83/-21); key paths: bridge8-patched.html, folder.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:bridge8-patched.html",
-      "8df99b45535a44e8a3aaeabbfbd46d578ff1f76d:folder.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886"
-  },
-  {
-    "seq": 62,
-    "timestamp": "2026-05-01T22:40:42-07:00",
-    "commit_hash": "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886",
-    "commit_short": "efcf3c8",
-    "code_fingerprint": "05a6e61acf2365fd7738dddf0a17a992ade68382c3a4f0e16690759cc25760ad",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-46); key paths: folder.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "efcf3c8b55f6a2d90a62c59bbafceddfa3b94886:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5"
-  },
-  {
-    "seq": 63,
-    "timestamp": "2026-05-01T19:23:30-07:00",
-    "commit_hash": "b453763041c6ec72f7dc19520862e29470d5a5e5",
-    "commit_short": "b453763",
-    "code_fingerprint": "997f01fec52d81610474b5f0c8484b93ee38e4d3a0d5ae8c2a42c0e5d271b66a",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-60); key paths: folder.html. Behavior: updates UI/UX flow; applies remediation/fix logic.",
-    "functional_impacts": [
-      "translation",
-      "joining/rejoining flow",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "b453763041c6ec72f7dc19520862e29470d5a5e5:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: translation, joining/rejoining flow, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703"
-  },
-  {
-    "seq": 64,
-    "timestamp": "2026-05-01T18:36:44-07:00",
-    "commit_hash": "a3e213d2f427f2275569c7ba94c9aea0f7f12703",
-    "commit_short": "a3e213d",
-    "code_fingerprint": "c7cf370042161c86896d4d9e6aaee6ddf1388d3fac044260334163ce2cbdfc4f",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+8/-5); key paths: bridge8-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "a3e213d2f427f2275569c7ba94c9aea0f7f12703:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95"
-  },
-  {
-    "seq": 65,
-    "timestamp": "2026-05-01T17:24:22-07:00",
-    "commit_hash": "d36c711b38df63cf4750882c9a197d7928569a95",
-    "commit_short": "d36c711",
-    "code_fingerprint": "b6f0ed5d7c49b7bd735b146cbb713163a4461099f1fa1b057e8853eaa7b434e7",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+43/-31); key paths: folder.html. Behavior: modifies call termination behavior; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "d36c711b38df63cf4750882c9a197d7928569a95:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: call termination behavior, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2"
-  },
-  {
-    "seq": 66,
-    "timestamp": "2026-05-01T11:26:39-07:00",
-    "commit_hash": "af1e316ba52ea02575df8877ed4c49b1cccbb3e2",
-    "commit_short": "af1e316",
-    "code_fingerprint": "704f5ec77eff1047ae603f422efbc0045188f20d534cbd70fa7e9b2f5c9008cf",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+14/-9); key paths: bridge8-patched.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "af1e316ba52ea02575df8877ed4c49b1cccbb3e2:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6"
-  },
-  {
-    "seq": 67,
-    "timestamp": "2026-05-01T01:28:59-07:00",
-    "commit_hash": "c62a620eb345d738a7c6876a2653d68715735bf6",
-    "commit_short": "c62a620",
-    "code_fingerprint": "db5dabb7e22794c60e645143e6fd49487df9515a21db51cea86b147e1d1e6ab2",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-3); key paths: folder.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "c62a620eb345d738a7c6876a2653d68715735bf6:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8"
-  },
-  {
-    "seq": 68,
-    "timestamp": "2026-05-01T01:28:17-07:00",
-    "commit_hash": "babd6c517be24b83d08a5ab92af0b0fb2e2316b8",
-    "commit_short": "babd6c5",
-    "code_fingerprint": "e86cabe06685c5b21b9ce7ee5eca24e2041a4dbd4910ab345f022d7d641e7c2a",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+91/-11); key paths: bridge8-patched.html, folder.html. Behavior: changes joining/rejoining behavior; modifies call termination behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "transcription",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:bridge8-patched.html",
-      "babd6c517be24b83d08a5ab92af0b0fb2e2316b8:folder.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66"
-  },
-  {
-    "seq": 69,
-    "timestamp": "2026-05-01T01:26:55-07:00",
-    "commit_hash": "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66",
-    "commit_short": "0bbe3bb",
-    "code_fingerprint": "db5dabb7e22794c60e645143e6fd49487df9515a21db51cea86b147e1d1e6ab2",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+4/-3); key paths: folder.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "0bbe3bb0feeb8f3412fd9a53066a2fcc422f5c66:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "2661a802963c02b840d9be6107d00391063aae84"
-  },
-  {
-    "seq": 70,
-    "timestamp": "2026-05-01T01:16:11-07:00",
-    "commit_hash": "2661a802963c02b840d9be6107d00391063aae84",
-    "commit_short": "2661a80",
-    "code_fingerprint": "ff11bc1b6acaf4c7aac578cd43bbaf050208a48029b952838373f0966072fae6",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+7/-3); key paths: bridge8-patched.html. Behavior: modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "2661a802963c02b840d9be6107d00391063aae84:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2"
-  },
-  {
-    "seq": 71,
-    "timestamp": "2026-05-01T00:38:52-07:00",
-    "commit_hash": "6074eb1be207e02c35ef43fceda38081481019a2",
-    "commit_short": "6074eb1",
-    "code_fingerprint": "864c6253726ed8765d61ca028cbc6a2c10d51477dacf560703e6f5c00526cb4a",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "combine.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+28/-89); key paths: bridge8-patched.html, combine.html. Behavior: adds normalization logic; adjusts transcription handling; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "6074eb1be207e02c35ef43fceda38081481019a2:bridge8-patched.html",
-      "6074eb1be207e02c35ef43fceda38081481019a2:combine.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc"
-  },
-  {
-    "seq": 72,
-    "timestamp": "2026-04-30T19:12:48-07:00",
-    "commit_hash": "1ca55a4db797027a611be068345f5d002e5ba7dc",
-    "commit_short": "1ca55a4",
-    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-21); key paths: folder.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "1ca55a4db797027a611be068345f5d002e5ba7dc:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269"
-  },
-  {
-    "seq": 73,
-    "timestamp": "2026-04-30T19:12:32-07:00",
-    "commit_hash": "75f804905813803e1af5c50c2872a79b1c5d9269",
-    "commit_short": "75f8049",
-    "code_fingerprint": "b076bf56fdca9239433888816749094ffa315e8beebf7ab1669dacd4b77a13fa",
-    "primary_filename": "combine.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "combine.html"
-      },
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+110/-11); key paths: combine.html, folder.html. Behavior: adds normalization logic; adjusts transcription handling; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "75f804905813803e1af5c50c2872a79b1c5d9269:combine.html",
-      "75f804905813803e1af5c50c2872a79b1c5d9269:folder.html"
-    ],
-    "launch_ref": "combine.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a"
-  },
-  {
-    "seq": 74,
-    "timestamp": "2026-04-30T19:11:29-07:00",
-    "commit_hash": "9807fc9d9ee78265619f56573090a33dd8fae85a",
-    "commit_short": "9807fc9",
-    "code_fingerprint": "a94cf8d58f97db3122065117e8a7bcbf52b406a9f43f18edc2fe025a0a02cc77",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+11/-21); key paths: folder.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "9807fc9d9ee78265619f56573090a33dd8fae85a:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287"
-  },
-  {
-    "seq": 75,
-    "timestamp": "2026-04-30T17:29:42-07:00",
-    "commit_hash": "505ee3639da7242f762ffc75f6426ad242cfb287",
-    "commit_short": "505ee36",
-    "code_fingerprint": "c4bd923274cf2c217e025829e00a7d3354bca46237c71cd26d289d2f2d3cbeed",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+17/-12); key paths: folder.html.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "505ee3639da7242f762ffc75f6426ad242cfb287:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a"
-  },
-  {
-    "seq": 76,
-    "timestamp": "2026-04-30T15:37:26-07:00",
-    "commit_hash": "0109ef79bf0d709dcf6db76489132abdfda1b83a",
-    "commit_short": "0109ef7",
-    "code_fingerprint": "ca1b8e1f764c569e153d2df94df9a9b9318205754071572d2cd2c3558bf7f195",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+9/-9); key paths: bridge8-patched.html. Behavior: adds normalization logic; changes joining/rejoining behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "joining/rejoining flow",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "0109ef79bf0d709dcf6db76489132abdfda1b83a:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, joining/rejoining flow, ui/ux flow changes.",
-    "previous_commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a"
-  },
-  {
-    "seq": 77,
-    "timestamp": "2026-04-30T15:25:02-07:00",
-    "commit_hash": "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a",
-    "commit_short": "47d49d4",
-    "code_fingerprint": "4b90b0ca4ea9dafd71af017623b0b1e29bb869d5b92f13eb0e61813604ddec7a",
-    "primary_filename": "folder.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1425/-1286); key paths: folder.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "47d49d44f3ef1aa2f651fabdc238ee3bf0276b3a:folder.html"
-    ],
-    "launch_ref": "folder.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f"
-  },
-  {
-    "seq": 78,
-    "timestamp": "2026-04-30T09:52:39-07:00",
-    "commit_hash": "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f",
-    "commit_short": "f5ca35c",
-    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "f5ca35c7aa4e176003b334a2d5c0aae495c43e6f:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39"
-  },
-  {
-    "seq": 79,
-    "timestamp": "2026-04-30T09:52:21-07:00",
-    "commit_hash": "000d821d2703645cb42d7ab4a2ec08cc8059dc39",
-    "commit_short": "000d821",
-    "code_fingerprint": "f268df82511591d7a72b4c6945d606826aa4240f7c9114bc25cd24b7ccd277ce",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "D",
-        "path": "bridge8-patched.html"
-      },
-      {
-        "status": "M",
-        "path": "folder-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+17/-1574); key paths: bridge8-patched.html, folder-v1.html. Behavior: modifies call termination behavior; modifies compose focus behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:bridge8-patched.html",
-      "000d821d2703645cb42d7ab4a2ec08cc8059dc39:folder-v1.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4"
-  },
-  {
-    "seq": 80,
-    "timestamp": "2026-04-30T09:43:05-07:00",
-    "commit_hash": "5fbfd050889202865fd1d369a9f9f46835347cf4",
-    "commit_short": "5fbfd05",
-    "code_fingerprint": "bcb19198be951ef196afa20cd544644296df2f271b5a3962ac2ccf9190233035",
-    "primary_filename": "bridge8-patched.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge8-patched.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1563/-0); key paths: bridge8-patched.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "5fbfd050889202865fd1d369a9f9f46835347cf4:bridge8-patched.html"
-    ],
-    "launch_ref": "bridge8-patched.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b"
-  },
-  {
-    "seq": 81,
-    "timestamp": "2026-04-30T05:58:04-07:00",
-    "commit_hash": "612ed7c646da2e6fe69bd82c2f57013ebdecc65b",
-    "commit_short": "612ed7c",
-    "code_fingerprint": "83f0c06c861127a61717679182026cced4a2fb286ec47c30119e68b5f25e4a1b",
-    "primary_filename": "folder-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-10); key paths: folder-v1.html. Behavior: updates UI/UX flow.",
-    "functional_impacts": [
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "612ed7c646da2e6fe69bd82c2f57013ebdecc65b:folder-v1.html"
-    ],
-    "launch_ref": "folder-v1.html",
-    "note": "Inferred impacts from patch hunks: ui/ux flow changes.",
-    "previous_commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826"
-  },
-  {
-    "seq": 82,
-    "timestamp": "2026-04-29T20:48:12-07:00",
-    "commit_hash": "47dcdfe54ff286772521ccc0992d4506c8807826",
-    "commit_short": "47dcdfe",
-    "code_fingerprint": "5ab5f4cedbba3c34965684bbdaf9e2f184ef47adac5a5d8fc1bf8902383178fc",
-    "primary_filename": "folder-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+30/-3); key paths: folder-v1.html. Behavior: updates translation/language flow; changes joining/rejoining behavior; modifies compose focus behavior.",
-    "functional_impacts": [
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "47dcdfe54ff286772521ccc0992d4506c8807826:folder-v1.html"
-    ],
-    "launch_ref": "folder-v1.html",
-    "note": "Inferred impacts from patch hunks: translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a"
-  },
-  {
-    "seq": 83,
-    "timestamp": "2026-04-29T15:28:50-07:00",
-    "commit_hash": "51fdf0baf671eca52961f8ae50683f2257f4860a",
-    "commit_short": "51fdf0b",
-    "code_fingerprint": "73e06a56193f04241aa2e76bab7109e2a8e5f5acc78069e4e1e43645b68947b0",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+7/-4); key paths: bridge8.html. Behavior: adds normalization logic; adjusts transcription handling; applies remediation/fix logic.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "51fdf0baf671eca52961f8ae50683f2257f4860a:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, remediation/repair/fix behavior.",
-    "previous_commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8"
-  },
-  {
-    "seq": 84,
-    "timestamp": "2026-04-29T15:13:46-07:00",
-    "commit_hash": "9f9f905d5e81a12101a8175e9ede5772bc0276a8",
-    "commit_short": "9f9f905",
-    "code_fingerprint": "b352417bc83e83c490639783cfea4ea43934130fcaf449840d9657f7a9827ca3",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+13/-46); key paths: bridge8.html. Behavior: adjusts transcription handling; updates translation/language flow; modifies compose focus behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "9f9f905d5e81a12101a8175e9ede5772bc0276a8:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8"
-  },
-  {
-    "seq": 85,
-    "timestamp": "2026-04-29T14:53:22-07:00",
-    "commit_hash": "78b712f6f394afc43c81e0edb6236379401c21d8",
-    "commit_short": "78b712f",
-    "code_fingerprint": "a42fc90b484bd7070df28a46ccc041bf4883f372b1796240fc07119ea8240cd4",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-26); key paths: bridge8.html. Behavior: adds normalization logic; adjusts transcription handling; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "78b712f6f394afc43c81e0edb6236379401c21d8:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, remediation/repair/fix behavior.",
-    "previous_commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee"
-  },
-  {
-    "seq": 86,
-    "timestamp": "2026-04-29T14:53:05-07:00",
-    "commit_hash": "8e48d01b2416178c985dc35ca5a3f7da64cd46ee",
-    "commit_short": "8e48d01",
-    "code_fingerprint": "fc3bfe80715192c3e468f722c242d22f1c6222e2ddca10d5bebfa338fe9f2bd7",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      },
-      {
-        "status": "M",
-        "path": "folder-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+81/-59); key paths: bridge8.html, folder-v1.html. Behavior: adjusts transcription handling; changes joining/rejoining behavior; modifies compose focus behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:bridge8.html",
-      "8e48d01b2416178c985dc35ca5a3f7da64cd46ee:folder-v1.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354"
-  },
-  {
-    "seq": 87,
-    "timestamp": "2026-04-29T14:52:28-07:00",
-    "commit_hash": "9a517b6654ac77afe65153ff64e781d02f25a354",
-    "commit_short": "9a517b6",
-    "code_fingerprint": "a42fc90b484bd7070df28a46ccc041bf4883f372b1796240fc07119ea8240cd4",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+31/-26); key paths: bridge8.html. Behavior: adds normalization logic; adjusts transcription handling; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "joining/rejoining flow",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "9a517b6654ac77afe65153ff64e781d02f25a354:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, joining/rejoining flow, remediation/repair/fix behavior.",
-    "previous_commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11"
-  },
-  {
-    "seq": 88,
-    "timestamp": "2026-04-29T14:25:57-07:00",
-    "commit_hash": "f92b1a8823d53cfdb012e2acfe3081f5ea12de11",
-    "commit_short": "f92b1a8",
-    "code_fingerprint": "233e22ddb2a8a2a63c0c42aa754710283264a86e56cb70a1e2a79e92aeb6cb38",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+37/-9); key paths: bridge8.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "f92b1a8823d53cfdb012e2acfe3081f5ea12de11:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f"
-  },
-  {
-    "seq": 89,
-    "timestamp": "2026-04-29T13:37:59-07:00",
-    "commit_hash": "a8459ec1dcc0b081f970b53b341167e8e5cd829f",
-    "commit_short": "a8459ec",
-    "code_fingerprint": "2cf98ac2af63acd3825ba4460de7c57cbe516760b39e7dcf0f534990182db69b",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+22/-9); key paths: bridge8.html. Behavior: adjusts transcription handling; changes joining/rejoining behavior; modifies call termination behavior.",
-    "functional_impacts": [
-      "transcription",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "a8459ec1dcc0b081f970b53b341167e8e5cd829f:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: transcription, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029"
-  },
-  {
-    "seq": 90,
-    "timestamp": "2026-04-29T12:57:43-07:00",
-    "commit_hash": "70905ee5ad416786a2cfefa64f619d0ed4eb2029",
-    "commit_short": "70905ee",
-    "code_fingerprint": "93c669513442e86748c1fec321db00f594ce7f8a50c81016dcfcf3e193c19f7d",
-    "primary_filename": "bridge8.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge8.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+350/-209); key paths: bridge8.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "70905ee5ad416786a2cfefa64f619d0ed4eb2029:bridge8.html"
-    ],
-    "launch_ref": "bridge8.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007"
-  },
-  {
-    "seq": 91,
-    "timestamp": "2026-04-29T11:49:48-07:00",
-    "commit_hash": "5498e012fcbea3d98b08ac8f8719f3483ef9c007",
-    "commit_short": "5498e01",
-    "code_fingerprint": "0259e887db6534a97e0df5567bad965b942d7279629f0a70321e2258b2534b91",
-    "primary_filename": "bridge5-reliability-implementation-guide.md",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "bridge5-reliability-implementation-guide.md"
-      },
-      {
-        "status": "M",
-        "path": "bridge5.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 2 file(s) (+412/-1); key paths: bridge5-reliability-implementation-guide.md, bridge5.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "5498e012fcbea3d98b08ac8f8719f3483ef9c007:bridge5-reliability-implementation-guide.md",
-      "5498e012fcbea3d98b08ac8f8719f3483ef9c007:bridge5.html"
-    ],
-    "launch_ref": "bridge5-reliability-implementation-guide.md",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5"
-  },
-  {
-    "seq": 92,
-    "timestamp": "2026-04-29T10:20:03-07:00",
-    "commit_hash": "a91df5c90b90d2debc24f01d5f627ec973ad05e5",
-    "commit_short": "a91df5c",
-    "code_fingerprint": "3c1dba789b6f8cf212d80a882a36bdaf3d55900ebdc864e3d44305ea2d2b099a",
-    "primary_filename": "folder-v1.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "folder-v1.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+79/-20); key paths: folder-v1.html. Behavior: modifies call termination behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "call termination behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "a91df5c90b90d2debc24f01d5f627ec973ad05e5:folder-v1.html"
-    ],
-    "launch_ref": "folder-v1.html",
-    "note": "Inferred impacts from patch hunks: call termination behavior, ui/ux flow changes.",
-    "previous_commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f"
-  },
-  {
-    "seq": 93,
-    "timestamp": "2026-04-29T10:09:14-07:00",
-    "commit_hash": "da3471207c91bbb0eab4c89b80cb7d0e8896375f",
-    "commit_short": "da34712",
-    "code_fingerprint": "1e06043cd0030a497fc58aad99c67809600395c9ea1d55fa985ff54cb2af3104",
-    "primary_filename": "mvp.html",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": "mvp.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+1200/-0); key paths: mvp.html. Behavior: adds normalization logic; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "normalization",
-      "translation",
-      "joining/rejoining flow",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "da3471207c91bbb0eab4c89b80cb7d0e8896375f:mvp.html"
-    ],
-    "launch_ref": "mvp.html",
-    "note": "Inferred impacts from patch hunks: normalization, translation, joining/rejoining flow, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2"
-  },
-  {
-    "seq": 94,
-    "timestamp": "2026-04-29T04:02:01-07:00",
-    "commit_hash": "334bb3779a443984362ae932b2d77b7d7449eca2",
-    "commit_short": "334bb37",
-    "code_fingerprint": "4b8985737a30e8fa9cdb1c0617e60b7059a6e1af8ac8c04f4085407ca889875e",
-    "primary_filename": "bridge4.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge4.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+257/-212); key paths: bridge4.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "334bb3779a443984362ae932b2d77b7d7449eca2:bridge4.html"
-    ],
-    "launch_ref": "bridge4.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b"
-  },
-  {
-    "seq": 95,
-    "timestamp": "2026-04-29T03:43:03-07:00",
-    "commit_hash": "edb2b1455cbbe3e5b0a15b998acc68931606ae9b",
-    "commit_short": "edb2b14",
-    "code_fingerprint": "8eac21a3d827a227889abdff1b655223b539c1e251d5e20929210278e3d471ad",
-    "primary_filename": "bridge3.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge3.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+33/-10); key paths: bridge3.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "edb2b1455cbbe3e5b0a15b998acc68931606ae9b:bridge3.html"
-    ],
-    "launch_ref": "bridge3.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, joining/rejoining flow, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6"
-  },
-  {
-    "seq": 96,
-    "timestamp": "2026-04-29T02:43:41-07:00",
-    "commit_hash": "5de44ec461db4973f9253be2f1224da1bc802af6",
-    "commit_short": "5de44ec",
-    "code_fingerprint": "1bb24a9b032bee3980a924453227faaa7417c970e35d854d335528cc84dca6a0",
-    "primary_filename": "bridge3.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge3.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+301/-86); key paths: bridge3.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "5de44ec461db4973f9253be2f1224da1bc802af6:bridge3.html"
-    ],
-    "launch_ref": "bridge3.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579"
-  },
-  {
-    "seq": 97,
-    "timestamp": "2026-04-29T02:02:52-07:00",
-    "commit_hash": "d226e42a50e87bcca0724c882cfffe7870b16579",
-    "commit_short": "d226e42",
-    "code_fingerprint": "8fd22a61dc6c9b37b5807aff81659bb484fd1d51440da24677112eadd42e4197",
-    "primary_filename": "bridge5.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge5.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+117/-76); key paths: bridge5.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "d226e42a50e87bcca0724c882cfffe7870b16579:bridge5.html"
-    ],
-    "launch_ref": "bridge5.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad"
-  },
-  {
-    "seq": 98,
-    "timestamp": "2026-04-29T01:59:17-07:00",
-    "commit_hash": "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad",
-    "commit_short": "075ddc1",
-    "code_fingerprint": "9a4155d76e21298008ce53d9776cf0478aa876eb0495dd9beabc87118e4fc321",
-    "primary_filename": "bridge5.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge5.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+34/-19); key paths: bridge5.html. Behavior: adds normalization logic; modifies call termination behavior; updates UI/UX flow.",
-    "functional_impacts": [
-      "normalization",
-      "call termination behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "075ddc16a0ec60ab62e8c5988ea86670b9a4e2ad:bridge5.html"
-    ],
-    "launch_ref": "bridge5.html",
-    "note": "Inferred impacts from patch hunks: normalization, call termination behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388"
-  },
-  {
-    "seq": 99,
-    "timestamp": "2026-04-29T00:16:16-07:00",
-    "commit_hash": "b940a35c57c2249a1556ec296ab98ce1c4ab8388",
-    "commit_short": "b940a35",
-    "code_fingerprint": "e014789f04953a019f0db35fc9707cd0f2b248e9903f4e5b0221d11844c3cbc4",
-    "primary_filename": "bridge4.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge4.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+297/-112); key paths: bridge4.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "b940a35c57c2249a1556ec296ab98ce1c4ab8388:bridge4.html"
-    ],
-    "launch_ref": "bridge4.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18"
-  },
-  {
-    "seq": 100,
-    "timestamp": "2026-04-28T23:16:44-07:00",
-    "commit_hash": "9562b493dc73cbcf7078ce1158ccce866241ac18",
-    "commit_short": "9562b49",
-    "code_fingerprint": "a3aed8ccb9a777a0c4a266a828ee6e10a86e40a27af83d9bb7c4cb4364d58ddc",
-    "primary_filename": "bridge5.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge5.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+18/-22); key paths: bridge5.html. Behavior: adjusts transcription handling; updates translation/language flow; changes joining/rejoining behavior.",
-    "functional_impacts": [
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes"
-    ],
-    "blob_refs": [
-      "9562b493dc73cbcf7078ce1158ccce866241ac18:bridge5.html"
-    ],
-    "launch_ref": "bridge5.html",
-    "note": "Inferred impacts from patch hunks: transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes.",
-    "previous_commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b"
-  },
-  {
-    "seq": 101,
-    "timestamp": "2026-04-28T22:46:25-07:00",
-    "commit_hash": "76a9c93a783e1ac0b80d939a3062007dd82e609b",
-    "commit_short": "76a9c93",
-    "code_fingerprint": "5b5aa7e42e818290dd88be77590846eac9f47bd4032154bd787dcf30452ac170",
-    "primary_filename": "bridge5.html",
-    "changed_paths": [
-      {
-        "status": "M",
-        "path": "bridge5.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 1 file(s) (+242/-290); key paths: bridge5.html. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "76a9c93a783e1ac0b80d939a3062007dd82e609b:bridge5.html"
-    ],
-    "launch_ref": "bridge5.html",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960"
-  },
-  {
-    "seq": 102,
-    "timestamp": "2026-04-28T22:28:50-07:00",
-    "commit_hash": "3ecf3325193e3049bd0adc9853df6c976794f960",
-    "commit_short": "3ecf332",
-    "code_fingerprint": "5d6c4086fb05852fe0d57a640ba216ba7f9551d908be6dae5e264874aac0f184",
-    "primary_filename": ".bolt/config.json",
-    "changed_paths": [
-      {
-        "status": "A",
-        "path": ".bolt/config.json"
-      },
-      {
-        "status": "A",
-        "path": ".bolt/prompt"
-      },
-      {
-        "status": "A",
-        "path": ".github/workflows/static.yml"
-      },
-      {
-        "status": "A",
-        "path": ".gitignore"
-      },
-      {
-        "status": "A",
-        "path": "2vid.html"
-      },
-      {
-        "status": "A",
-        "path": "Boid-fun.html"
-      },
-      {
-        "status": "A",
-        "path": "FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md"
-      },
-      {
-        "status": "A",
-        "path": "GET_WELL_PATCH_PROMPT.md"
-      },
-      {
-        "status": "A",
-        "path": "Instructions.txt"
-      },
-      {
-        "status": "A",
-        "path": "MyPlaceToChill.html"
-      },
-      {
-        "status": "A",
-        "path": "QA_LIFECYCLE_SCRIPT.md"
-      },
-      {
-        "status": "A",
-        "path": "README.md"
-      },
-      {
-        "status": "A",
-        "path": "SECRETS.md"
-      },
-      {
-        "status": "A",
-        "path": "SESSION_INSTRUCTION_SET.md"
-      },
-      {
-        "status": "A",
-        "path": "TALK-SAY-PRD-v1.md"
-      },
-      {
-        "status": "A",
-        "path": "TALK-SAY-PRD.md"
-      },
-      {
-        "status": "A",
-        "path": "Talk-Say-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "UI-v2.html.html"
-      },
-      {
-        "status": "A",
-        "path": "Visual MAD v3.html"
-      },
-      {
-        "status": "A",
-        "path": "ai-jobs-kanban (3).html"
-      },
-      {
-        "status": "A",
-        "path": "ai-jobs-kanban.json"
-      },
-      {
-        "status": "A",
-        "path": "app.html"
-      },
-      {
-        "status": "A",
-        "path": "battle.html"
-      },
-      {
-        "status": "A",
-        "path": "biord.html"
-      },
-      {
-        "status": "A",
-        "path": "block.html"
-      },
-      {
-        "status": "A",
-        "path": "blue.html"
-      },
-      {
-        "status": "A",
-        "path": "boid perp-plus.html"
-      },
-      {
-        "status": "A",
-        "path": "boid-perp.html"
-      },
-      {
-        "status": "A",
-        "path": "boidfloid wb.html"
-      },
-      {
-        "status": "A",
-        "path": "boidfloid-pro.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge (20).html"
-      },
-      {
-        "status": "A",
-        "path": "bridge (5).html"
-      },
-      {
-        "status": "A",
-        "path": "bridge (6).html"
-      },
-      {
-        "status": "A",
-        "path": "bridge (7).html"
-      },
-      {
-        "status": "A",
-        "path": "bridge-c.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge-dcr.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge-transcript-analysis.md"
-      },
-      {
-        "status": "A",
-        "path": "bridge-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge-v2.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge-v3.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge1-test-matrix.md"
-      },
-      {
-        "status": "A",
-        "path": "bridge1.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge2.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge3.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge4.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge5.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge5a.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge5b.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge5c.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge6.html"
-      },
-      {
-        "status": "A",
-        "path": "bridge8.html"
-      },
-      {
-        "status": "A",
-        "path": "buildit.html"
-      },
-      {
-        "status": "A",
-        "path": "casa.html"
-      },
-      {
-        "status": "A",
-        "path": "chat.html"
-      },
-      {
-        "status": "A",
-        "path": "clock.html"
-      },
-      {
-        "status": "A",
-        "path": "combined_oauth_server_for_repo.js"
-      },
-      {
-        "status": "A",
-        "path": "compound.html"
-      },
-      {
-        "status": "A",
-        "path": "convo.html"
-      },
-      {
-        "status": "A",
-        "path": "core.html"
-      },
-      {
-        "status": "A",
-        "path": "currency.html"
-      },
-      {
-        "status": "A",
-        "path": "dash.html"
-      },
-      {
-        "status": "A",
-        "path": "dev.html"
-      },
-      {
-        "status": "A",
-        "path": "dg.html"
-      },
-      {
-        "status": "A",
-        "path": "diag.html"
-      },
-      {
-        "status": "A",
-        "path": "do.html"
-      },
-      {
-        "status": "A",
-        "path": "dualtime.html"
-      },
-      {
-        "status": "A",
-        "path": "enhanced-fixed.js"
-      },
-      {
-        "status": "A",
-        "path": "enhanced-hitomezashi.html"
-      },
-      {
-        "status": "A",
-        "path": "enhanced.js"
-      },
-      {
-        "status": "A",
-        "path": "eslint.config.js"
-      },
-      {
-        "status": "A",
-        "path": "fastType/deleteme"
-      },
-      {
-        "status": "A",
-        "path": "fastType/fastText.common.wasm"
-      },
-      {
-        "status": "A",
-        "path": "fastType/lid.176.ftz"
-      },
-      {
-        "status": "A",
-        "path": "fetch-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "fetch.html"
-      },
-      {
-        "status": "A",
-        "path": "finapp.html"
-      },
-      {
-        "status": "A",
-        "path": "flags.png"
-      },
-      {
-        "status": "A",
-        "path": "fly.html"
-      },
-      {
-        "status": "A",
-        "path": "flyv1.html"
-      },
-      {
-        "status": "A",
-        "path": "flyv2.html"
-      },
-      {
-        "status": "A",
-        "path": "folder-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "folder.html"
-      },
-      {
-        "status": "A",
-        "path": "g.html"
-      },
-      {
-        "status": "A",
-        "path": "ga.html"
-      },
-      {
-        "status": "A",
-        "path": "game.html"
-      },
-      {
-        "status": "A",
-        "path": "gdrive-metadata-extraction.html"
-      },
-      {
-        "status": "A",
-        "path": "getit.html"
-      },
-      {
-        "status": "A",
-        "path": "gg.html"
-      },
-      {
-        "status": "A",
-        "path": "ggg.html"
-      },
-      {
-        "status": "A",
-        "path": "gggg.html"
-      },
-      {
-        "status": "A",
-        "path": "gh.html"
-      },
-      {
-        "status": "A",
-        "path": "gh.html.html"
-      },
-      {
-        "status": "A",
-        "path": "git.html"
-      },
-      {
-        "status": "A",
-        "path": "github.html"
-      },
-      {
-        "status": "A",
-        "path": "glate.html"
-      },
-      {
-        "status": "A",
-        "path": "goji.html"
-      },
-      {
-        "status": "A",
-        "path": "groove.html"
-      },
-      {
-        "status": "A",
-        "path": "groovy.html"
-      },
-      {
-        "status": "A",
-        "path": "gt.html"
-      },
-      {
-        "status": "A",
-        "path": "gtg.html"
-      },
-      {
-        "status": "A",
-        "path": "hexi.html"
-      },
-      {
-        "status": "A",
-        "path": "home.html"
-      },
-      {
-        "status": "A",
-        "path": "index copy.html"
-      },
-      {
-        "status": "A",
-        "path": "index.html"
-      },
-      {
-        "status": "A",
-        "path": "ithub.html"
-      },
-      {
-        "status": "A",
-        "path": "join.html"
-      },
-      {
-        "status": "A",
-        "path": "joy.html"
-      },
-      {
-        "status": "A",
-        "path": "kaleidoscope_visualizer_advanced.html"
-      },
-      {
-        "status": "A",
-        "path": "kanban.html"
-      },
-      {
-        "status": "A",
-        "path": "kanban.json"
-      },
-      {
-        "status": "A",
-        "path": "kanban2.html"
-      },
-      {
-        "status": "A",
-        "path": "kanban3.html"
-      },
-      {
-        "status": "A",
-        "path": "landmark-bridge.html"
-      },
-      {
-        "status": "A",
-        "path": "layout.html"
-      },
-      {
-        "status": "A",
-        "path": "lim.html"
-      },
-      {
-        "status": "A",
-        "path": "liminal_breach_stable_classic_graphics.html"
-      },
-      {
-        "status": "A",
-        "path": "love.html"
-      },
-      {
-        "status": "A",
-        "path": "love2.html"
-      },
-      {
-        "status": "A",
-        "path": "loveit.html"
-      },
-      {
-        "status": "A",
-        "path": "magic+.html"
-      },
-      {
-        "status": "A",
-        "path": "magic.html"
-      },
-      {
-        "status": "A",
-        "path": "menu.html"
-      },
-      {
-        "status": "A",
-        "path": "metadata-sync-worker.js"
-      },
-      {
-        "status": "A",
-        "path": "metadata_extractor_lib.js"
-      },
-      {
-        "status": "A",
-        "path": "metric.html"
-      },
-      {
-        "status": "A",
-        "path": "mic.html"
-      },
-      {
-        "status": "A",
-        "path": "milkyway.html"
-      },
-      {
-        "status": "A",
-        "path": "mob.html"
-      },
-      {
-        "status": "A",
-        "path": "mobapp.html"
-      },
-      {
-        "status": "A",
-        "path": "mobweb (1) (2).html"
-      },
-      {
-        "status": "A",
-        "path": "mobweb.html"
-      },
-      {
-        "status": "A",
-        "path": "noon-dear.html"
-      },
-      {
-        "status": "A",
-        "path": "noon.html"
-      },
-      {
-        "status": "A",
-        "path": "notify.html"
-      },
-      {
-        "status": "A",
-        "path": "onedrive.html"
-      },
-      {
-        "status": "A",
-        "path": "orb.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-dev-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-gdrive-integrated-hold.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-gdrive-integrated-v0.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-gdrive-integrated-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-gdrive-integrated.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-login.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-metadata-worker.js"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-sw.js"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v10.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v11.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v12.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v13.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v14 copy.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v14.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v14.html.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v14b.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v15.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v2.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v3.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v3a.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v4.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v5-old.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8-v5.html"
-      },
-      {
-        "status": "A",
-        "path": "orbital8.html"
-      },
-      {
-        "status": "A",
-        "path": "p.html"
-      },
-      {
-        "status": "A",
-        "path": "package-lock.json"
-      },
-      {
-        "status": "A",
-        "path": "package.json"
-      },
-      {
-        "status": "A",
-        "path": "packs/global/delete.txt"
-      },
-      {
-        "status": "A",
-        "path": "packs/global/logging.json"
-      },
-      {
-        "status": "A",
-        "path": "packs/global/script-old.js"
-      },
-      {
-        "status": "A",
-        "path": "packs/global/script.js"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/blue/download.jpeg"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/blue/msg.txt"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/blue/sound.mp3"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/delete.txt"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/joy/delete.txt"
-      },
-      {
-        "status": "A",
-        "path": "packs/local/love/delete.txt"
-      },
-      {
-        "status": "A",
-        "path": "partial.html"
-      },
-      {
-        "status": "A",
-        "path": "peace.html"
-      },
-      {
-        "status": "A",
-        "path": "pend.html"
-      },
-      {
-        "status": "A",
-        "path": "plan.html"
-      },
-      {
-        "status": "A",
-        "path": "playdoh.html"
-      },
-      {
-        "status": "A",
-        "path": "portal-create.html"
-      },
-      {
-        "status": "A",
-        "path": "portal.html"
-      },
-      {
-        "status": "A",
-        "path": "postcss.config.js"
-      },
-      {
-        "status": "A",
-        "path": "quilt.html"
-      },
-      {
-        "status": "A",
-        "path": "rec08.html"
-      },
-      {
-        "status": "A",
-        "path": "reco01.html"
-      },
-      {
-        "status": "A",
-        "path": "reco02.html"
-      },
-      {
-        "status": "A",
-        "path": "reco03.html"
-      },
-      {
-        "status": "A",
-        "path": "reco04.html"
-      },
-      {
-        "status": "A",
-        "path": "reco05.html"
-      },
-      {
-        "status": "A",
-        "path": "reco06.html"
-      },
-      {
-        "status": "A",
-        "path": "reco07.html"
-      },
-      {
-        "status": "A",
-        "path": "repoblast.html"
-      },
-      {
-        "status": "A",
-        "path": "repolist.html"
-      },
-      {
-        "status": "A",
-        "path": "restructure.txt"
-      },
-      {
-        "status": "A",
-        "path": "roll.html"
-      },
-      {
-        "status": "A",
-        "path": "rss.html"
-      },
-      {
-        "status": "A",
-        "path": "sacred.html"
-      },
-      {
-        "status": "A",
-        "path": "say-alpha.html"
-      },
-      {
-        "status": "A",
-        "path": "say.html"
-      },
-      {
-        "status": "A",
-        "path": "sayit-v2.html.html"
-      },
-      {
-        "status": "A",
-        "path": "sayit-v3.html"
-      },
-      {
-        "status": "A",
-        "path": "sayit-v4.html"
-      },
-      {
-        "status": "A",
-        "path": "sayit.html"
-      },
-      {
-        "status": "A",
-        "path": "scribe.html"
-      },
-      {
-        "status": "A",
-        "path": "scrub.html"
-      },
-      {
-        "status": "A",
-        "path": "shad.html"
-      },
-      {
-        "status": "A",
-        "path": "shader.html"
-      },
-      {
-        "status": "A",
-        "path": "sigma.html"
-      },
-      {
-        "status": "A",
-        "path": "slideswipe.html"
-      },
-      {
-        "status": "A",
-        "path": "solar.html"
-      },
-      {
-        "status": "A",
-        "path": "spin.html"
-      },
-      {
-        "status": "A",
-        "path": "src/App.tsx"
-      },
-      {
-        "status": "A",
-        "path": "src/index.css"
-      },
-      {
-        "status": "A",
-        "path": "src/main.tsx"
-      },
-      {
-        "status": "A",
-        "path": "src/vite-env.d.ts"
-      },
-      {
-        "status": "A",
-        "path": "stars.html"
-      },
-      {
-        "status": "A",
-        "path": "stt-test.html"
-      },
-      {
-        "status": "A",
-        "path": "supabase/functions/venice-ai/index.ts"
-      },
-      {
-        "status": "A",
-        "path": "sw-enhanced.js"
-      },
-      {
-        "status": "A",
-        "path": "sy.html"
-      },
-      {
-        "status": "A",
-        "path": "synesthetic_experience_updated.html"
-      },
-      {
-        "status": "A",
-        "path": "tab.html"
-      },
-      {
-        "status": "A",
-        "path": "tag-example.html"
-      },
-      {
-        "status": "A",
-        "path": "tailwind.config.js"
-      },
-      {
-        "status": "A",
-        "path": "talk-notifications-sw.js"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-claude.html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-gemini.html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-prd-v1.7.pdf"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-v1.5 (1).html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-v1.5 (2).html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-v1.6.html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-v3.2 (3).html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-v3.2 (5).html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say-venice.html"
-      },
-      {
-        "status": "A",
-        "path": "talk-say.html"
-      },
-      {
-        "status": "A",
-        "path": "talk.html"
-      },
-      {
-        "status": "A",
-        "path": "talk.webmanifest"
-      },
-      {
-        "status": "A",
-        "path": "talk01.html"
-      },
-      {
-        "status": "A",
-        "path": "talkv2.html"
-      },
-      {
-        "status": "A",
-        "path": "tb-app.js"
-      },
-      {
-        "status": "A",
-        "path": "tb-media.js"
-      },
-      {
-        "status": "A",
-        "path": "tb-transcribe.js"
-      },
-      {
-        "status": "A",
-        "path": "tb-translate.js"
-      },
-      {
-        "status": "A",
-        "path": "tb-transport.js"
-      },
-      {
-        "status": "A",
-        "path": "test-outline.md"
-      },
-      {
-        "status": "A",
-        "path": "test-pam (2).html"
-      },
-      {
-        "status": "A",
-        "path": "test-pam-objective-analysis-plan.md"
-      },
-      {
-        "status": "A",
-        "path": "test-pam.html"
-      },
-      {
-        "status": "A",
-        "path": "test-rollback.html"
-      },
-      {
-        "status": "A",
-        "path": "test.html"
-      },
-      {
-        "status": "A",
-        "path": "test01.html"
-      },
-      {
-        "status": "A",
-        "path": "test02.html"
-      },
-      {
-        "status": "A",
-        "path": "test03.html"
-      },
-      {
-        "status": "A",
-        "path": "testplan.html"
-      },
-      {
-        "status": "A",
-        "path": "thai-transcriber-v2.html"
-      },
-      {
-        "status": "A",
-        "path": "thai-transcriber-v4.html"
-      },
-      {
-        "status": "A",
-        "path": "thai-transcriber-v7 (3).html"
-      },
-      {
-        "status": "A",
-        "path": "tilt-balance-mobile-fixed-v3-1.html"
-      },
-      {
-        "status": "A",
-        "path": "time.html"
-      },
-      {
-        "status": "A",
-        "path": "tk.html"
-      },
-      {
-        "status": "A",
-        "path": "tksy.html"
-      },
-      {
-        "status": "A",
-        "path": "tracker.html"
-      },
-      {
-        "status": "A",
-        "path": "tsconfig.app.json"
-      },
-      {
-        "status": "A",
-        "path": "tsconfig.json"
-      },
-      {
-        "status": "A",
-        "path": "tsconfig.node.json"
-      },
-      {
-        "status": "A",
-        "path": "ugh.html"
-      },
-      {
-        "status": "A",
-        "path": "update_test_html_patch_prompt.txt"
-      },
-      {
-        "status": "A",
-        "path": "uri.html"
-      },
-      {
-        "status": "A",
-        "path": "v.html"
-      },
-      {
-        "status": "A",
-        "path": "venice.html"
-      },
-      {
-        "status": "A",
-        "path": "vite.config.ts"
-      },
-      {
-        "status": "A",
-        "path": "voice-c.html"
-      },
-      {
-        "status": "A",
-        "path": "voice.html"
-      },
-      {
-        "status": "A",
-        "path": "voicehelper.html"
-      },
-      {
-        "status": "A",
-        "path": "vsay.html"
-      },
-      {
-        "status": "A",
-        "path": "vvv.html"
-      },
-      {
-        "status": "A",
-        "path": "vvvv.html"
-      },
-      {
-        "status": "A",
-        "path": "week.html"
-      },
-      {
-        "status": "A",
-        "path": "weekend-v1.html"
-      },
-      {
-        "status": "A",
-        "path": "weekend-v2.html"
-      },
-      {
-        "status": "A",
-        "path": "weekend-v3.html"
-      },
-      {
-        "status": "A",
-        "path": "weekend.html"
-      },
-      {
-        "status": "A",
-        "path": "x.html"
-      },
-      {
-        "status": "A",
-        "path": "xlate.html"
-      },
-      {
-        "status": "A",
-        "path": "xml.html"
-      },
-      {
-        "status": "A",
-        "path": "zoom.html"
-      }
-    ],
-    "description_delta_from_previous": "Patch touched 287 file(s) (+343512/-0); key paths: .bolt/config.json, .bolt/prompt, .github/workflows/static.yml. Behavior: adds normalization logic; adjusts transcription handling; updates translation/language flow.",
-    "functional_impacts": [
-      "normalization",
-      "transcription",
-      "translation",
-      "joining/rejoining flow",
-      "call termination behavior",
-      "compose strip focus behavior",
-      "ui/ux flow changes",
-      "remediation/repair/fix behavior"
-    ],
-    "blob_refs": [
-      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/config.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:.bolt/prompt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:.github/workflows/static.yml",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:.gitignore",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:2vid.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:Boid-fun.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:FINAL_ACCEPTANCE_SAMSUNG_CHROME_2026-04-09.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:GET_WELL_PATCH_PROMPT.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:Instructions.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:MyPlaceToChill.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:QA_LIFECYCLE_SCRIPT.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:README.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:SECRETS.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:SESSION_INSTRUCTION_SET.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:TALK-SAY-PRD-v1.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:TALK-SAY-PRD.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:Talk-Say-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:UI-v2.html.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:Visual MAD v3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ai-jobs-kanban (3).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ai-jobs-kanban.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:app.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:battle.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:biord.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:block.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:blue.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:boid perp-plus.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:boid-perp.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:boidfloid wb.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:boidfloid-pro.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge (20).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge (5).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge (6).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge (7).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-c.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-dcr.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-transcript-analysis.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-v2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge-v3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge1-test-matrix.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge4.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge5.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge5a.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge5b.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge5c.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge6.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:bridge8.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:buildit.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:casa.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:chat.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:clock.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:combined_oauth_server_for_repo.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:compound.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:convo.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:core.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:currency.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:dash.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:dev.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:dg.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:diag.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:do.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:dualtime.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:enhanced-fixed.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:enhanced-hitomezashi.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:enhanced.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:eslint.config.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fastType/deleteme",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fastType/fastText.common.wasm",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fastType/lid.176.ftz",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fetch-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fetch.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:finapp.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:flags.png",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:fly.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:flyv1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:flyv2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:folder-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:folder.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:g.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ga.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:game.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gdrive-metadata-extraction.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:getit.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gg.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ggg.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gggg.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gh.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gh.html.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:git.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:github.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:glate.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:goji.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:groove.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:groovy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gt.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:gtg.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:hexi.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:home.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:index copy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:index.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ithub.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:join.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:joy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:kaleidoscope_visualizer_advanced.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:kanban.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:kanban.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:kanban2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:kanban3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:landmark-bridge.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:layout.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:lim.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:liminal_breach_stable_classic_graphics.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:love.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:love2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:loveit.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:magic+.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:magic.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:menu.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:metadata-sync-worker.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:metadata_extractor_lib.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:metric.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:mic.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:milkyway.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:mob.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:mobapp.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:mobweb (1) (2).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:mobweb.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:noon-dear.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:noon.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:notify.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:onedrive.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orb.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-dev-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-gdrive-integrated-hold.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-gdrive-integrated-v0.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-gdrive-integrated-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-gdrive-integrated.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-login.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-metadata-worker.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-sw.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v10.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v11.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v12.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v13.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v14 copy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v14.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v14.html.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v14b.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v15.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v3a.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v4.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v5-old.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8-v5.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:orbital8.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:p.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:package-lock.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:package.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/global/delete.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/global/logging.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/global/script-old.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/global/script.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/blue/download.jpeg",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/blue/msg.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/blue/sound.mp3",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/delete.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/joy/delete.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:packs/local/love/delete.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:partial.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:peace.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:pend.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:plan.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:playdoh.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:portal-create.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:portal.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:postcss.config.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:quilt.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:rec08.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco01.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco02.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco03.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco04.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco05.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco06.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:reco07.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:repoblast.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:repolist.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:restructure.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:roll.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:rss.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sacred.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:say-alpha.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:say.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sayit-v2.html.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sayit-v3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sayit-v4.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sayit.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:scribe.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:scrub.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:shad.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:shader.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sigma.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:slideswipe.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:solar.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:spin.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:src/App.tsx",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:src/index.css",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:src/main.tsx",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:src/vite-env.d.ts",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:stars.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:stt-test.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:supabase/functions/venice-ai/index.ts",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sw-enhanced.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:sy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:synesthetic_experience_updated.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tab.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tag-example.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tailwind.config.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-notifications-sw.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-claude.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-gemini.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-prd-v1.7.pdf",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-v1.5 (1).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-v1.5 (2).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-v1.6.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-v3.2 (3).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-v3.2 (5).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say-venice.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk-say.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk.webmanifest",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talk01.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:talkv2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tb-app.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tb-media.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tb-transcribe.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tb-translate.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tb-transport.js",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test-outline.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test-pam (2).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test-pam-objective-analysis-plan.md",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test-pam.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test-rollback.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test01.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test02.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:test03.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:testplan.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:thai-transcriber-v2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:thai-transcriber-v4.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:thai-transcriber-v7 (3).html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tilt-balance-mobile-fixed-v3-1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:time.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tk.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tksy.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tracker.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tsconfig.app.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tsconfig.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:tsconfig.node.json",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:ugh.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:update_test_html_patch_prompt.txt",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:uri.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:v.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:venice.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:vite.config.ts",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:voice-c.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:voice.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:voicehelper.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:vsay.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:vvv.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:vvvv.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:week.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:weekend-v1.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:weekend-v2.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:weekend-v3.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:weekend.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:x.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:xlate.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:xml.html",
-      "3ecf3325193e3049bd0adc9853df6c976794f960:zoom.html"
-    ],
-    "launch_ref": ".bolt/config.json",
-    "note": "Inferred impacts from patch hunks: normalization, transcription, translation, joining/rejoining flow, call termination behavior, compose strip focus behavior, ui/ux flow changes, remediation/repair/fix behavior.",
-    "previous_commit_hash": null
+    "note": "Author acmeproducts. Diff-evidence only summary generated from bridge* lineage chain rooted at ec23f33.",
+    "previous_commit_hash": "116ce1466570b35b822be41ef99ad9d2044784de"
   }
 ]

--- a/repo.html
+++ b/repo.html
@@ -12,7 +12,7 @@
     .left { background:#020617; border-right:1px solid var(--line); overflow:auto; }
     .right { overflow:auto; }
     .top { padding:10px; border-bottom:1px solid var(--line); position:sticky; top:0; background:#020617; z-index:10; }
-    .search { width:100%; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
+    .search,.sel { width:100%; background:#0b1220; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px; }
     .list { padding:10px; display:flex; flex-direction:column; gap:6px; }
     .item { padding:8px; border:1px solid var(--line); border-radius:8px; cursor:pointer; background:#0b1220; }
     .item.active { border-color:var(--brand); }
@@ -20,32 +20,37 @@
     .card { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:10px; margin-bottom:10px; }
     .muted{ color:var(--muted); font-size:.9rem; }
     code { color:#bae6fd; }
+    .tabs button{background:#0b1220;color:var(--text);border:1px solid var(--line);padding:6px 10px;border-radius:8px;margin-right:6px;cursor:pointer}
+    .tabs .active{border-color:var(--brand)}
+    .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}.frame{width:100%;height:65vh;border:1px solid var(--line);border-radius:8px;background:#fff}
   </style>
 </head>
 <body>
   <div class="app" id="app">
-    <aside class="left">
-      <div class="top">
-        <input class="search" id="omni" placeholder="Search hash, path, impact, summary" />
-      </div>
-      <div class="list" id="variantList"></div>
-    </aside>
-    <main class="right">
-      <section class="pane" id="explorer">
-        <div class="card" id="activeMeta"></div>
-      </section>
-    </main>
+    <aside class="left"><div class="top"><input class="search" id="omni" placeholder="Search hash, path, impact, summary, PT time" /></div><div class="list" id="variantList"></div></aside>
+    <main class="right"><section class="pane"><div class="tabs"><button id="tabDetails" class="active">Details</button><button id="tabSide">Side-by-Side</button></div><div id="detailsPane" class="card"></div><div id="sidePane" class="card" style="display:none"><div class="row"><div><input class="search" id="leftFilter" placeholder="Filter left options"/><select id="leftSel" class="sel"></select><div class='muted' id='leftFile'></div><div><a id='leftBlob' target='_blank'>view blob</a> · <a id='leftLaunch' target='_blank'>launch actual version</a></div><iframe id="leftFrame" class="frame"></iframe></div><div><input class="search" id="rightFilter" placeholder="Filter right options"/><select id="rightSel" class="sel"></select><div class='muted' id='rightFile'></div><div><a id='rightBlob' target='_blank'>view blob</a> · <a id='rightLaunch' target='_blank'>launch actual version</a></div><iframe id="rightFrame" class="frame"></iframe></div></div></div></section></main>
   </div>
 <script>
-let all=[]; let shown=[]; let current=null;
+let all=[]; let shown=[]; let current=null; let leftOpts=[]; let rightOpts=[];
 const $=id=>document.getElementById(id);
 function esc(s){return String(s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
 function setCurrentBySeq(seq){current=shown.find(x=>x.seq===seq)||shown[0]; renderList(); renderCurrent();}
-function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.seq===x.seq?'active':''}' data-seq='${x.seq}'><strong>#${x.seq} ${esc(x.commit_short)}</strong><div class='muted'>${esc(x.timestamp)} · ${esc(x.primary_filename||'')}</div><div class='muted'>${esc((x.functional_impacts||[]).join(', ')||'no impact tags')}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrentBySeq(Number(n.dataset.seq))); }
-function renderCurrent(){ if(!current) return; $('activeMeta').innerHTML=`<strong>Timeline Entry #${current.seq}</strong><div class='muted'>${esc(current.timestamp)}</div><div><code title='${esc(current.commit_hash)}'>${esc(current.commit_short)}</code> · <span class='muted'>full: ${esc(current.commit_hash)}</span></div><div><strong>code_fingerprint</strong>: <code>${esc(current.code_fingerprint)}</code></div><div><strong>description_delta_from_previous</strong>: ${esc(current.description_delta_from_previous)}</div><div><strong>functional_impacts</strong>: ${esc((current.functional_impacts||[]).join(', ')||'none')}</div><div><strong>primary_filename</strong>: ${esc(current.primary_filename||'N/A')}</div><div><strong>changed_paths</strong><pre>${esc(JSON.stringify(current.changed_paths||[], null, 2))}</pre></div>`; }
-function applyFilter(q){ const n=q.toLowerCase().trim(); shown=all.filter(x=>[x.commit_hash,x.commit_short,x.primary_filename,x.description_delta_from_previous,(x.functional_impacts||[]).join(' '),JSON.stringify(x.changed_paths||[])].join(' ').toLowerCase().includes(n)); current=null; if(shown[0]) setCurrentBySeq(shown[0].seq); else {renderList(); $('activeMeta').innerHTML='<div class="muted">No matching entries.</div>';} }
+function label(x){return `#${x.seq} ${x.commit_short} · ${x.primary_filename||''} · ${x.timestamp_pt}`;}
+function blobUrl(x){const f=x.primary_filename||''; return `https://github.com/acmeproducts/stuff/blob/${x.commit_hash}/${f}`;}
+function launchUrl(x){return x.launch_ref||x.primary_filename||'';}
+function renderList(){ $('variantList').innerHTML=shown.map(x=>`<div class='item ${current&&current.seq===x.seq?'active':''}' data-seq='${x.seq}'><strong>#${x.seq} ${esc(x.commit_short)}</strong><div class='muted'>${esc(x.timestamp_pt)} · ${esc(x.primary_filename||'')}</div><div class='muted'>${esc(x.commit_message||'')}</div><div class='muted'>${esc(x.note||'')}</div></div>`).join(''); $('variantList').querySelectorAll('.item').forEach(n=>n.onclick=()=>setCurrentBySeq(Number(n.dataset.seq))); }
+function renderCurrent(){ if(!current) return; $('detailsPane').innerHTML=`<strong>Timeline Entry #${current.seq}</strong><div class='muted'>${esc(current.timestamp_pt)} (${esc(current.timestamp)})</div><div><code title='${esc(current.commit_hash)}'>${esc(current.commit_short)}</code> · ${esc(current.commit_message||'')}</div><div><strong>description_delta_from_previous</strong>: ${esc(current.description_delta_from_previous)}</div><div><strong>functional_impacts</strong>: ${esc((current.functional_impacts||[]).join(', ')||'none')}</div><div><strong>note</strong>: ${esc(current.note||'')}</div><div><strong>file</strong>: ${esc(current.primary_filename||'')}</div><div><a href="${esc(blobUrl(current))}" target="_blank">view blob</a> · <a href="${esc(launchUrl(current))}" target="_blank">launch actual version</a></div>`; }
+function applyFilter(q){ const n=q.toLowerCase().trim(); shown=all.filter(x=>[x.commit_hash,x.commit_short,x.primary_filename,x.description_delta_from_previous,(x.functional_impacts||[]).join(' '),JSON.stringify(x.changed_paths||[]),x.commit_message,x.note,x.timestamp_pt,x.timestamp].join(' ').toLowerCase().includes(n)); current=null; if(shown[0]) setCurrentBySeq(shown[0].seq); else {renderList(); $('detailsPane').innerHTML='<div class="muted">No matching entries.</div>';} updateSelects(); }
+function syncSide(side,opt){ if(!opt) return; $(side+'Frame').src=launchUrl(opt)||''; $(side+'File').textContent=`file: ${opt.primary_filename||''}`; $(side+'Blob').href=blobUrl(opt); $(side+'Launch').href=launchUrl(opt); }
+function fillSelect(selId, opts){ const sel=$(selId); sel.innerHTML=opts.map(o=>`<option value="${esc(o.seq)}">${esc(label(o))}</option>`).join(''); if(opts[0]) syncSide(selId==='leftSel'?'left': 'right', opts[0]); }
+function updateSelects(){ leftOpts=[...shown]; rightOpts=[...shown]; fillSelect('leftSel', leftOpts); fillSelect('rightSel', rightOpts); }
+function wireFilters(inputId, selId, side){ $(inputId).oninput=e=>{ const q=e.target.value.toLowerCase(); const opts=shown.filter(x=>label(x).toLowerCase().includes(q)); side==='left'?leftOpts=opts:rightOpts=opts; fillSelect(selId, opts); }; }
 $('omni').oninput=e=>applyFilter(e.target.value);
-fetch('bridge-lineage-timeline-model.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{ all=[...data].sort((a,b)=>b.seq-a.seq); shown=[...all]; if(shown[0]) setCurrentBySeq(shown[0].seq); else $('activeMeta').textContent='Timeline model is empty.'; }).catch(e=>{$('activeMeta').textContent='Load failed: '+e.message;});
+$('leftSel').onchange=e=>syncSide('left', shown.find(x=>String(x.seq)===e.target.value)); $('rightSel').onchange=e=>syncSide('right', shown.find(x=>String(x.seq)===e.target.value));
+wireFilters('leftFilter','leftSel','left'); wireFilters('rightFilter','rightSel','right');
+$('tabDetails').onclick=()=>{$('tabDetails').classList.add('active');$('tabSide').classList.remove('active');$('detailsPane').style.display='block';$('sidePane').style.display='none';};
+$('tabSide').onclick=()=>{$('tabSide').classList.add('active');$('tabDetails').classList.remove('active');$('detailsPane').style.display='none';$('sidePane').style.display='block';};
+fetch('bridge-lineage-timeline-model.json',{cache:'no-store'}).then(r=>r.json()).then(data=>{ all=[...data].sort((a,b)=>b.seq-a.seq); shown=[...all]; if(shown[0]) setCurrentBySeq(shown[0].seq); else $('detailsPane').textContent='Timeline model is empty.'; updateSelects(); }).catch(e=>{$('detailsPane').textContent='Load failed: '+e.message;});
 </script>
 </body>
 </html>

--- a/scripts/build-lineage-model.mjs
+++ b/scripts/build-lineage-model.mjs
@@ -3,135 +3,74 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 
 const MODEL_PATH = 'bridge-lineage-timeline-model.json';
-const SCOPE_PATH = '.';
+const START_COMMIT = 'ec23f33';
+const PT_FORMATTER = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles', year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false, timeZoneName: 'short' });
+const BRIDGE_PATHSPEC = [':(glob)bridge*.html'];
 
-function git(args) {
-  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 256 }).trimEnd();
-}
-
-function hashText(text) {
-  return createHash('sha256').update(text).digest('hex');
-}
+const git = (args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 256 }).trimEnd();
+const hashText = (text) => createHash('sha256').update(text).digest('hex');
+const formatPacific = (iso) => PT_FORMATTER.format(new Date(iso));
 
 function normalizePatch(text) {
-  return text
-    .replace(/\r\n/g, '\n')
-    .split('\n')
-    .filter((line) => !line.startsWith('index '))
-    .map((line) => line.replace(/[ \t]+$/g, ''))
-    .join('\n')
-    .trim();
+  return text.replace(/\r\n/g, '\n').split('\n').filter((line) => !line.startsWith('index ')).map((line) => line.replace(/[ \t]+$/g, '')).join('\n').trim();
 }
-
-const impactMatchers = [
-  ['normalization', /(normalize|normalization|canonical|trim\(|sanitize|dedupe|clean)/i],
-  ['transcription', /(transcrib|speech|stt|recognition|utterance|transcript)/i],
-  ['translation', /(translat|locale|language|i18n|thai|english|xlate)/i],
-  ['joining/rejoining flow', /(rejoin|join\b|reconnect|session|handshake|room|participant)/i],
-  ['call termination behavior', /(hangup|terminate|end call|disconnect|teardown|close\(|leave call)/i],
-  ['compose strip focus behavior', /(compose|focus|cursor|caret|textarea|input field|contenteditable)/i],
-  ['ui/ux flow changes', /(button|modal|panel|tab|layout|render|view|screen|ux|ui|timeline|explorer)/i],
-  ['remediation/repair/fix behavior', /(fix|bug|repair|rollback|guard|fallback|recover|hotfix|patch)/i],
-];
 
 function extractPatchSignals(patch) {
-  const changedFiles = [];
-  const addedLines = [];
-  const removedLines = [];
+  const files = []; const added = []; const removed = []; const hunks = [];
+  let file = null; let hunk = null;
   for (const raw of patch.split('\n')) {
-    if (raw.startsWith('diff --git ')) {
-      const m = raw.match(/ b\/(.+)$/);
-      if (m) changedFiles.push(m[1]);
-      continue;
-    }
-    if (raw.startsWith('+++ ') || raw.startsWith('--- ') || raw.startsWith('@@')) continue;
-    if (raw.startsWith('+')) addedLines.push(raw.slice(1));
-    if (raw.startsWith('-')) removedLines.push(raw.slice(1));
+    if (raw.startsWith('diff --git ')) { const m = raw.match(/ b\/(.+)$/); file = m ? m[1] : null; if (file) files.push(file); continue; }
+    if (raw.startsWith('@@')) { hunk = { file, header: raw, added: [], removed: [] }; hunks.push(hunk); continue; }
+    if (raw.startsWith('+++ ') || raw.startsWith('--- ')) continue;
+    if (raw.startsWith('+')) { const line = raw.slice(1); added.push(line); if (hunk) hunk.added.push(line); continue; }
+    if (raw.startsWith('-')) { const line = raw.slice(1); removed.push(line); if (hunk) hunk.removed.push(line); }
   }
-  return { changedFiles, addedLines, removedLines };
+  return { files, added, removed, hunks };
 }
 
-function classifyImpacts(patch) {
-  const { addedLines, removedLines } = extractPatchSignals(patch);
-  const corpus = `${addedLines.join('\n')}\n${removedLines.join('\n')}`;
-  const hits = [];
-  for (const [name, re] of impactMatchers) {
-    if (re.test(corpus)) hits.push(name);
-  }
-  return hits;
+function classifyFromEvidence(signals) {
+  const text = `${signals.added.join('\n')}\n${signals.removed.join('\n')}`;
+  const impacts = [];
+  if (/function\s+|=>|class\s+/i.test(text)) impacts.push('logic-flow changes');
+  if (/<(button|input|select|iframe|section|main|aside)\b/i.test(text)) impacts.push('ui/ux flow changes');
+  if (/(addEventListener|onclick|onchange|oninput|fetch\()/i.test(text)) impacts.push('interaction behavior');
+  if (/(America\/Los_Angeles|timestamp|DateTimeFormat|timeZone)/i.test(text)) impacts.push('time display/search behavior');
+  return impacts;
 }
 
-function summarizePatch(patch) {
-  if (!patch.trim()) return 'No code diff from previous timeline entry.';
-  const { changedFiles, addedLines, removedLines } = extractPatchSignals(patch);
-  const files = [...new Set(changedFiles)];
-  const actionHints = [];
-  if (/(normalize|sanitize|canonical|trim\()/i.test(addedLines.join('\n'))) actionHints.push('adds normalization logic');
-  if (/(transcrib|transcript|speech|recognition)/i.test(addedLines.join('\n'))) actionHints.push('adjusts transcription handling');
-  if (/(translat|locale|language|i18n)/i.test(addedLines.join('\n'))) actionHints.push('updates translation/language flow');
-  if (/(rejoin|reconnect|join\b|session|participant)/i.test(addedLines.join('\n'))) actionHints.push('changes joining/rejoining behavior');
-  if (/(hangup|terminate|disconnect|end call|teardown)/i.test(`${addedLines.join('\n')}\n${removedLines.join('\n')}`)) actionHints.push('modifies call termination behavior');
-  if (/(compose|focus|cursor|caret|textarea|contenteditable)/i.test(`${addedLines.join('\n')}\n${removedLines.join('\n')}`)) actionHints.push('modifies compose focus behavior');
-  if (/(button|panel|layout|render|timeline|explorer|tab)/i.test(`${addedLines.join('\n')}\n${removedLines.join('\n')}`)) actionHints.push('updates UI/UX flow');
-  if (/(fix|guard|fallback|recover|rollback|patch)/i.test(addedLines.join('\n'))) actionHints.push('applies remediation/fix logic');
+const commitLines = git(['log', '--reverse', '--date=iso-strict', '--pretty=format:%H%x09%h%x09%cI%x09%an%x09%s', `${START_COMMIT}^..HEAD`, '--', ...BRIDGE_PATHSPEC]).split('\n').filter(Boolean);
 
-  const changedSummary = `Patch touched ${files.length} file(s) (+${addedLines.length}/-${removedLines.length})`;
-  const keyPaths = files.slice(0, 3).join(', ');
-  const behavior = actionHints.length ? ` Behavior: ${actionHints.slice(0, 3).join('; ')}.` : '';
-  return `${changedSummary}${keyPaths ? `; key paths: ${keyPaths}.` : '.'}${behavior}`;
-}
-
-const commitLines = git(['log', '--date=iso-strict', '--pretty=format:%H%x09%h%x09%cI', '--', SCOPE_PATH]).split('\n').filter(Boolean);
-
-const commits = commitLines.map((line, idx) => {
-  const [full, short, timestamp] = line.split('\t');
-  return { seq: idx + 1, full, short, timestamp };
+const commits = commitLines.map((line, i) => {
+  const [full, short, timestamp, author, ...subjectParts] = line.split('\t');
+  return { seq: i + 1, full, short, timestamp, author, message: subjectParts.join('\t').trim() };
 });
 
 const rows = commits.map((commit, idx) => {
-  const previous = commits[idx + 1]?.full ?? null;
-  const patch = previous
-    ? git(['diff', `${previous}..${commit.full}`, '--patch', '--', SCOPE_PATH])
-    : git(['show', commit.full, '--patch', '--pretty=format:', '--', SCOPE_PATH]);
-  const nameStatusRaw = previous
-    ? git(['diff', '--name-status', `${previous}..${commit.full}`, '--', SCOPE_PATH])
-    : git(['show', '--name-status', '--pretty=format:', commit.full, '--', SCOPE_PATH]);
-
-  const changed_paths = nameStatusRaw
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => {
-      const parts = line.split('\t');
-      const status = parts[0];
-      if (status.startsWith('R')) {
-        return { status, from: parts[1], to: parts[2] };
-      }
-      return { status, path: parts[1] };
-    });
-
-  const code_fingerprint = hashText(normalizePatch(patch));
-  const primary_filename = changed_paths[0]?.to || changed_paths[0]?.path || 'N/A';
-  const functional_impacts = classifyImpacts(patch);
-  const blob_refs = changed_paths.map((entry) => {
-    const path = entry.to || entry.path;
-    return path ? `${commit.full}:${path}` : `${commit.full}:N/A`;
-  });
-
+  const previous = commits[idx - 1]?.full ?? null;
+  const patch = previous ? git(['diff', `${previous}..${commit.full}`, '--patch', '--', ...BRIDGE_PATHSPEC]) : git(['show', commit.full, '--patch', '--pretty=format:', '--', ...BRIDGE_PATHSPEC]);
+  const nameStatusRaw = previous ? git(['diff', '--name-status', `${previous}..${commit.full}`, '--', ...BRIDGE_PATHSPEC]) : git(['show', '--name-status', '--pretty=format:', commit.full, '--', ...BRIDGE_PATHSPEC]);
+  const changed_paths = nameStatusRaw.split('\n').filter(Boolean).map((line) => { const p = line.split('\t'); return p[0].startsWith('R') ? { status: p[0], from: p[1], to: p[2], rename: true } : { status: p[0], path: p[1] }; });
+  const signals = extractPatchSignals(patch);
+  const patchNormalized = normalizePatch(patch);
+  const functional_impacts = classifyFromEvidence(signals);
+  const primary_filename = changed_paths[0]?.to || changed_paths[0]?.path || 'bridge.html';
   return {
     seq: commit.seq,
     timestamp: commit.timestamp,
+    timestamp_pt: formatPacific(commit.timestamp),
     commit_hash: commit.full,
     commit_short: commit.short,
-    code_fingerprint,
+    commit_message: commit.message,
+    code_fingerprint: hashText(patchNormalized),
     primary_filename,
     changed_paths,
-    description_delta_from_previous: summarizePatch(patch),
+    description_delta_from_previous: signals.added.length || signals.removed.length ? `Changed ${[...new Set(signals.files)].join(', ')} (+${signals.added.length}/-${signals.removed.length}).` : 'No bridge* diff from previous timeline entry.',
     functional_impacts,
-    blob_refs,
+    diff_evidence: { files_changed: [...new Set(signals.files)], added_lines: signals.added.length, removed_lines: signals.removed.length, tagged_hunks: signals.hunks.filter((h) => h.added.length || h.removed.length).map((h) => ({ file: h.file, hunk: h.header, added_preview: h.added.slice(0, 2), removed_preview: h.removed.slice(0, 2) })) },
+    patch_hash: hashText(patchNormalized),
+    blob_refs: changed_paths.map((entry) => `${commit.full}:${entry.to || entry.path || 'bridge.html'}`),
     launch_ref: primary_filename,
-    note: functional_impacts.length
-      ? `Inferred impacts from patch hunks: ${functional_impacts.join(', ')}.`
-      : 'No prioritized behavior category detected from patch hunks.',
+    note: `Author ${commit.author}. Diff-evidence only summary generated from bridge* lineage chain rooted at ${START_COMMIT}.`,
     previous_commit_hash: previous,
   };
 });


### PR DESCRIPTION
## Summary
- narrowed lineage generation to `bridge*.html` commits only, rooted at `ec23f33`, so timeline `seq: 1` is the requested inception commit and non-bridge project commits are excluded.
- replaced broad keyword tagging with stricter diff-evidence-only classification and factual delta summaries computed from adjacent bridge lineage diffs.
- updated explorer rendering so Details and Side-by-Side show actual filenames and expose working `view blob` and `launch actual version` links in both tabs.
- regenerated `bridge-lineage-timeline-model.json` from the updated generator.

## Validation
- `node scripts/build-lineage-model.mjs`
- `git status --short`
- `git commit -m "Refine bridge-only lineage and fix explorer links"`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0003883c34832db1d53a1464c7050e)