### PR TITLE
v3.5.2 — fix FastText global (ft_no_global) + startup version log

### DIFF
--- a/bridge-patched-v1.html
+++ b/bridge-patched-v1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- talkbridge · dcr · v3.5.1 -->
+<!-- talkbridge · dcr · v3.5.2 -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -400,7 +400,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
       <div class="lobby-footer" style="flex-shrink:0;border-top:1px solid var(--surface2);padding-top:6px;margin-top:4px;display:flex;align-items:center;justify-content:space-between;">
         <button class="lobby-footer-btn" onclick="openLog()" title="Debug log">🪲</button>
         <span id="ft-lobby-status" class="ft-status-pill"><span class="ft-status-dot loading" id="ft-dot"></span><span id="ft-label">Lang model loading…</span></span>
-        <span style="font-size:10px;color:var(--text-muted);">v3.5.1</span>
+        <span style="font-size:10px;color:var(--text-muted);">v3.5.2</span>
         <button class="lobby-footer-btn" onclick="toggleKeysPanel()" id="keys-gear-btn" title="API keys">⚙️</button>
       </div>
     </div>    </div>
@@ -2832,6 +2832,7 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(
 if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
 if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
 if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
+log('startup',{v:'3.5.2',ua:navigator.userAgent.slice(0,80)});
 pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();_syncFtStatus();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
 $('call-transcript').addEventListener('click',function(ev){

--- a/fastType/fastText.common.js
+++ b/fastType/fastText.common.js
@@ -8714,7 +8714,7 @@ run();
 }
 );
 })();
-module.exports = FastTextModule;
+if(typeof module!=='undefined'&&module.exports)module.exports=FastTextModule;
 
   function FastText(){}
   FastText.prototype.loadModel=function(url){


### PR DESCRIPTION
## One file changed: `fastType/fastText.common.js`

**The bug:** `module.exports = FastTextModule` at line 8717 is bare top-level code. In a browser with no bundler, `module` is undefined — this throws `ReferenceError` the instant the script runs. Everything below that line, including `global.FastText=FastText` at the bottom, never executes. The script loads fine over the network but `FastText` is always undefined. That's the `ft_no_global` you've been seeing since the beginning.

**The fix:** `if(typeof module!=='undefined'&&module.exports)module.exports=FastTextModule`

**Also:** `bridge-patched-v1.html` bumped to `v3.5.2` with `log('startup',{v:'3.5.2',...})` as the first log line on every page load.

## How to confirm

After merge, open the app and check the 🪲 log. First line should be:
```
startup {"v":"3.5.2", ...}
```
Then shortly after:
```
ft_load_start → ft_model_load → ft_ready
```
No more `ft_no_global`.

https://claude.ai/code/session_01K1jsihY1SZVkac1DT4HhXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1jsihY1SZVkac1DT4HhXt)_