### PR TITLE
Fix fastText result parsing and make startup overlay non-blocking

### DIFF
--- a/bridge-patched-v1.html
+++ b/bridge-patched-v1.html
@@ -845,6 +845,13 @@ function _ftStartupDone(ok,msg){
   if(_ftStartupStatus)_ftStartupStatus.textContent=ok?'Detector ready':'Degraded mode: language detector unavailable';
   log('ft_startup_'+(ok?'ready':'degraded'),{message:msg||null},ok?'ok':'warn');
   if(ok){setTimeout(function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';},400);}
+  else{
+    if(_ftStartupOverlay){
+      _ftStartupOverlay.style.cursor='pointer';
+      _ftStartupOverlay.onclick=function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';};
+    }
+    setTimeout(function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';},1800);
+  }
 }
 function _ftWhitelist(){return Object.keys(LANGS||{});} 
 function _ftAllowed(code){return _ftWhitelist().indexOf(code)>=0;}
@@ -871,10 +878,30 @@ function _probeFtAsset(path){
 }
 function _ftPredictLabel(ft,text){
   var r=ft.predict(text,1);
-  var item=r&&r.length?r[0]:null;
-  var label=item&&item.label?String(item.label).replace('__label__',''):null;
-  var score=item?(item.prob||item.score||item.probability||0):0;
-  return (label&&score>=FT_CONF&&_ftAllowed(label))?label:null;
+  var item=null,label=null,score=null;
+  function _normLabel(v){
+    if(v==null)return null;
+    return String(v).replace(/^(__label__|label__)/,'');
+  }
+  if(r instanceof Map){
+    var first=r.entries().next();
+    if(!first.done){label=_normLabel(first.value[0]);score=first.value[1];}
+  }else if(Array.isArray(r)){
+    item=r.length?r[0]:null;
+    if(Array.isArray(item)){label=_normLabel(item[0]);score=item[1];}
+    else if(item&&typeof item==='object'){label=_normLabel(item.label);score=(item.prob!=null?item.prob:(item.score!=null?item.score:item.probability));}
+    else if(typeof item==='string'){label=_normLabel(item);}
+  }else if(r&&typeof r==='object'){
+    label=_normLabel(r.label!=null?r.label:r[0]);
+    score=(r.prob!=null?r.prob:(r.score!=null?r.score:r.probability));
+  }else if(typeof r==='string'){
+    label=_normLabel(r);
+  }
+  if(!label||!_ftAllowed(label))return null;
+  if(score==null)return label;
+  var n=Number(score);
+  if(!isFinite(n))return null;
+  return n>=FT_CONF?label:null;
 }
 function _loadFastText(){
   if(_ftReady||_ftLoadFailed)return;
@@ -898,23 +925,23 @@ function _loadFastText(){
         var ft=new FastText();
         _ftStartupStep('model load');
         log('ft_model_load',{model:FT_MODEL});
-        var timer=setTimeout(function(){log('ft_model_timeout',{ms:FT_LOAD_TIMEOUT_MS},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'model_timeout');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];},FT_LOAD_TIMEOUT_MS);
+        var timer=setTimeout(function(){log('ft_model_timeout',{ms:FT_LOAD_TIMEOUT_MS,reason:'FastText model load timeout'},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'timeout: model load exceeded '+FT_LOAD_TIMEOUT_MS+'ms');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];},FT_LOAD_TIMEOUT_MS);
         ft.loadModel(FT_MODEL).then(function(){
           _ftStartupStep('smoke tests');
           return Promise.all(FT_SMOKE.map(function(pair){
             var got=_ftPredictLabel(ft,pair[0]);
-            if(got!==pair[1])throw new Error('smoke_'+pair[1]+'_got_'+got);
+            if(got!==pair[1])throw new Error('smoke mismatch: input="'+pair[0]+'" expected="'+pair[1]+'" got="'+got+'"');
             return got;
           }));
         }).then(function(){
           clearTimeout(timer);_ftModule=ft;_ftReady=true;_syncFtStatus();_ftStartupDone(true,'ready');log('ft_ready',{},'ok');_ftPending.forEach(function(cb){cb(ft);});_ftPending=[];
         }).catch(function(e){
-          clearTimeout(timer);log('ft_model_err',{e:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];
+          clearTimeout(timer);log('ft_model_err',{reason:'runtime/model init or smoke failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];
         });
-      }catch(e){log('ft_init_err',{e:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];}
+      }catch(e){log('ft_init_err',{reason:'FastText constructor/init failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];}
     };
     document.head.appendChild(s);
-  }).catch(function(e){_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];});
+  }).catch(function(e){log('ft_probe_err',{reason:'asset probe failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];});
 }
 function _detectLangAsync(text){
   var t=(text||'').trim();if(!t)return Promise.resolve(null);


### PR DESCRIPTION
### Motivation
- Prevent fastText smoke-gate false-negatives caused by varied black-box `predict()` return shapes so language detection whitelist can work reliably.
- Avoid blocking the UI on detector startup failure while still surfacing a clear error state in the lobby status pill.
- Improve diagnosability of degraded startup by surfacing explicit failure reasons for model/timeouts/probe/smoke errors.

### Description
- Enhanced `_ftPredictLabel(ft,text)` to accept and normalize all wrapper `predict()` shapes: `Map`, array of tuples, array of objects, array of labels, plain object, and plain string, and to strip `__label__` and `label__` prefixes.
- Kept LANGS whitelist gating and `FT_CONF` threshold semantics exactly, allowing whitelist-approved labels with no score while applying threshold when score is present.
- Made degraded startup non-blocking by auto-dismissing the startup overlay after a brief interval and making it dismissible on click, while preserving the existing success hide behavior and the lobby status pill error indicator via `_syncFtStatus()`.
- Added explicit, detailed logging for failure paths including model load timeout, smoke-test mismatches, constructor/init errors, and asset probe failures, while preserving existing probe events (`ft_asset_probe`, `ft_asset_ok`, `ft_asset_err`).
- Preserved detector contract and behavior: Unicode shortcuts run before WASM path, existing fallback timing retained, and API usage remains `new FastText()`, `loadModel(modelUrl)`, `predict(text,k)`.

### Testing
- Ran quick repository and file inspections: `git -C /workspace/stuff status --short` which showed the updated file, and reviewed the patched region with `nl -ba bridge-patched-v1.html | sed -n '836,972p'`, both succeeded.
- Committed the change with `git -C /workspace/stuff commit -m "Fix fastText result parsing and non-blocking degraded startup"` which completed successfully.
- No automated unit tests existed or were run as part of this patch; only the lightweight CI/inspection commands above were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02af0e438c832d9d7eb05de0a084fe)