### PR TITLE
Add HAR-only browser extractor and README for exporting /assets from HAR

### DIFF
--- a/nimbus_export/README.md
+++ b/nimbus_export/README.md
@@ -1,0 +1,35 @@
+# HAR-only asset export (upload HAR file, no terminal tools)
+
+You already have HAR data. Use the included browser tool to upload your HAR and export files.
+
+## 1) Capture in Chrome
+
+1. Open site and press `F12`.
+2. Go to **Network**.
+3. Enable **Preserve log** and **Disable cache**.
+4. Hard refresh (`Ctrl+Shift+R`) and trigger lazy-loaded features.
+5. In request table right-click: **Copy** → **Copy all as HAR (sanitized)**.
+6. Paste into a file named `session.har`.
+
+## 2) Run the extractor
+
+1. Open `nimbus_export/har_uploader_extractor.html` in Chrome.
+2. Upload `session.har`.
+3. Click **Extract + Download ZIP**.
+4. The tool generates `nimbus_export.zip` containing:
+   - `index.html` (main document if present)
+   - all `/assets/*` files with relative paths preserved exactly (`assets/...`)
+   - `dependency-list.json` with categorized dependency lists
+
+## 3) Verify completeness
+
+After extraction, open `dependency-list.json` and confirm categories:
+
+- `entry_js`
+- `dynamic_chunks`
+- `audio_files`
+- `textures_material_maps`
+- `fonts`
+- `worker_files`
+
+If anything is missing, recapture with cache disabled and include interactions that trigger lazy-loaded assets.

--- a/nimbus_export/fetch_log.json
+++ b/nimbus_export/fetch_log.json
@@ -1,0 +1,15 @@
+{
+  "fetched": {
+    "/": {
+      "status": 0,
+      "type": "",
+      "url": "https://nimbusflight.vercel.app/"
+    }
+  },
+  "verify": [
+    [
+      "/",
+      0
+    ]
+  ]
+}

--- a/nimbus_export/har_uploader_extractor.html
+++ b/nimbus_export/har_uploader_extractor.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HAR Asset Extractor</title>
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 24px; line-height: 1.4; }
+    .box { max-width: 840px; padding: 16px; border: 1px solid #ddd; border-radius: 8px; }
+    button { margin-top: 12px; padding: 10px 14px; }
+    pre { background: #f7f7f7; padding: 12px; border-radius: 6px; overflow:auto; }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>HAR Asset Extractor</h1>
+    <p>Upload a <code>Copy all as HAR (sanitized)</code> JSON file. This exports <code>index.html</code>, all <code>/assets/*</code> files, and a dependency report into a ZIP.</p>
+    <input id="harFile" type="file" accept=".har,.json" />
+    <br />
+    <button id="runBtn">Extract + Download ZIP</button>
+    <pre id="log"></pre>
+  </div>
+
+  <script>
+    const logEl = document.getElementById('log');
+    const btn = document.getElementById('runBtn');
+
+    const audioExt = ['.mp3','.wav','.ogg','.m4a','.aac','.flac','.opus'];
+    const texExt = ['.png','.jpg','.jpeg','.webp','.ktx2','.dds','.bmp','.gif','.tga','.hdr','.exr'];
+    const fontExt = ['.woff2','.woff','.ttf','.otf'];
+
+    const hasExt = (p, arr) => arr.some(e => p.toLowerCase().endsWith(e));
+
+    function sanitizePath(url) {
+      const clean = url.split('#')[0].split('?')[0];
+      try {
+        const u = new URL(clean);
+        if (u.pathname === '/' || u.pathname === '') return 'index.html';
+        if (u.pathname.startsWith('/assets/')) return u.pathname.slice(1);
+        return null;
+      } catch {
+        return null;
+      }
+    }
+
+    function toBytes(content) {
+      const text = content?.text;
+      if (text == null) return null;
+      if ((content.encoding || '').toLowerCase() === 'base64') {
+        const bin = atob(text);
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out;
+      }
+      return new TextEncoder().encode(text);
+    }
+
+    btn.onclick = async () => {
+      try {
+        logEl.textContent = 'Reading HAR...';
+        const file = document.getElementById('harFile').files[0];
+        if (!file) throw new Error('Please choose a HAR file first.');
+        const txt = await file.text();
+        const har = JSON.parse(txt);
+        const entries = har?.log?.entries || [];
+
+        const zip = new JSZip();
+        const deps = {
+          entry_js: [], dynamic_chunks: [], audio_files: [],
+          textures_material_maps: [], fonts: [], worker_files: []
+        };
+
+        let written = 0;
+        const jsFiles = [];
+
+        for (const e of entries) {
+          const req = e.request || {};
+          const res = e.response || {};
+          if ((res.status || 0) !== 200) continue;
+
+          const rel = sanitizePath(req.url || '');
+          if (!rel) continue;
+
+          const bytes = toBytes(res.content || {});
+          if (!bytes) continue;
+
+          zip.file(rel, bytes);
+          written++;
+
+          const lower = rel.toLowerCase();
+          if (lower.endsWith('.js')) jsFiles.push(rel);
+          if (hasExt(lower, audioExt)) deps.audio_files.push(rel);
+          if (hasExt(lower, texExt)) deps.textures_material_maps.push(rel);
+          if (hasExt(lower, fontExt)) deps.fonts.push(rel);
+          if (lower.includes('worker') || lower.endsWith('.worker.js')) deps.worker_files.push(rel);
+        }
+
+        const uniq = arr => [...new Set(arr)].sort();
+        const jsUniq = uniq(jsFiles);
+        deps.entry_js = jsUniq.filter(f => /assets\/index-.*\.js$/i.test(f));
+        deps.dynamic_chunks = jsUniq.filter(f => !deps.entry_js.includes(f));
+        deps.audio_files = uniq(deps.audio_files);
+        deps.textures_material_maps = uniq(deps.textures_material_maps);
+        deps.fonts = uniq(deps.fonts);
+        deps.worker_files = uniq(deps.worker_files);
+
+        zip.file('dependency-list.json', JSON.stringify(deps, null, 2));
+
+        logEl.textContent = `Files added: ${written}\nCreating ZIP...`;
+        const blob = await zip.generateAsync({ type: 'blob' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'nimbus_export.zip';
+        a.click();
+        URL.revokeObjectURL(a.href);
+
+        logEl.textContent += '\nDone: downloaded nimbus_export.zip';
+      } catch (err) {
+        logEl.textContent = 'Error: ' + err.message;
+      }
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a zero-install, browser-based way to extract site assets from a HAR export so users can create an uploadable ZIP without terminal tools.
- Produce a categorized dependency manifest to aid verification and further processing of extracted assets.

### Description

- Add `nimbus_export/har_uploader_extractor.html`, a self-contained browser UI that accepts a sanitized HAR file, extracts `index.html` and all files under `/assets/*` (preserving relative paths), classifies dependencies, and packages them with `JSZip` into `nimbus_export.zip`.
- Implement URL sanitization and content decoding that respects `base64`-encoded responses and skips non-200 entries, and classify files into `entry_js`, `dynamic_chunks`, `audio_files`, `textures_material_maps`, `fonts`, and `worker_files` in `dependency-list.json`.
- Add `nimbus_export/README.md` documenting how to capture a HAR in Chrome and use the extractor tool, and include a `nimbus_export/fetch_log.json` placeholder with a basic fetch record.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0042c4d920832da3e28e1d33640000)