### PR TITLE
Improve duplicate detection in transcript entries with subtitle sequences

### DIFF
--- a/bridge-restore-plus-2.html
+++ b/bridge-restore-plus-2.html
@@ -1233,8 +1233,12 @@ function showSub(text,cls){
 
 function addTr(who,src,tr,sL,tL,ss){
   src=normalizeText(src,'speech');tr=normalizeText(tr,'speech');if(!src&&!tr)return;if(!tr)tr=src;
-  var prev=transcript.length?transcript[transcript.length-1]:null;
-  if(prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;
+  if(ss){
+    if(transcript.some(function(e){return e.who===who&&e.subtitleSeq===ss;}))return;
+  }else{
+    var prev=transcript.length?transcript[transcript.length-1]:null;
+    if(prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;
+  }
   var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
   transcript.push(entry);if(transcript.length>MAX_TR)transcript.splice(0,transcript.length-MAX_TR);
   saveTr();appendTrDom(entry);


### PR DESCRIPTION
## Summary
Enhanced the duplicate detection logic in the `addTr()` function to handle subtitle sequence-based deduplication separately from time-based deduplication.

## Key Changes
- Added conditional logic to check for subtitle sequence (`ss`) parameter
- When a subtitle sequence is provided, the function now checks if an entry with the same speaker and subtitle sequence already exists in the transcript, preventing exact duplicates
- When no subtitle sequence is provided, the function falls back to the original time-based deduplication logic (checking the last entry within 5 seconds)
- This prevents duplicate transcript entries when the same subtitle is processed multiple times while maintaining the original behavior for non-subtitle-based entries

## Implementation Details
- The deduplication strategy is now split into two paths based on whether a subtitle sequence ID is present
- Subtitle-based deduplication uses `Array.some()` to search the entire transcript for matching speaker and sequence
- Time-based deduplication continues to check only the most recent entry for efficiency
- Both approaches prevent adding duplicate entries but use different matching criteria appropriate to their use case

https://claude.ai/code/session_01LoXeBgSbYAN1892yt91eXn