### PR TITLE
Improve startup resilience and performance diagnostics in soothe wallpaper

### DIFF
--- a/soothe.html
+++ b/soothe.html
@@ -550,6 +550,8 @@
         lastFrameCost: 0,
         frameCounter: 0,
         lastPerfMessage: 0,
+        slowFrameCount: 0,
+        worstFrameCost: 0,
         audioLevel: 0,
         bass: 0,
         mids: 0,
@@ -637,6 +639,28 @@
         else if (pressure < 0.56) state.adaptivePenalty = clamp(state.adaptivePenalty - 0.028, 0, 1);
       }
 
+
+      function logPerformanceIssue(frameCost, frameBudget) {
+        const pressure = frameCost / Math.max(1, frameBudget);
+        state.worstFrameCost = Math.max(state.worstFrameCost, frameCost);
+        if (pressure > 1.25) {
+          state.slowFrameCount += 1;
+          if (state.slowFrameCount === 1 || state.slowFrameCount % 15 === 0) {
+            console.warn('[Soothe] Slow frame detected', {
+              frameCostMs: Number(frameCost.toFixed(2)),
+              frameBudgetMs: Number(frameBudget.toFixed(2)),
+              pressure: Number(pressure.toFixed(2)),
+              adaptivePenalty: Number(state.adaptivePenalty.toFixed(2)),
+              qualityMode: controls.qualityMode.value,
+              renderScale: Number(controls.renderScale.value),
+              frameCap: Number(controls.frameCap.value)
+            });
+          }
+        } else if (state.slowFrameCount > 0 && pressure < 0.9) {
+          state.slowFrameCount -= 1;
+        }
+      }
+
       function updatePerfLine(force = false) {
         if (!perfLine) return;
         const now = performance.now();
@@ -644,7 +668,7 @@
         state.lastPerfMessage = now;
         const fps = Math.round(1000 / targetFrameMs());
         const penalty = Math.round(state.adaptivePenalty * 100);
-        perfLine.textContent = `Guard: ${controls.qualityMode.value}, ${fps} fps cap, ${controls.renderScale.value}% scale, adaptive trim ${penalty}%, last draw ${state.lastFrameCost.toFixed(1)} ms.`;
+        perfLine.textContent = `Guard: ${controls.qualityMode.value}, ${fps} fps cap, ${controls.renderScale.value}% scale, adaptive trim ${penalty}%, last draw ${state.lastFrameCost.toFixed(1)} ms, worst ${state.worstFrameCost.toFixed(1)} ms.`;
       }
 
       function hsl(parts, alpha = 1, lightAdjust = 0, satAdjust = 0, hueAdjust = 0) {
@@ -1083,7 +1107,9 @@
         drawVignette();
         drawGrain();
 
-        updatePerformanceGuard(performance.now() - frameStart, frameBudget);
+        const frameCost = performance.now() - frameStart;
+        updatePerformanceGuard(frameCost, frameBudget);
+        logPerformanceIssue(frameCost, frameBudget);
         state.frameCounter += 1;
         if (state.frameCounter % 12 === 0) updatePerfLine(false);
       }
@@ -1270,13 +1296,29 @@
       }
 
       function init() {
-        bindEvents();
-        updateOutputs();
-        resize();
-        cancelAnimationFrame(animationFrame);
-        state.last = performance.now();
-        state.lastDraw = state.last;
-        animationFrame = requestAnimationFrame(animate);
+        if (!canvas || !ctx) {
+          console.error('[Soothe] Startup failed: Canvas context could not be created.');
+          if (perfLine) {
+            perfLine.textContent = 'Startup issue: canvas rendering is unavailable in this browser.';
+            perfLine.className = 'statusLine bad';
+          }
+          return;
+        }
+        try {
+          bindEvents();
+          updateOutputs();
+          resize();
+          cancelAnimationFrame(animationFrame);
+          state.last = performance.now();
+          state.lastDraw = state.last;
+          animationFrame = requestAnimationFrame(animate);
+        } catch (error) {
+          console.error('[Soothe] Startup failed unexpectedly.', error);
+          if (perfLine) {
+            perfLine.textContent = `Startup issue: ${error.message || 'unexpected error'}.`;
+            perfLine.className = 'statusLine bad';
+          }
+        }
       }
 
       init();


### PR DESCRIPTION
### Motivation
- Prevent the live wallpaper from crashing or failing silently during boot when the canvas or rendering context is unavailable and provide visible feedback. 
- Surface recurring performance problems so slow-frame conditions can be diagnosed and tuned.

### Description
- Added new perf-tracking state fields `slowFrameCount` and `worstFrameCost` to the `state` object in `soothe.html`.
- Introduced `logPerformanceIssue(frameCost, frameBudget)` which updates `worstFrameCost`, tracks sustained slow frames via `slowFrameCount`, and emits structured `console.warn` entries when frame pressure is high.
- Wired logging into the animation loop by computing `frameCost` and calling `updatePerformanceGuard(frameCost, frameBudget)` followed by `logPerformanceIssue(frameCost, frameBudget)` so issues are observed continuously.
- Hardened initialization in `init()` with a `canvas`/`ctx` availability check and a `try/catch` around boot steps that writes a user-facing message to the performance status line `perfLine` and logs console errors on startup failure.

### Testing
- No automated test suite is configured for this single-page artifact, so changes were validated via static inspection of the modified `soothe.html` to confirm the new state fields, `logPerformanceIssue` function, animation-loop integration, and updated `init()` behavior were applied correctly.
- Basic smoke checks on the edited file verified the performance line now includes `worst` frame time and that the logging code paths are present and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02aace6100832d93753c75379d27f4)