### PR TITLE
Add isolated FastText WASM runtime diagnostics PoC page

### DIFF
--- a/docs/fasttext-wasm-poc.md
+++ b/docs/fasttext-wasm-poc.md
@@ -1,0 +1,23 @@
+# FastText WASM PoC
+
+## Purpose
+This page validates runtime FastText behavior in isolation using the deployed wrapper/core/model assets, with staged diagnostics and deep probes that go beyond simple smoke tests.
+
+## How to open/run
+1. Open `fasttext-wasm-poc.html` in the same environment where `fastType/...` assets are served.
+2. Click **Run Full Probe**.
+3. Optionally run **Manual predict(k=1)** after model load.
+
+## What to inspect in logs
+- Asset probing rows (`wrapper`, `mjs`, `wasm`, `model`) for status and byte size.
+- Stage diagnostics for wrapper load, FastText global check, constructor/init, model load timing (or timeout), smoke status.
+- Deep probe table for per-call return-shape classification and normalized extraction.
+- Loop probe stats and captured per-call failures.
+- Error payload normalization: context, JS type, detail, timestamp.
+
+## Expected pass/fail signals
+- **Pass**: all asset probes `ok`, model load stage reports ms timing, smoke tests pass, deep probe rows populate shapes/normalized labels.
+- **Fail (non-blocking)**: any stage can fail without a blocking overlay; details stay visible in status panel and log area.
+
+## Why this differs from simple smoke tests
+Smoke checks can pass on a narrow fixed input set while runtime still fails on shape variants, edge inputs, or repeated-call stability. This PoC adds shape introspection, normalization visualization, and repeated-call failure capture to expose those runtime gaps.

--- a/fasttext-wasm-poc.html
+++ b/fasttext-wasm-poc.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FastText WASM PoC</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 20px; background:#0f1115; color:#e6e8ee; }
+    h1,h2 { margin: 0 0 10px; }
+    .grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(280px,1fr)); gap:12px; }
+    .card { border:1px solid #2a2f3a; border-radius:8px; padding:12px; background:#171b22; }
+    .status { font-weight:700; }
+    .ok { color:#51d88a; } .warn { color:#ffcf5c; } .err { color:#ff6b6b; }
+    table { width:100%; border-collapse: collapse; font-size: 13px; }
+    th,td { border-bottom:1px solid #2a2f3a; padding:6px; vertical-align:top; text-align:left; }
+    button { background:#2b8cff; border:none; color:#fff; padding:8px 10px; border-radius:6px; cursor:pointer; }
+    pre { white-space: pre-wrap; background:#11151b; border:1px solid #2a2f3a; padding:8px; border-radius:6px; max-height:280px; overflow:auto; }
+    input,textarea { width:100%; background:#11151b; border:1px solid #2a2f3a; color:#e6e8ee; border-radius:6px; padding:8px; }
+  </style>
+</head>
+<body>
+  <h1>FastText WASM Runtime PoC</h1>
+  <p>Isolated diagnostics page for real runtime behavior (no production app mutation).</p>
+
+  <div class="grid">
+    <div class="card">
+      <h2>Controls</h2>
+      <button id="runBtn">Run Full Probe</button>
+      <p class="status" id="overallStatus">Status: idle</p>
+      <label>Manual input</label>
+      <textarea id="manualInput" rows="3">hello from runtime probe</textarea>
+      <button id="manualPredict">Manual predict(k=1)</button>
+      <pre id="manualOut"></pre>
+    </div>
+    <div class="card">
+      <h2>Stage Diagnostics</h2>
+      <table>
+        <tbody id="stageRows"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card" style="margin-top:12px;">
+    <h2>Asset Probes</h2>
+    <table>
+      <thead><tr><th>Asset</th><th>Path</th><th>Status</th><th>Size</th><th>Detail</th></tr></thead>
+      <tbody id="assetRows"></tbody>
+    </table>
+  </div>
+
+  <div class="card" style="margin-top:12px;">
+    <h2>Deep Probe</h2>
+    <table>
+      <thead><tr><th>Case</th><th>Shape</th><th>Normalized</th><th>Score</th><th>Raw sample</th><th>Error</th></tr></thead>
+      <tbody id="deepRows"></tbody>
+    </table>
+    <p id="loopStats"></p>
+  </div>
+
+  <div class="card" style="margin-top:12px;">
+    <h2>Logs</h2>
+    <pre id="logOut"></pre>
+  </div>
+
+  <script>
+    const FT_CONF = 0.5;
+    const FT_LOAD_TIMEOUT_MS = 5000;
+    const FT_WRAPPER_JS = 'fastType/fasttext-wrapper.umd.js';
+    const FT_CORE_JS = 'fastType/core/fasttext.mjs';
+    const FT_CORE_WASM = 'fastType/core/fasttext.wasm';
+    const FT_MODEL = 'fastType/model/lid.176.ftz';
+    const FT_ASSETS = [
+      { key: 'wrapper', path: FT_WRAPPER_JS },
+      { key: 'mjs', path: FT_CORE_JS },
+      { key: 'wasm', path: FT_CORE_WASM },
+      { key: 'model', path: FT_MODEL }
+    ];
+    const WHITELIST = ['en','es','fr','de','it','pt','nl','ru','ja','ko','zh','ar','hi','th'];
+    const SMOKE = [['hello how are you today','en'],['hola como estas hoy','es'],['bonjour comment allez vous','fr'],['guten morgen wie geht es dir','de']];
+    let ftInstance = null;
+
+    function nowTs() { return new Date().toISOString(); }
+    function normErr(context, err) {
+      const t = err === null ? 'null' : typeof err;
+      let detail;
+      try { detail = JSON.stringify(err); } catch (_) { detail = String(err); }
+      if (!detail || detail === '{}' || detail === 'null') detail = String(err);
+      return { context, type: t, detail, timestamp: nowTs() };
+    }
+    function log(level, context, payload) {
+      const line = `[${nowTs()}] [${level}] ${context} ${JSON.stringify(payload ?? {})}`;
+      document.getElementById('logOut').textContent += line + '\n';
+    }
+
+    function setStage(name, status, detail) {
+      const tbody = document.getElementById('stageRows');
+      let row = tbody.querySelector(`[data-stage="${name}"]`);
+      if (!row) {
+        row = document.createElement('tr');
+        row.dataset.stage = name;
+        row.innerHTML = `<td>${name}</td><td class="stage-status"></td><td class="stage-detail"></td>`;
+        tbody.appendChild(row);
+      }
+      row.querySelector('.stage-status').textContent = status;
+      row.querySelector('.stage-status').className = `stage-status ${status === 'ok' ? 'ok' : status === 'error' ? 'err' : 'warn'}`;
+      row.querySelector('.stage-detail').textContent = detail || '';
+    }
+
+    async function probeAsset(asset) {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${asset.key}</td><td>${asset.path}</td><td>loading</td><td>-</td><td></td>`;
+      document.getElementById('assetRows').appendChild(row);
+      try {
+        const res = await fetch(asset.path, { cache: 'no-store' });
+        if (!res.ok) throw new Error(`status_${res.status}`);
+        const buf = await res.arrayBuffer();
+        if (!buf.byteLength) throw new Error('empty');
+        row.cells[2].innerHTML = '<span class="ok">ok</span>';
+        row.cells[3].textContent = String(buf.byteLength);
+        row.cells[4].textContent = 'probe success';
+        return { ok: true, size: buf.byteLength };
+      } catch (e) {
+        const n = normErr('asset_probe', e);
+        row.cells[2].innerHTML = '<span class="err">error</span>';
+        row.cells[4].textContent = n.detail;
+        log('error', 'asset_probe', n);
+        return { ok: false, error: n };
+      }
+    }
+
+    function classifyShape(r) {
+      if (r instanceof Map) return 'Map';
+      if (Array.isArray(r)) {
+        const first = r[0];
+        if (Array.isArray(first)) return 'Array of tuples';
+        if (first && typeof first === 'object') return 'Array of objects';
+        if (typeof first === 'string') return 'Array of labels';
+      }
+      if (r && typeof r === 'object') return 'plain object';
+      if (typeof r === 'string') return 'string';
+      return 'unknown';
+    }
+
+    function parsePredictionForPoc(raw) {
+      let label = null, score = null;
+      const n = v => (v == null ? null : String(v).replace(/^(__label__|label__)/, ''));
+      if (raw instanceof Map) {
+        const first = raw.entries().next(); if (!first.done) { label = n(first.value[0]); score = first.value[1]; }
+      } else if (Array.isArray(raw)) {
+        const item = raw[0];
+        if (Array.isArray(item)) { label = n(item[0]); score = item[1]; }
+        else if (item && typeof item === 'object') { label = n(item.label); score = item.prob ?? item.score ?? item.probability; }
+        else if (typeof item === 'string') { label = n(item); }
+      } else if (raw && typeof raw === 'object') {
+        label = n(raw.label ?? raw[0]); score = raw.prob ?? raw.score ?? raw.probability;
+      } else if (typeof raw === 'string') label = n(raw);
+
+      if (!label || !WHITELIST.includes(label)) return { label: null, score: null, pass: false, reason: 'not-whitelisted-or-empty' };
+      if (score == null) return { label, score: null, pass: true, reason: 'label-only' };
+      const nScore = Number(score);
+      if (!Number.isFinite(nScore)) return { label: null, score: null, pass: false, reason: 'invalid-score' };
+      return { label: nScore >= FT_CONF ? label : null, score: nScore, pass: nScore >= FT_CONF, reason: nScore >= FT_CONF ? 'threshold-pass' : 'threshold-fail' };
+    }
+
+    async function loadFastText() {
+      setStage('wrapper script load', 'pending', 'loading script');
+      window.Module = { locateFile: (p) => /\.wasm$/i.test(String(p || '')) ? FT_CORE_WASM : `fastType/${String(p || '').split('/').pop().split('\\').pop()}` };
+      window.FastTextModule = window.Module;
+      await new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = FT_WRAPPER_JS;
+        s.onload = resolve;
+        s.onerror = () => reject(new Error('wrapper load failed'));
+        document.head.appendChild(s);
+      });
+      setStage('wrapper script load', 'ok', FT_WRAPPER_JS);
+
+      setStage('FastText global availability', typeof FastText === 'undefined' ? 'error' : 'ok', `typeof FastText=${typeof FastText}`);
+      if (typeof FastText === 'undefined') throw new Error('FastText global missing');
+
+      setStage('constructor/init', 'pending', 'new FastText()');
+      ftInstance = new FastText();
+      setStage('constructor/init', 'ok', 'instance created');
+
+      setStage('model load', 'pending', FT_MODEL);
+      const start = performance.now();
+      await Promise.race([
+        ftInstance.loadModel(FT_MODEL),
+        new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout after ${FT_LOAD_TIMEOUT_MS}ms`)), FT_LOAD_TIMEOUT_MS))
+      ]);
+      const ms = Math.round(performance.now() - start);
+      setStage('model load', 'ok', `${ms}ms`);
+      log('ok', 'model_load', { ms });
+    }
+
+    async function runSmoke() {
+      setStage('smoke tests', 'pending', `${SMOKE.length} cases`);
+      for (const [text, exp] of SMOKE) {
+        const raw = ftInstance.predict(text, 1);
+        const parsed = parsePredictionForPoc(raw);
+        if (parsed.label !== exp) throw new Error(`smoke mismatch exp=${exp} got=${parsed.label}`);
+      }
+      setStage('smoke tests', 'ok', 'all passed');
+    }
+
+    async function runDeepProbe() {
+      const cases = [
+        { name: 'short', text: 'hello' },
+        { name: 'long', text: 'This is a long english text '.repeat(60) },
+        { name: 'punctuation', text: '¿Hola?! ... !!! -- testing punctuation ;;;' },
+        { name: 'unicode', text: 'こんにちは世界 مرحبا بالعالم Привет мир' },
+        { name: 'empty-trimmed guarded', text: '     ' }
+      ];
+      const tbody = document.getElementById('deepRows');
+      tbody.innerHTML = '';
+      for (const c of cases) {
+        const tr = document.createElement('tr');
+        try {
+          if (!c.text.trim()) throw new Error('guarded empty input: skip predict');
+          const raw = ftInstance.predict(c.text, 1);
+          const shape = classifyShape(raw);
+          const parsed = parsePredictionForPoc(raw);
+          tr.innerHTML = `<td>${c.name}</td><td>${shape}</td><td>${parsed.label ?? '(null)'}</td><td>${parsed.score ?? '-'}</td><td>${JSON.stringify(raw).slice(0,160)}</td><td></td>`;
+        } catch (e) {
+          const n = normErr('deep_probe_case', e);
+          tr.innerHTML = `<td>${c.name}</td><td>unknown</td><td>(null)</td><td>-</td><td>-</td><td>${n.detail}</td>`;
+          log('warn', 'deep_probe_case', n);
+        }
+        tbody.appendChild(tr);
+      }
+
+      const loopN = 40;
+      let failures = 0;
+      const t0 = performance.now();
+      for (let i = 0; i < loopN; i++) {
+        try { ftInstance.predict('loop english probe ' + i, 1); } catch (e) { failures++; log('error', 'loop_predict', normErr('loop_predict', e)); }
+      }
+      const elapsed = Math.round(performance.now() - t0);
+      document.getElementById('loopStats').textContent = `Loop probe: ${loopN} calls in ${elapsed}ms, failures=${failures}`;
+    }
+
+    async function runAll() {
+      document.getElementById('overallStatus').textContent = 'Status: running';
+      document.getElementById('assetRows').innerHTML = '';
+      document.getElementById('logOut').textContent = '';
+      try {
+        setStage('asset probing', 'pending', 'wrapper/mjs/wasm/model');
+        const res = await Promise.all(FT_ASSETS.map(probeAsset));
+        if (res.some(x => !x.ok)) throw new Error('asset probing failed');
+        setStage('asset probing', 'ok', 'all assets readable');
+        await loadFastText();
+        await runSmoke();
+        await runDeepProbe();
+        document.getElementById('overallStatus').innerHTML = 'Status: <span class="ok">success</span>';
+      } catch (e) {
+        const n = normErr('runAll', e);
+        log('error', 'runAll', n);
+        document.getElementById('overallStatus').innerHTML = 'Status: <span class="err">failed (non-blocking)</span>';
+      }
+    }
+
+    document.getElementById('runBtn').addEventListener('click', runAll);
+    document.getElementById('manualPredict').addEventListener('click', () => {
+      const out = document.getElementById('manualOut');
+      try {
+        const txt = document.getElementById('manualInput').value;
+        if (!ftInstance) throw new Error('FastText not initialized yet');
+        const raw = ftInstance.predict(txt, 1);
+        const parsed = parsePredictionForPoc(raw);
+        out.textContent = JSON.stringify({ shape: classifyShape(raw), parsed, raw }, null, 2);
+      } catch (e) {
+        out.textContent = JSON.stringify(normErr('manual_predict', e), null, 2);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide an isolated proof-of-concept page to exercise the deployed FastText WASM runtime (wrapper/core/wasm/model) without modifying production HTML or vendor files.
- Surface runtime issues that simple smoke tests miss by exercising the exact API contract `new FastText()`, `loadModel(modelUrl)`, and `predict(text, k)` across varied inputs and repeated calls.
- Offer staged diagnostics, normalized error logging, and a visual deep-probe to make failure modes non-blocking but clearly visible in-page.

### Description
- Add `fasttext-wasm-poc.html`, a standalone diagnostics PoC that references the same asset paths (`fastType/...`) and implements asset probing, wrapper-load tracking, global availability check, constructor/init, timed model load with timeout handling, smoke tests, deep-probe cases, repeated-loop probes, return-shape classification, and normalized label+score extraction for each call.
- Implement a PoC parser/normalizer mirroring the app semantics (whitelist, threshold `FT_CONF`, label prefix trimming) and a `normErr` function that normalizes errors with `context`, JS `type`, `detail`, and `timestamp` for logs.
- Ensure failures are non-blocking and surfaced in-page via a status panel, stage table, assets table, deep-probe table, loop stats, and a log area rather than a fullscreen overlay.
- Add `docs/fasttext-wasm-poc.md` describing purpose, how to run, what to inspect, expected pass/fail signals, and how this PoC differs from simple smoke tests.

### Testing
- Ran a repository search with `rg -n "FastText|loadModel|predict|wasm|model" bridge-patched-v1.html` to confirm no production HTML was modified, and the command completed successfully.
- Created and committed the two new files with `git add` / `git commit` and verified repository status with `git status --short`, all of which succeeded.
- Packaged PR metadata via the `make_pr` helper action to record the change set and summary, which executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b5cea518832db1da2fb01aa31aee)