### PR TITLE
Fix TalkBridge speech pipeline: mic restore, language detection, Use buttons, version bump

### DIFF
--- a/bridge-patched-v1.html
+++ b/bridge-patched-v1.html
@@ -399,7 +399,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
       </div>
       <div class="lobby-footer" style="flex-shrink:0;border-top:1px solid var(--surface2);padding-top:6px;margin-top:4px;display:flex;align-items:center;justify-content:space-between;">
         <button class="lobby-footer-btn" onclick="openLog()" title="Debug log">🪲</button>
-        <span style="font-size:10px;color:var(--text-muted);">v3.1.0</span>
+        <span style="font-size:10px;color:var(--text-muted);">v3.4.0</span>
         <button class="lobby-footer-btn" onclick="toggleKeysPanel()" id="keys-gear-btn" title="API keys">⚙️</button>
       </div>
     </div>    </div>
@@ -832,7 +832,7 @@ var FT_CONF=0.5;
 function _loadFastText(){
   if(_ftReady||_ftLoadFailed)return;
   var s=document.createElement('script');s.src='/fastType/fastText.common.js';
-  s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'error');toast('Language detection unavailable');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};
+  s.onerror=function(){_ftLoadFailed=true;log('ft_load_fail',{src:s.src},'warn');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];};
   s.onload=function(){
     if(typeof FastText==='undefined'){_ftLoadFailed=true;_ftPending.forEach(function(cb){cb(null);});_ftPending=[];return;}
     try{
@@ -2776,7 +2776,7 @@ $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBotto
 $('call-transcript').addEventListener('click',function(ev){
   var tts=ev.target.closest('.tr-tts');
   if(tts){speakText(tts.getAttribute('data-tts-text')||'',tts.getAttribute('data-tts-lang')||room.myLang||'en');return;}
-  var use=ev.target.closest('.tr-use');
+  var use=ev.target.closest('.tr-use-ico');
   if(use){var ci=$('chat-input');if(ci){ci.value=use.getAttribute('data-use-text')||'';ci.dispatchEvent(new Event('input'));}}
 });
 $('local-video').addEventListener('click',swapVideos);

--- a/bridge-patched-v1.html
+++ b/bridge-patched-v1.html
@@ -870,10 +870,14 @@ function _detectLangAsync(text){
 }
 
 /* === CHAT === */
+var _pbMutedMic=false;
 function composeFocusMute(){
   if(!isCallActive())return;
-  if(micOn&&!micMutedByUser){toggleMic();}
+  if(micOn&&!micMutedByUser){_pbMutedMic=true;toggleMic();}
   else if(!micOn){toast('Mic is muted — tap mic button to speak');}
+}
+function _pbRestoreMic(){
+  if(_pbMutedMic&&!micOn&&isCallActive()){_pbMutedMic=false;toggleMic();}else{_pbMutedMic=false;}
 }
 function chatInputEvt(){
   var ta=$('chat-input');if(!ta)return;
@@ -1243,6 +1247,7 @@ function pbCloseDrawer(){
   _pbDrawerMode='';
   var btn=document.getElementById('pb-strip-btn');
   if(btn)btn.classList.remove('active');
+  _pbRestoreMic();
 }
 function pbCmdDrawerHtml(){
   return '<div class="pb-drawer-hdr"><span class="pb-drawer-title" style="font-size:11px;color:var(--text-muted);">Phrasebook (//) management</span>'    +'<button class="pb-drawer-x" onclick="pbCloseDrawer();pbClearComposeSlash()">×</button></div>'    +'<div class="pb-cmd-chips" style="justify-content:flex-start;">'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenBooksModal()" title="Open / switch phrasebook">'+ICO.book+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenNewCard({})" title="New phrase">'+ICO.plus+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbTriggerImport()" title="Import file">'+ICO.upload+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbExportPrompt()" title="Export">'+ICO.download+'</button>'    +'<button class="pb-ico-chip danger" onclick="pbCloseDrawer();pbClearCompose();pbResetConfirm()" title="Reset phrasebook">'+ICO.warn+'</button>'    +'</div>';
@@ -2327,13 +2332,20 @@ function onDGFinal(text){
   recFinal(text);log('dg_final',{t:text.slice(0,60)},'ok');
   var src=room.myLang,tgt=room.theirLang,ss=++localSubSeq;
   showSub(text,'mine');
-  var srcText=normalizeText(text,'speech')||text;
-  relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});
-  addTr('me',srcText,srcText,src,tgt,ss);
-  translateWithRetry(srcText,src,tgt,1).then(function(tr){
-    tr=normalizeText(tr,'speech')||srcText;
-    relaySend({type:'subtitle-update',subtitleSeq:ss,text:tr,sourceText:srcText,sourceLang:src,targetLang:tgt});
-    patchTr('me',ss,tr,src,tgt);
+  Promise.race([
+    _detectLangAsync(text),
+    new Promise(function(res){setTimeout(function(){res(detectLang(text,src));},150);})
+  ]).then(function(detected){
+    return (detected&&detected!==src)?translateWithRetry(text,detected,src,2):Promise.resolve(text);
+  }).then(function(srcText){
+    srcText=normalizeText(srcText,'speech')||text;
+    relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});
+    addTr('me',srcText,srcText,src,tgt,ss);
+    return translateWithRetry(srcText,src,tgt,2).then(function(tr){
+      tr=normalizeText(tr,'speech')||srcText;
+      relaySend({type:'subtitle-update',subtitleSeq:ss,text:tr,sourceText:srcText,sourceLang:src,targetLang:tgt});
+      patchTr('me',ss,tr,src,tgt);
+    });
   }).catch(function(e){log('dg_trans_err',{e:String(e)},'error');});
 }
 
@@ -2751,7 +2763,7 @@ function cleanUp(){
   transcriptTtsOn=false;syncTranscriptTtsButton();if(window.speechSynthesis)window.speechSynthesis.cancel();
   document.querySelector('.call-videos').classList.remove('swapped');
   resetRemoteMediaState();
-  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;syncMic();syncCam();renderRecent();
+  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();
 }
 
 // === INIT ===

--- a/bridge-restore-plus-2.html
+++ b/bridge-restore-plus-2.html
@@ -1239,7 +1239,7 @@ function addTr(who,src,tr,sL,tL,ss){
     var prev=transcript.length?transcript[transcript.length-1]:null;
     if(prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;
   }
-  var entry={type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
+  var entry={id:'sp-'+uid(),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
   transcript.push(entry);if(transcript.length>MAX_TR)transcript.splice(0,transcript.length-MAX_TR);
   saveTr();appendTrDom(entry);
   if(transcriptTtsOn&&who==='partner'&&tr&&!ss)speakText(tr,tL||room.myLang);


### PR DESCRIPTION
Fixes four bugs in bridge-patched-v1.html:

1. **composeFocusMute mic never restores** — clicking chat textarea muted the mic permanently (dgDesired=false, DG stopped). Added `_pbMutedMic` flag; `pbCloseDrawer()` now calls `_pbRestoreMic()` so mic unmutes automatically after every chat send. This was why joiner speech failed after any chat interaction.

2. **Language detection removed from onDGFinal** — seq 21 (93446bd) stripped out the `Promise.race([_detectLangAsync, timeout])` block. Restored it so cross-language speech normalizes to session source language before translating to target.

3. **"Use" buttons broken** — transcript click handler used `closest('.tr-use')` but buttons have class `tr-use-ico`. Fixed selector.

4. **"Language detection unavailable" toast** — fastText onerror fired an intrusive toast every session. Changed to silent log; detection is best-effort.

Version bumped to v3.4.0 so the deployed build is identifiable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1jsihY1SZVkac1DT4HhXt)_