### PR TITLE
v3.4.1: fix NFC double-normalize regression and eager-load fastText

### DIFF
--- a/bridge-patched-v1.html
+++ b/bridge-patched-v1.html
@@ -399,7 +399,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
       </div>
       <div class="lobby-footer" style="flex-shrink:0;border-top:1px solid var(--surface2);padding-top:6px;margin-top:4px;display:flex;align-items:center;justify-content:space-between;">
         <button class="lobby-footer-btn" onclick="openLog()" title="Debug log">🪲</button>
-        <span style="font-size:10px;color:var(--text-muted);">v3.4.0</span>
+        <span style="font-size:10px;color:var(--text-muted);">v3.4.1</span>
         <button class="lobby-footer-btn" onclick="toggleKeysPanel()" id="keys-gear-btn" title="API keys">⚙️</button>
       </div>
     </div>    </div>
@@ -750,7 +750,6 @@ function getMicConstraints(){
 function normalizeText(raw,mode){
   if(!raw)return'';
   var s=raw.normalize?raw.normalize('NFKC'):raw;
-  if(s.normalize)s=s.normalize('NFC');
   s=s.trim().replace(/\s+/g,' ');
   s=s.replace(/[\u200B-\u200D\uFEFF\u2060]/g,'');
   if(mode==='speech'){
@@ -2771,7 +2770,7 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(
 if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
 if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
 if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
-pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();
+pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
 $('call-transcript').addEventListener('click',function(ev){
   var tts=ev.target.closest('.tr-tts');


### PR DESCRIPTION
Two fixes for cross-language normalization in bridge-patched-v1.html:

1. Remove `s.normalize('NFC')` added in seq 21 — NFKC normalization is sufficient; adding NFC after NFKC was a noted regression from that commit.

2. Call `_loadFastText()` at page init. Previously the model loaded lazily on first speech detection call, meaning the 938KB `lid.176.ftz` model would never finish loading within the 150ms `Promise.race` window for the first utterance. Now the JS and model start fetching immediately on page load so they're ready when the user first speaks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1jsihY1SZVkac1DT4HhXt)_