### PR TITLE
Add TalkBridge web clients: `bridge-codex-v2.html` and `bridge-codex-omega.html`

### DIFF
--- a/bridge-codex-omega.html
+++ b/bridge-codex-omega.html
@@ -1,0 +1,2998 @@
+<!DOCTYPE html>
+<!-- talkbridge · dcr · vOmega -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+<title>TalkBridge</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Lora:wght@500;600&display=swap" rel="stylesheet">
+<style>
+*{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent;}
+:root{
+  --bg:#0a0a0a;--surface:#161616;--surface2:#222;
+  --teal:#2E8B8B;--teal-bright:#3FC1C1;
+  --text:#e8e4df;--text-dim:#888;--text-muted:#555;
+  --red:#e74c3c;--green:#2ecc71;
+  --radius:14px;
+}
+html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans",sans-serif;color:var(--text);}
+.lobby{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:0;z-index:10;background:var(--bg);transition:opacity .3s;overflow:hidden;}
+.lobby.hidden{opacity:0;pointer-events:none;}
+.lobby-card{width:min(100%,420px);height:100dvh;max-height:100dvh;display:flex;flex-direction:column;gap:0;overflow:hidden;padding:16px 20px 0;}
+.lobby-brand{font-family:"DM Sans",sans-serif;font-size:15px;font-weight:700;color:var(--teal-bright);text-align:left;letter-spacing:0;padding:14px 0 2px;}
+.lobby-sub{font-size:13px;color:var(--text-dim);text-align:center;margin-top:-8px;}
+.lobby-label{font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.6px;margin-bottom:-8px;}
+.lobby-input{width:100%;background:var(--surface);color:var(--text);border:1.5px solid var(--surface2);border-radius:10px;padding:12px 14px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;}
+.lobby-input:focus{border-color:var(--teal);}
+.lobby-input::placeholder{color:var(--text-muted);}
+.lobby-select{width:100%;background:var(--surface);color:var(--text);border:1.5px solid var(--surface2);border-radius:10px;padding:12px 14px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;-webkit-appearance:none;appearance:none;cursor:pointer;}
+.lobby-select:focus{border-color:var(--teal);}
+.lobby-btn{width:100%;background:var(--teal);color:#fff;border:none;border-radius:12px;padding:14px;font-size:16px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;transition:opacity .15s;margin-top:4px;}
+.lobby-btn:hover{opacity:.85;}
+.lobby-btn:disabled{opacity:.4;cursor:default;}
+.lobby-btn.secondary{background:var(--surface2);color:var(--text);}
+.lobby-btn.secondary:hover{background:var(--teal);color:#fff;opacity:1;}
+.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;}
+.modal-backdrop.show{display:flex;}
+.modal-card{background:var(--surface);border-radius:16px;padding:24px 20px;width:min(92vw,360px);display:flex;flex-direction:column;gap:14px;}
+.lobby-link-box{background:var(--surface);border:1.5px solid var(--surface2);border-radius:10px;padding:12px;word-break:break-all;font-size:11px;color:var(--teal-bright);margin-bottom:12px;cursor:pointer;}
+.recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}.recent-item.deleted-room{opacity:.85;border-left:3px solid #c0392b;}.recent-act.restore{color:#2e7d4f;}
+.recent-title{font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.6px;}
+.recent-item{background:var(--surface);border:1px solid var(--surface2);border-radius:10px;padding:10px 12px;}
+.recent-item-top{display:flex;align-items:center;gap:8px;}
+.recent-open{flex:1;min-width:0;background:none;border:none;color:var(--text);text-align:left;cursor:pointer;font:inherit;font-size:14px;font-weight:500;}
+.recent-open small{display:block;color:var(--text-dim);font-size:11px;}
+.recent-actions{display:flex;gap:6px;margin-top:8px;}
+.recent-act{flex:1;background:rgba(255,255,255,.06);color:var(--text-dim);border:none;border-radius:8px;padding:6px;font-size:11px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.recent-act:hover{background:var(--teal);color:#fff;}
+.recent-act.danger{color:var(--red);}
+.recent-act.danger:hover{background:var(--red);color:#fff;}
+.lobby-footer{display:flex;gap:8px;margin-top:4px;}
+.lobby-footer-btn{background:none;border:none;color:var(--text-dim);padding:6px 10px;font-size:18px;cursor:pointer;font-family:"DM Sans",sans-serif;border-radius:8px;line-height:1;}
+.lobby-footer-btn:hover{background:var(--surface2);color:var(--text);}.lobby-footer-btn.active{color:var(--teal-bright);}
+.ft-status-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:20px;background:rgba(255,255,255,.05);font-size:10px;color:var(--text-muted);transition:opacity .4s;}
+.ft-status-pill.ready{opacity:0;pointer-events:none;}
+.ft-status-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0;background:var(--text-muted);}
+.ft-status-dot.loading{background:#f39c12;animation:ftPulse .8s ease-in-out infinite alternate;}
+.ft-status-dot.ok{background:var(--green);}
+.ft-status-dot.err{background:var(--red);}
+@keyframes ftPulse{from{opacity:.35}to{opacity:1}}
+.joining-screen{position:fixed;inset:0;background:var(--bg);z-index:20;display:none;align-items:center;justify-content:center;flex-direction:column;gap:16px;}
+.joining-screen.show{display:flex;}
+.joining-spinner{width:40px;height:40px;border:3px solid var(--surface2);border-top-color:var(--teal-bright);border-radius:50%;animation:spin .8s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg)}}
+.joining-label{font-size:14px;color:var(--text-dim);}
+.log-overlay{position:fixed;inset:0;background:rgba(0,0,0,.96);z-index:50;display:none;flex-direction:column;}
+.log-overlay.show{display:flex;}
+.log-header{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--surface2);flex-shrink:0;gap:8px;flex-wrap:wrap;}
+.log-title{font-family:"Lora",serif;font-size:17px;color:var(--teal-bright);}
+.log-actions{display:flex;gap:6px;flex-wrap:wrap;}
+.log-btn{background:var(--surface2);color:var(--text);border:none;border-radius:8px;padding:7px 12px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.log-btn:hover{background:var(--teal);color:#fff;}
+.log-body{flex:1;overflow-y:auto;padding:10px 16px 20px;font-family:monospace;font-size:11px;line-height:1.7;color:#aaa;}
+.log-row{border-bottom:1px solid rgba(255,255,255,.03);padding:1px 0;}
+.log-row .ts{color:#555;}.log-row .ev{color:var(--teal-bright);}
+.log-row.error .ev{color:#e74c3c;}.log-row.warn .ev{color:#f39c12;}.log-row.ok .ev{color:#2ecc71;}
+.call{position:fixed;inset:0;background:#000;z-index:5;display:none;flex-direction:column;}
+.call.active{display:flex;}
+.vc-btn{width:36px;height:36px;border-radius:50%;border:none;background:rgba(255,255,255,.1);color:#ccc;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .2s;flex-shrink:0;}
+.vc-btn:hover{background:rgba(255,255,255,.18);color:#fff;}
+.vc-btn svg{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;}
+.vc-btn.muted{background:rgba(231,76,60,.25);color:#e74c3c;}
+.vc-btn.end{background:#e74c3c;color:#fff;}
+.vc-btn.end:hover{background:#c0392b;}
+.call-videos{position:relative;background:#000;overflow:hidden;flex:1;min-height:0;}
+#remote-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000;z-index:1;}
+#local-video{position:absolute;top:8px;right:8px;width:min(14%,80px);aspect-ratio:9/16;border-radius:8px;object-fit:cover;transform:scaleX(-1);border:2px solid rgba(255,255,255,.2);box-shadow:0 2px 12px rgba(0,0,0,.5);z-index:3;background:var(--surface);}
+.no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:"DM Sans",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:"DM Sans",sans-serif;display:none;}.reconnect-banner.show{display:block;}
+.solo-banner{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:2;text-align:center;pointer-events:none;}
+.solo-banner-text{background:rgba(0,0,0,.6);color:var(--text-dim);font-size:13px;padding:8px 18px;border-radius:20px;backdrop-filter:blur(6px);}
+.subtitle-area{position:absolute;bottom:0;left:0;right:0;z-index:4;padding:8px 14px 10px;pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:4px;background:linear-gradient(transparent,rgba(0,0,0,.6) 40%);}
+.subtitle-line{max-width:94%;padding:4px 12px;border-radius:6px;font-size:14px;line-height:1.35;text-align:center;word-break:break-word;}
+.subtitle-line.partner{background:rgba(0,0,0,.6);color:#fff;}
+.subtitle-line.mine{background:rgba(46,139,139,.2);color:rgba(255,255,255,.65);font-size:12px;}
+.partner-speaking-indicator{position:absolute;right:12px;bottom:56px;z-index:5;min-width:34px;height:24px;border-radius:999px;background:rgba(0,0,0,.55);border:1px solid rgba(255,255,255,.2);color:#fff;display:none;align-items:center;justify-content:center;font-size:18px;font-weight:700;line-height:1;backdrop-filter:blur(4px);}
+.partner-speaking-indicator.show{display:flex;animation:pulseSpeak .9s ease-in-out infinite alternate;}
+@keyframes pulseSpeak{from{opacity:.55;transform:scale(.98)}to{opacity:1;transform:scale(1.03)}}
+.call-transcript{position:relative;flex:0 0 30%;min-height:0;max-height:45%;overflow-y:auto;background:var(--bg);border-top:1px solid var(--surface2);padding:0 12px;transition:flex-basis .2s ease;}
+.call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:6px 4px 6px 2px;position:sticky;top:0;background:var(--bg);z-index:1;gap:6px;}
+.call-transcript-title{font-size:12px;font-weight:700;color:var(--text-dim);letter-spacing:.3px;}
+.call-transcript-actions{display:flex;gap:6px;}
+.call-transcript-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,.06);color:#8f959d;border:1px solid rgba(255,255,255,.14);border-radius:8px;cursor:pointer;padding:0;}
+.call-transcript-btn:hover{background:rgba(255,255,255,.06);color:#b6bcc3;border-color:rgba(255,255,255,.26);}
+.call-transcript-btn svg{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+.call.transcript-collapsed .chevron-down{display:none;}
+.call:not(.transcript-collapsed) .chevron-right{display:none;}
+.transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}
+.transcript-more-indicator.show{display:flex;}
+.transcript-more-indicator:hover{background:var(--teal-bright);}
+.call.transcript-collapsed .call-transcript{flex:0 0 32px;max-height:32px;overflow:hidden;}
+.call.transcript-collapsed #transcript-body{display:none;}
+.call-videos.swapped #remote-video{top:8px;right:8px;left:auto;bottom:auto;width:min(14%,80px);height:auto;aspect-ratio:9/16;border-radius:8px;border:2px solid rgba(255,255,255,.2);box-shadow:0 2px 12px rgba(0,0,0,.5);z-index:3;}
+.call-videos.swapped #local-video{inset:0;width:100%;height:100%;border-radius:0;border:none;box-shadow:none;z-index:1;}
+.tr-entry{padding:6px 0;}
+.tr-bubble{border:1px solid rgba(255,255,255,.14);border-radius:12px;overflow:hidden;background:rgba(255,255,255,.02);}
+.tr-bubble.is-chat{border-color:rgba(63,193,193,.25);background:rgba(46,139,139,.08);}
+.tr-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:6px 10px;border-bottom:1px solid rgba(255,255,255,.08);font-size:11px;}
+.tr-who{font-weight:700;color:var(--text-dim);}
+.tr-who.mine{color:var(--teal-bright);}
+.tr-time{font-size:10px;color:var(--text-muted);font-variant-numeric:tabular-nums;}
+.tr-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.tr-col{padding:8px 10px;display:flex;flex-direction:column;gap:6px;min-width:0;}
+.tr-divider{background:rgba(255,255,255,.08);}
+.tr-text{font-size:13px;line-height:1.4;color:var(--text);word-break:break-word;}
+.tr-col.source .tr-text{color:var(--text-dim);}
+.tr-tts{border:none;background:transparent;color:#8f959d;cursor:pointer;padding:0;display:flex;align-items:center;gap:4px;font-size:10px;line-height:1;}
+.tr-tts:hover{color:#c4ccd4;}
+.tr-tts svg{width:13px;height:13px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+.tr-empty{color:var(--text-muted);font-size:12px;font-style:italic;padding:12px 0;}
+.call-controls{display:flex;align-items:center;justify-content:center;gap:14px;padding:8px 16px max(8px,env(safe-area-inset-bottom));background:var(--surface);flex-shrink:0;}
+.ctrl-btn{width:48px;height:48px;border-radius:50%;border:none;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,transform .1s;background:rgba(255,255,255,.1);color:#fff;}
+.ctrl-btn:hover{background:rgba(255,255,255,.18);}
+.ctrl-btn:active{transform:scale(.93);}
+.ctrl-btn.off{background:rgba(231,76,60,.2);color:var(--red);}
+.ctrl-btn.end-call{background:var(--red);color:#fff;width:56px;height:48px;border-radius:24px;}
+.ctrl-btn.end-call:hover{background:#c0392b;}
+#toast{position:fixed;bottom:90px;left:50%;transform:translateX(-50%) translateY(20px);background:rgba(255,255,255,.15);backdrop-filter:blur(12px);color:#fff;font-size:13px;font-weight:600;padding:10px 20px;border-radius:22px;z-index:100;opacity:0;transition:opacity .2s,transform .2s;pointer-events:none;white-space:pre-line;text-align:center;max-width:90vw;}
+#toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
+@media(min-width:768px){
+  .lobby-card{width:420px;}
+  #local-video{width:min(18%,160px);}
+  .call-controls{gap:20px;padding:10px 24px;}
+  .ctrl-btn{width:54px;height:54px;}
+  .ctrl-btn.end-call{width:64px;height:54px;}
+  .subtitle-line{font-size:16px;max-width:80%;}
+  .call-transcript{flex-basis:28%;}
+}
+@media(max-height:500px) and (orientation:landscape){
+  .call-transcript{flex-basis:34%;}
+  #local-video{width:min(16%,90px);top:6px;right:6px;}
+  .call-controls{gap:10px;padding:6px 12px;}
+  .ctrl-btn{width:40px;height:40px;}
+  .ctrl-btn.end-call{width:48px;height:40px;}
+  .subtitle-line{font-size:12px;padding:3px 8px;}
+}
+@media(max-width:400px){
+  .call-controls{gap:10px;}
+  .ctrl-btn{width:44px;height:44px;}
+  .ctrl-btn.end-call{width:52px;height:44px;}
+}
+.call-info-wrap{position:absolute;top:8px;left:50%;transform:translateX(-50%);z-index:5;display:flex;flex-direction:column;align-items:center;gap:3px;pointer-events:none;}
+.room-name-chip{background:rgba(0,0,0,.72);color:#fff;border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:600;white-space:nowrap;max-width:min(78vw,260px);overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(5px);}
+.lang-flags-chip{background:rgba(0,0,0,.55);color:#fff;border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:2px 10px;font-size:15px;backdrop-filter:blur(4px);}
+.chat-compose-strip{display:flex;align-items:flex-end;gap:8px;padding:8px 12px max(8px,env(safe-area-inset-bottom));background:var(--surface);border-top:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+.chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:"DM Sans",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}
+.chat-compose-ta::-webkit-scrollbar{display:none;}
+.chat-compose-ta::placeholder{color:var(--text-muted);}
+.chat-compose-ta:focus{border-color:var(--teal);}
+.chat-send-btn{width:38px;height:38px;border-radius:50%;border:none;background:var(--teal);color:#fff;cursor:pointer;flex-shrink:0;display:flex;align-items:center;justify-content:center;transition:opacity .15s;}
+.chat-send-btn:disabled{opacity:.3;cursor:default;}
+.chat-send-btn:hover:not(:disabled){opacity:.85;}
+/* ═══ PHRASEBOOK v2 STYLES ═══════════════════════════════════════════════ */
+.pb-drawer{position:fixed;left:0;right:0;bottom:-56dvh;height:56dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:20;transition:bottom .2s ease;display:flex;flex-direction:column;overflow:hidden;}
+.pb-drawer.open{bottom:0;}
+.pb-drawer-hdr{display:flex;align-items:center;gap:8px;padding:10px 12px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;}
+.pb-drawer-title{font-size:13px;font-weight:700;color:var(--text-dim);flex:1;}
+.pb-drawer-x{background:none;border:none;color:var(--text-dim);font-size:20px;cursor:pointer;line-height:1;padding:2px 6px;}
+.pb-drawer-x:hover{color:var(--text);}
+#pb-drawer-content{flex:1;display:flex;flex-direction:column;overflow:hidden;}
+.pb-chip-ribbon{display:flex;overflow-x:auto;gap:7px;padding:7px 10px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;-webkit-overflow-scrolling:touch;scrollbar-width:none;}
+.pb-chip-ribbon::-webkit-scrollbar{display:none;}
+.pb-cr-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:999px;padding:5px 12px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;flex-shrink:0;transition:background .12s,border-color .12s;}
+.pb-cr-chip:hover{background:var(--teal);border-color:var(--teal);color:#fff;}
+.pb-cr-chip.danger{color:var(--red);border-color:rgba(231,76,60,.4);}
+.pb-cr-chip.danger:hover{background:var(--red);border-color:var(--red);color:#fff;}
+.pb-ico-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:8px 10px;cursor:pointer;line-height:0;display:inline-flex;align-items:center;justify-content:center;transition:background .12s;flex-shrink:0;}
+.pb-ico-chip:hover{background:var(--teal);border-color:var(--teal);color:#fff;}
+.pb-ico-chip.danger:hover{background:var(--red);border-color:var(--red);}
+.pb-search-inp{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:10px;padding:8px 12px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;}
+.pb-search-inp:focus{border-color:var(--teal-bright);}
+.pb-search-inp::placeholder{color:var(--text-muted);}
+.pb-pair-badge{background:rgba(63,193,193,.15);color:var(--teal-bright);border-radius:999px;padding:3px 10px;font-size:11px;font-weight:700;flex-shrink:0;}
+.pb-search-results{overflow-y:auto;padding:8px 10px;flex:1;}
+.pb-empty{color:var(--text-muted);font-size:13px;padding:16px;text-align:center;}
+.pb-bubble{background:#fff;border-radius:12px;margin-bottom:10px;overflow:hidden;border:1px solid #e0dbd6;font-family:"DM Sans",sans-serif;}
+.pb-bbl-hdr{display:flex;align-items:center;gap:6px;padding:6px 10px;background:#f5f1ec;border-bottom:1px solid #e0dbd6;font-size:11px;min-height:28px;}
+.pb-bbl-pair{font-weight:700;color:#5a5552;flex:1;}
+.pb-bbl-ts{font-size:10px;color:#9a9592;flex:1;font-variant-numeric:tabular-nums;}
+.room-trash-details{margin-top:6px;}
+.room-trash-details summary{font-size:11px;color:var(--text-muted);padding:4px 2px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:5px;user-select:none;}
+.room-trash-details summary::-webkit-details-marker{display:none;}
+.pb-book-row{display:flex;align-items:center;padding:10px;border:1px solid #e0dbd6;border-radius:10px;margin-bottom:6px;background:#fff;gap:8px;}
+.pb-book-name{flex:1;font-size:14px;color:#1a1714;font-weight:500;}
+.pb-vbadge{font-size:11px;font-weight:700;padding:1px 5px;border-radius:4px;}
+.pb-vbadge.good{color:#2e7d4f;background:#e8f5ee;}
+.pb-vbadge.flag{color:#c0392b;background:#fdedec;}
+.pb-tag-ct{font-size:10px;color:#9a9592;}
+.pb-del-btn{background:none;border:none;cursor:pointer;color:#c0392b;font-size:13px;padding:0;margin-left:auto;opacity:.65;}
+.pb-del-btn:hover{opacity:1;}
+.pb-bbl-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.pb-bbl-col{padding:10px;display:flex;flex-direction:column;gap:6px;}
+.pb-bbl-div{background:#e0dbd6;}
+.pb-bbl-txt{font-size:15px;line-height:1.45;color:#1a1714;word-break:break-word;flex:1;}
+.pb-bbl-acts{display:flex;align-items:center;gap:6px;}
+.pb-tts-btn{background:none;border:none;cursor:pointer;color:#9a9592;padding:3px;line-height:0;display:flex;align-items:center;}
+.pb-tts-btn:hover{color:#1a1714;}
+.pb-bbl-foot{border-top:1px solid #e0dbd6;display:flex;gap:1px;padding:3px 5px;background:#fdfaf7;}
+.pb-fbt{background:none;border:none;cursor:pointer;font-size:11px;font-weight:600;color:#9a9592;padding:4px 8px;border-radius:6px;font-family:"DM Sans",sans-serif;white-space:nowrap;flex:1;text-align:center;transition:background .1s;}
+.pb-fbt:hover{background:rgba(0,0,0,.05);color:#5a5552;}
+.pb-fbt.on{background:rgba(46,139,139,.12);color:#2e8b8b;}
+.pb-panel{border-top:1px solid #e0dbd6;background:#fdfaf7;}
+.pb-tpills{display:flex;flex-wrap:wrap;gap:4px;min-height:18px;}
+.pb-tp{background:#eee8ff;color:#6b4fbb;border-radius:5px;padding:2px 6px;font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px;}
+.pb-tag-inp{width:100%;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;outline:none;margin-top:6px;background:#fff;color:#1a1714;}
+.pb-tag-inp:focus{border-color:#2e8b8b;}
+.pb-tsugg{display:flex;flex-wrap:wrap;gap:5px;margin-top:6px;}
+.pb-tsugg-chip{border:1px solid #e0dbd6;background:#fff;border-radius:999px;padding:2px 8px;font-size:11px;cursor:pointer;color:#5a5552;}
+.pb-tsugg-chip:hover{border-color:#2e8b8b;color:#2e8b8b;}
+.pb-clarify-item{margin-bottom:6px;}
+.pb-clarify-meta{display:flex;justify-content:space-between;align-items:center;}
+.pb-clarify-author{font-size:11px;font-weight:700;color:#5a5552;}
+.pb-clarify-body{font-size:13px;color:#1a1714;line-height:1.4;margin-top:2px;}
+.pb-clarify-inp{flex:1;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;outline:none;background:#fff;color:#1a1714;}
+.pb-clarify-inp:focus{border-color:#2e8b8b;}
+.pb-clarify-send{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-bt-run{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;margin-bottom:8px;display:block;font-family:"DM Sans",sans-serif;}
+.pb-vbtn{border:none;border-radius:7px;padding:4px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-vbtn.good{background:#e8f5ee;color:#2e7d4f;}
+.pb-vbtn.flag{background:#fdedec;color:#c0392b;}
+.pb-vbtn.sm{background:#f5f1ec;color:#5a5552;font-size:10px;}
+.pb-overlay{position:fixed;inset:0;background:#fdfaf7;z-index:30;display:none;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-ov-hdr{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fdfaf7;flex-shrink:0;}
+.pb-ov-back{background:none;border:none;cursor:pointer;color:#5a5552;font-size:22px;padding:4px 6px;border-radius:8px;line-height:1;}
+.pb-ov-back:hover{background:#eeede9;}
+.pb-ov-title{flex:1;font-family:"Lora",serif;font-size:17px;font-weight:600;color:#1a1714;}
+.pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;padding:6px 8px;border-radius:8px;line-height:0;display:inline-flex;align-items:center;}
+.pb-ov-act:hover{background:#eeede9;color:#1a1714;}
+.pb-ov-act:hover{background:#eeede9;color:#1a1714;}
+.pb-ov-searchbar{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-ov-si{flex:1;border:1.5px solid #e0dbd6;border-radius:10px;padding:8px 12px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;background:#fff;color:#1a1714;}
+.pb-ov-si:focus{border-color:#2e8b8b;}
+.pb-ov-si::placeholder{color:#9a9592;}
+.pb-ov-filter-bar{display:flex;flex-wrap:wrap;gap:6px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fdfaf7;flex-shrink:0;}
+.pb-fc{background:#fff;border:1.5px solid #e0dbd6;border-radius:999px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;color:#5a5552;font-family:"DM Sans",sans-serif;transition:all .12s;}
+.pb-fc:hover{border-color:#2e8b8b;color:#2e8b8b;}
+.pb-fc.act{background:#2e8b8b;border-color:#2e8b8b;color:#fff;}
+#pb-ov-cards{flex:1;overflow-y:auto;padding:10px 14px 80px;}
+.pb-import-modal{position:fixed;inset:0;background:#fdfaf7;z-index:40;display:none;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-im-hdr{display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-im-title{flex:1;font-size:17px;font-weight:600;color:#1a1714;}
+.pb-im-x{background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;}
+.pb-im-sel-bar{display:flex;gap:10px;padding:8px 14px 0;flex-shrink:0;}
+.pb-im-sel-btn{background:none;border:none;color:#2e8b8b;font-size:12px;font-weight:700;cursor:pointer;padding:4px 0;font-family:"DM Sans",sans-serif;}
+#pb-import-list{flex:1;overflow-y:auto;padding:8px 14px;}
+.pb-import-row{display:flex;align-items:flex-start;gap:10px;padding:10px;border:1px solid #e0dbd6;border-radius:10px;margin-bottom:6px;background:#fff;cursor:pointer;}
+.pb-import-row input[type=checkbox]{margin-top:2px;width:16px;height:16px;accent-color:#2e8b8b;flex-shrink:0;}
+.pb-import-info{flex:1;min-width:0;}
+.pb-import-pair{display:inline-block;background:#e6f4f4;color:#2e8b8b;border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;margin-bottom:4px;}
+.pb-import-src{display:block;font-size:13px;color:#1a1714;font-weight:500;}
+.pb-import-tgt{display:block;font-size:12px;color:#5a5552;margin-top:1px;}
+.pb-im-footer{display:flex;gap:8px;padding:12px 14px max(12px,env(safe-area-inset-bottom));border-top:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-im-cancel{flex:1;background:#f5f1ec;color:#5a5552;border:1px solid #e0dbd6;border-radius:10px;padding:12px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-im-ok{flex:2;background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-sheet{position:fixed;left:0;right:0;bottom:-65dvh;height:65dvh;background:#fdfaf7;border-top:1px solid #e0dbd6;border-radius:14px 14px 0 0;z-index:35;transition:bottom .22s ease;display:flex;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-nc-sheet.open{bottom:0;}
+.pb-nc-hdr{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;flex-shrink:0;}
+.pb-nc-title{flex:1;font-size:15px;font-weight:700;color:#1a1714;}
+.pb-nc-x{background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;}
+.pb-nc-label{font-size:11px;font-weight:700;color:#9a9592;text-transform:uppercase;letter-spacing:.4px;margin-bottom:4px;display:block;}
+.pb-nc-sel{border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;color:#1a1714;cursor:pointer;-webkit-appearance:none;}
+.pb-nc-sel:focus{border-color:#2e8b8b;}
+.pb-nc-ta{width:100%;border:1.5px solid #e0dbd6;border-radius:10px;padding:9px 12px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;resize:none;outline:none;min-height:60px;color:#1a1714;}
+.pb-nc-ta:focus{border-color:#2e8b8b;}
+.pb-nc-trans{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:8px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;margin:8px 0;}
+.pb-nc-save{background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:15px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;}
+.phrase-mini{border:1px solid rgba(255,255,255,.12);border-radius:10px;padding:8px;margin:8px 0;background:rgba(255,255,255,.03);}
+.phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+.phrase-mini-side{border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:6px;}
+.phrase-mini-meta{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;}
+.phrase-mini-src{font-size:13px;color:var(--text-dim);}
+.phrase-mini-tgt{font-size:13px;color:var(--text);margin-top:2px;}
+.phrase-mini-actions{display:flex;gap:6px;margin-top:6px;}
+.phrase-mini-actions button{background:rgba(255,255,255,.08);color:var(--text);border:none;border-radius:8px;padding:6px 8px;font-size:11px;cursor:pointer;}
+#chat-body{padding:0;}
+.ch-entry{padding:4px 0;}
+.ch-bubble{border:1px solid rgba(255,255,255,.14);border-radius:12px;overflow:hidden;background:rgba(255,255,255,.03);}
+.ch-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:4px 10px;border-bottom:1px solid rgba(255,255,255,.08);font-size:11px;}
+.ch-who{font-weight:700;}.ch-who.mine{color:var(--teal-bright);}.ch-who.theirs{color:var(--text-dim);}
+.ch-time{font-size:10px;color:var(--text-muted);font-variant-numeric:tabular-nums;}
+.ch-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.ch-col{padding:7px 10px;font-size:13px;line-height:1.4;color:var(--text);word-break:break-word;min-width:0;}
+.ch-col.orig{color:var(--text-dim);}
+.ch-divider{background:rgba(255,255,255,.08);}
+@media(min-width:768px){.chat-compose-ta{font-size:15px;}}
+@media(max-height:500px) and (orientation:landscape){.chat-compose-strip{padding:5px 10px;}.chat-compose-ta{min-height:32px;font-size:13px;}}
+.joiner-landing{position:fixed;inset:0;z-index:30;display:none;flex-direction:column;align-items:center;justify-content:center;gap:24px;padding:32px 20px;background-image:linear-gradient(rgba(10,10,10,.82),rgba(10,10,10,.82)),url('./flags.gif'),url('./flags.png'),linear-gradient(135deg,#0a2020,#0a1020);background-size:cover,cover,cover,cover;background-position:center,center,center,center;background-repeat:no-repeat,no-repeat,no-repeat,no-repeat;}
+.joiner-landing.show{display:flex;}
+.joiner-lang-pill{font-size:28px;letter-spacing:2px;}
+.joiner-room-name{font-family:"Lora",serif;font-size:22px;font-weight:600;color:#fff;text-align:center;line-height:1.3;width:100%;word-break:break-word;}
+.joiner-flags{font-size:36px;letter-spacing:4px;}
+.joiner-join-btn{width:100%;background:var(--teal-bright);color:#fff;border:none;border-radius:16px;padding:18px;font-size:18px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.joiner-sub{font-size:13px;color:rgba(255,255,255,.6);text-align:center;}
+.thankyou-page{position:fixed;inset:0;background:var(--bg);z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;}
+.thankyou-page.show{display:flex;}
+.thankyou-page-bg{position:fixed;inset:0;z-index:0;pointer-events:none;background-image:linear-gradient(rgba(10,10,10,.82),rgba(10,10,10,.82)),url('./flags.gif'),url('./flags.png'),linear-gradient(135deg,#0a2020,#0a1020);background-size:cover,cover,cover,cover;background-position:center,center,center,center;background-repeat:no-repeat,no-repeat,no-repeat,no-repeat;}.thankyou-title{font-family:"Lora",serif;font-size:22px;font-weight:600;color:#fff;text-align:center;position:relative;z-index:1;}
+.thankyou-sub{font-size:14px;color:rgba(255,255,255,.6);text-align:center;line-height:1.5;position:relative;z-index:1;}
+.thankyou-btn{background:rgba(255,255,255,.12);color:#fff;border:1px solid rgba(255,255,255,.25);border-radius:12px;padding:12px 24px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;position:relative;z-index:1;}
+
+
+/* ─── Call PiP overlay ─────────────────────────────────── */
+#pip-overlay{position:fixed;bottom:24px;right:16px;width:min(44vw,200px);z-index:50;display:none;flex-direction:column;border-radius:14px;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,.6);background:#000;}
+#pip-overlay.show{display:flex;}
+#pip-overlay video{width:100%;display:block;object-fit:cover;}
+#pip-remote{aspect-ratio:9/16;max-height:200px;}
+#pip-local{width:32%;aspect-ratio:9/16;position:absolute;bottom:6px;right:6px;border-radius:6px;border:1.5px solid rgba(255,255,255,.25);}
+.pip-controls{position:absolute;top:6px;right:6px;display:flex;gap:6px;}
+.pip-btn{background:rgba(0,0,0,.55);border:none;border-radius:50%;width:28px;height:28px;cursor:pointer;color:#fff;display:flex;align-items:center;justify-content:center;line-height:0;backdrop-filter:blur(4px);}
+.pip-btn:hover{background:rgba(0,0,0,.8);}
+#pip-overlay .pip-tap-target{position:absolute;inset:0;cursor:pointer;}
+
+/* ─── PB v2+ additions ───────────────────────────────── */
+/* Icon-only action buttons */
+.pb-icon-btn{background:none;border:none;cursor:pointer;color:#9a9592;padding:4px;border-radius:6px;line-height:0;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;transition:color .12s,background .12s;}
+.pb-icon-btn:hover{color:#1a1714;background:rgba(0,0,0,.06);}
+.pb-icon-btn.danger:hover{color:#c0392b;background:rgba(192,57,43,.08);}
+.pb-icon-btn.restore:hover{color:#2e7d4f;background:rgba(46,125,79,.08);}
+/* Chevron expand */
+.pb-chevron-row{display:flex;align-items:center;justify-content:flex-end;padding:0 6px 4px;gap:6px;}
+.pb-chevron-row.deleted{background:rgba(192,57,43,.05);}
+/* Soft-deleted bubble */
+.pb-bubble.deleted .pb-bbl-txt{text-decoration:line-through;opacity:.5;}
+.pb-bubble.deleted .pb-bbl-hdr{background:#f9eded;}
+/* Use button — icon only */
+.pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;line-height:1.4;display:inline-flex;align-items:center;justify-content:center;}
+.pb-use-btn:hover{background:#2e8b8b;color:#fff;}
+/* BT TTS */
+.pb-bt-tts{background:none;border:none;cursor:pointer;color:#9a9592;padding:3px;display:inline-flex;align-items:center;vertical-align:middle;}
+.pb-bt-tts:hover{color:#2e8b8b;}
+/* URL import inline row */
+
+.pb-url-go{background:var(--teal);color:#fff;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;}
+/* Attachment modal */
+#att-modal{position:fixed;inset:0;background:rgba(0,0,0,.75);z-index:60;display:none;align-items:center;justify-content:center;padding:16px;}
+#att-modal.show{display:flex;}
+#att-modal-inner{background:var(--surface);border-radius:14px;max-width:min(96vw,640px);max-height:90dvh;width:100%;display:flex;flex-direction:column;overflow:hidden;}
+#att-modal-hdr{display:flex;align-items:center;gap:8px;padding:12px 14px;border-bottom:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+#att-modal-name{flex:1;font-size:13px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+#att-modal-body{flex:1;overflow:auto;padding:14px;}
+#att-modal-body img{max-width:100%;border-radius:8px;}
+#att-modal-body iframe{width:100%;height:60dvh;border:none;border-radius:8px;background:#fff;}
+/* tr-use icon style */
+.tr-use-ico{border:none;background:rgba(255,255,255,.08);color:#c4ccd4;border-radius:5px;padding:3px 6px;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:600;}
+.tr-use-ico:hover{background:rgba(63,193,193,.25);color:var(--teal-bright);}
+/* Chat attach SVG */
+.chat-attach-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;}
+.chat-attach-btn:hover{color:var(--text);}
+.pb-strip-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;transition:color .12s;}
+.pb-strip-btn:hover{color:var(--teal-bright);}
+.pb-strip-btn.active{color:var(--teal-bright);}
+</style>
+</head>
+<body>
+
+<div class="lobby" id="lobby">
+  <div class="lobby-card">
+    <div class="lobby-brand">TalkBridge</div>
+    <div id="lobby-setup" style="display:flex;flex-direction:column;flex:1;min-height:0;">
+      <div style="flex:1;overflow-y:auto;padding-bottom:8px;">
+        <div style="display:flex;flex-direction:column;gap:10px;padding-bottom:4px;">
+          <button class="lobby-btn" onclick="openCreateRoomModal()">＋ Create new room</button>
+          <input type="hidden" id="room-name" value="">
+          <select id="my-lang" style="display:none"></select>
+          <select id="their-lang" style="display:none"></select>
+        </div>
+        <div id="keys-panel" style="display:none;flex-direction:column;gap:10px;margin-top:14px;padding-top:14px;border-top:1px solid var(--surface2);">
+          <div><div class="lobby-label" style="margin-bottom:6px;">Deepgram API key</div>
+          <input class="lobby-input" id="dg-key" type="password" placeholder="Paste key — stored locally" oninput="onDgKeyInput()">
+          <div id="dg-key-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+          <div><div class="lobby-label" style="margin-bottom:6px;">Cloudflare TURN token ID</div>
+          <input class="lobby-input" id="cf-turn-id" type="password" placeholder="Paste token ID — stored locally" oninput="onCfTurnInput()">
+          <div class="lobby-label" style="margin-bottom:6px;margin-top:10px;">Cloudflare TURN API token</div>
+          <input class="lobby-input" id="cf-turn-tok" type="password" placeholder="Paste API token — stored locally" oninput="onCfTurnInput()">
+          <div id="cf-turn-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+        </div>
+        <div class="recent-rooms" id="recent-rooms" style="display:none;margin-top:14px;">
+          <div class="recent-title">Recent rooms</div>
+          <div class="recent-rooms-scroll" id="recent-rooms-list"></div>
+        </div>
+      </div>
+      <div class="lobby-footer" style="flex-shrink:0;border-top:1px solid var(--surface2);padding-top:6px;margin-top:4px;display:flex;align-items:center;justify-content:space-between;">
+        <button class="lobby-footer-btn" onclick="openLog()" title="Debug log">🪲</button>
+        <span id="ft-lobby-status" class="ft-status-pill"><span class="ft-status-dot loading" id="ft-dot"></span><span id="ft-label">Lang model loading…</span></span>
+        <span style="font-size:10px;color:var(--text-muted);">vOmega</span>
+        <button class="lobby-footer-btn" onclick="toggleKeysPanel()" id="keys-gear-btn" title="API keys">⚙️</button>
+      </div>
+    </div>
+    <div id="lobby-waiting" style="display:none;">
+      <div style="font-size:14px;color:var(--text-dim);text-align:center;margin-bottom:10px;" id="room-name-display"></div>
+      <div class="lobby-link-box" id="lobby-link" onclick="copyLink()">—</div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-backdrop" id="create-room-backdrop">
+  <div class="modal-card">
+    <div style="font-family:'Lora',serif;font-size:18px;font-weight:600;color:var(--text);">Create new room</div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">Room name (optional)</div>
+    <input class="lobby-input" id="modal-room-name" placeholder="e.g. Doctor visit" maxlength="60"></div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">I speak</div>
+    <select class="lobby-select" id="modal-my-lang" onchange="syncModalBtn()"></select></div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">They speak</div>
+    <select class="lobby-select" id="modal-their-lang" onchange="syncModalBtn()"></select></div>
+    <div style="display:flex;gap:10px;">
+      <button class="lobby-btn secondary" style="flex:1;" onclick="closeCreateRoomModal()">Cancel</button>
+      <button class="lobby-btn" style="flex:1;" id="modal-create-btn" onclick="confirmCreateRoom()" disabled>OK</button>
+    </div>
+  </div>
+</div>
+<div class="joining-screen" id="joining-screen">
+  <div class="joining-spinner"></div>
+  <div class="joining-label">Joining call…</div>
+</div>
+
+<div class="log-overlay" id="log-overlay">
+  <div class="log-header">
+    <span class="log-title">🪲 Debug Log</span>
+    <div class="log-actions">
+      <button class="log-btn" onclick="copyLogText()">Copy</button>
+      <button class="log-btn" onclick="clearLogText()">Clear</button>
+      <button class="log-btn" onclick="closeLog()"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> Close</button>
+    </div>
+  </div>
+  <div class="log-body" id="log-body"></div>
+</div>
+
+<div class="log-overlay" id="room-tr-overlay">
+  <div class="log-header">
+    <span class="log-title" id="room-tr-title">Transcript</span>
+    <div class="log-actions">
+      <button class="log-btn" onclick="copyRoomTr()">Copy</button>
+      <button class="log-btn" onclick="closeRoomTr()"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> Close</button>
+    </div>
+  </div>
+  <div class="log-body" id="room-tr-body" style="font-family:'DM Sans',sans-serif;font-size:13px;"></div>
+</div>
+
+<div class="joiner-landing" id="joiner-landing">
+  <div class="joiner-lang-pill" id="joiner-lang-pill"></div>
+  <div class="joiner-room-name" id="joiner-room-name">You are invited to join a call</div>
+  <div class="joiner-flags" id="joiner-flags"></div>
+  <button class="joiner-join-btn" id="joiner-join-btn" onclick="joinerProceed()">Join Call</button>
+  <div class="joiner-sub" id="joiner-sub">Tap to allow camera &amp; microphone access</div>
+</div>
+<div class="thankyou-page" id="thankyou-page">
+  <div class="thankyou-page-bg"></div>
+  <div class="joiner-lang-pill" id="thankyou-lang-pill"></div>
+  <div class="thankyou-title" id="thankyou-title">Thanks for calling.</div>
+  <button class="thankyou-btn" onclick="copyLogText();toast('Log copied')">📋 Copy log</button>
+  <button class="thankyou-btn" onclick="downloadThankyouLog()">⬇ Download log</button>
+  <button class="thankyou-btn" onclick="copyTr();toast('Transcript copied')">📋 Copy transcript</button>
+  <button class="thankyou-btn" id="thankyou-dl-btn" onclick="exportTxt()">⬇ Download transcript</button>
+  <button class="thankyou-btn" id="thankyou-rejoin-btn" onclick="rejoinCall()" style="display:none">🔄 Rejoin</button>
+  <div class="thankyou-sub" id="thankyou-sub" style="margin-top:auto;padding-top:16px;">You can close this tab.</div>
+</div>
+<div class="call" id="call-screen">
+  <div class="call-videos" id="call-videos">
+    <video id="remote-video" autoplay playsinline></video>
+    <video id="local-video" autoplay muted playsinline></video>
+    <div class="no-video-placeholder" id="no-video-msg">👤</div>
+    <div class="remote-cam-off" id="remote-cam-off"><div class="remote-cam-off-icon">👤</div><div class="remote-cam-off-label" id="remote-cam-off-label">Camera off</div></div>
+    <div class="partner-disconnected-overlay" id="partner-disconnected-overlay"><div style="font-size:36px;">📵</div><div class="partner-disconnected-label" id="partner-disconnected-label">Partner has disconnected</div><div class="partner-disconnected-sub" id="partner-disconnected-sub">Waiting to reconnect…</div></div>
+    <button class="reconnect-banner" id="reconnect-banner" onclick="forceReconnect()">Tap to reconnect</button>
+    <div class="solo-banner" id="solo-banner" style="display:none;">
+      <div class="solo-banner-text">Waiting for partner to join…</div>
+    </div>
+    <div class="partner-speaking-indicator" id="partner-speaking-indicator" aria-hidden="true">…</div>
+    <div class="subtitle-area" id="subtitle-area"></div>
+  </div>
+  <div class="call-transcript" id="call-transcript">
+    <div class="call-transcript-header" style="justify-content:space-between;">
+      <div class="call-transcript-actions">
+        <button class="call-transcript-btn" id="transcript-toggle-btn" onclick="toggleTranscript()" title="Collapse" aria-label="Collapse transcript" aria-expanded="true">
+          <svg class="chevron-down" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg>
+          <svg class="chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg>
+        </button>
+        <button class="call-transcript-btn" id="transcript-tts-toggle" onclick="toggleTranscriptTts()" title="TTS" aria-pressed="false">
+          <svg class="tts-on" viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/><path d="M18 7a7 7 0 0 1 0 10"/></svg>
+          <svg class="tts-off" viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><line x1="3" y1="21" x2="21" y2="3" stroke="#e74c3c" stroke-width="2.5"/></svg>
+        </button>
+        <button class="call-transcript-btn" id="strip-share-btn" onclick="shareLink()" title="Share" style="display:none;">
+          <svg viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.8 10.8l6.4-3.6M8.8 13.2l6.4 3.6"/></svg>
+        </button>
+        <button class="call-transcript-btn" onclick="copyTr()" title="Copy">
+          <svg viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
+        </button>
+        <button class="call-transcript-btn" onclick="exportTxt()" title="Download">
+          <svg viewBox="0 0 24 24"><path d="M12 3v11"/><path d="M8 10l4 4 4-4"/><path d="M4 20h16"/></svg>
+        </button>
+      </div>
+      <div style="display:flex;gap:6px;align-items:center;">
+        <button class="vc-btn" id="top-mic-btn" onclick="toggleMic()" title="Mic">
+          <svg viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+        </button>
+        <button class="vc-btn" id="top-cam-btn" onclick="toggleCam()" title="Cam">
+          <svg viewBox="0 0 24 24"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+        </button>
+        <button class="vc-btn end" onclick="hangUp()" title="End">
+          <svg viewBox="0 0 24 24"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.11 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4z" transform="rotate(135 12 12)"/></svg>
+        </button>
+      </div>
+    </div>
+    <div id="transcript-body"><div class="tr-empty">Speak or type to see transcript here.</div></div>
+    <div class="transcript-more-indicator" id="transcript-more-indicator" onclick="scrollToBottom()">↓</div>
+  </div>
+  <div class="chat-compose-strip" id="chat-compose-strip">
+    <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-attach-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button class="pb-strip-btn" id="pb-strip-btn" onclick="pbToggleDrawer()" title="Phrases"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></button><textarea class="chat-compose-ta" id="chat-input" placeholder="type here to chat" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)" onfocus="composeFocusMute()" onblur="_pbRestoreMic()"></textarea>
+    <button class="chat-send-btn" id="chat-send-btn" onclick="sendChat()" disabled title="Send">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+    </button>
+  </div>
+</div>
+<!-- PiP overlay -->
+<div id="pip-overlay">
+  <div class="pip-tap-target" onclick="pipExpand()"></div>
+  <video id="pip-remote" autoplay playsinline muted></video>
+  <video id="pip-local" autoplay muted playsinline style="transform:scaleX(-1);"></video>
+  <div class="pip-controls">
+    <button class="pip-btn" onclick="pipExpand()" title="Expand"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></button>
+    <button class="pip-btn" onclick="pipClose()" title="End call"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+</div>
+<!-- Attachment modal -->
+<div id="att-modal">
+  <div id="att-modal-inner">
+    <div id="att-modal-hdr">
+      <span id="att-modal-name"></span>
+      <a id="att-modal-dl" href="#" download style="color:var(--teal-bright);font-size:12px;margin-right:4px;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></a>
+      <button onclick="attModalClose()" style="background:none;border:none;cursor:pointer;color:var(--text-dim);line-height:0;padding:4px;"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+    </div>
+    <div id="att-modal-body"></div>
+  </div>
+</div>
+<!-- ══ PHRASEBOOK v2 ══ -->
+<div id="pb-drawer" class="pb-drawer"><div id="pb-drawer-content"></div></div>
+
+<div id="pb-overlay" class="pb-overlay" style="display:none;">
+  <div class="pb-ov-hdr">
+    <button class="pb-ov-back" onclick="pbCloseOverlay()" title="Back"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg></button>
+    <div class="pb-ov-title">Phrasebook</div>
+    <button class="pb-ov-act" onclick="pbOpenNewCard({})" title="New phrase"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
+    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></button>
+    <button class="pb-ov-act" onclick="pbOpenBooksModal()" title="Switch phrasebook"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 1.41 14.14"/><path d="M4.93 4.93A10 10 0 0 0 3.52 19.07"/></svg></button>
+    <button class="pb-ov-act" onclick="pbResetConfirm()" title="Reset phrasebook" style="color:#c0392b;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></button>
+    <button class="pb-ov-act" onclick="pbCloseOverlay()" title="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+  <div class="pb-ov-searchbar">
+    <input id="pb-ov-search" class="pb-ov-si" placeholder="Search all phrases… (-word to exclude)" oninput="pbOvSearch()">
+  </div>
+  <div class="pb-ov-filter-bar" id="pb-ov-filter"></div>
+  <div id="pb-ov-cards"></div>
+</div>
+
+<div id="pb-import-modal" class="pb-import-modal" style="display:none;">
+  <div class="pb-im-hdr">
+    <span class="pb-im-title">Import Phrases</span>
+    <button class="pb-im-x" onclick="pbCloseImportModal()">×</button>
+  </div>
+  <div class="pb-im-sel-bar">
+    <button class="pb-im-sel-btn" onclick="pbSelectAllImport(true)">Select all</button>
+    <button class="pb-im-sel-btn" onclick="pbSelectAllImport(false)">Deselect all</button>
+  </div>
+  <div id="pb-import-list"></div>
+  <div class="pb-im-footer">
+    <button class="pb-im-cancel" onclick="pbCloseImportModal()">Cancel</button>
+    <button class="pb-im-ok" id="pb-import-ok" onclick="pbConfirmImport()">Import</button>
+  </div>
+</div>
+
+<div id="pb-new-card-sheet" class="pb-nc-sheet">
+  <div class="pb-nc-hdr">
+    <span class="pb-nc-title">New phrase</span>
+    <button class="pb-nc-x" onclick="pbCloseNewCard()">×</button>
+  </div>
+  <div class="pb-nc-body" style="flex:1;overflow-y:auto;padding:12px 14px;">
+    <div style="display:flex;gap:8px;margin-bottom:10px;align-items:flex-end;">
+      <div style="flex:1;"><span class="pb-nc-label">Source lang</span><select id="pbnc-sl" class="pb-nc-sel" style="width:100%;"></select></div>
+      <div style="flex:1;"><span class="pb-nc-label">Target lang</span><select id="pbnc-tl" class="pb-nc-sel" style="width:100%;"></select></div>
+    </div>
+    <span class="pb-nc-label">Source phrase</span>
+    <textarea id="pbnc-src" class="pb-nc-ta" rows="2" placeholder="Original phrase…"></textarea>
+    <button class="pb-nc-trans" onclick="pbNcAutoTranslate()">Translate →</button>
+    <span class="pb-nc-label">Translation</span>
+    <textarea id="pbnc-tgt" class="pb-nc-ta" rows="2" placeholder="Translation…"></textarea>
+    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:12px;">Save to phrasebook</button>
+  </div>
+</div>
+
+<div id="pb-books-modal" style="position:fixed;inset:0;background:#fdfaf7;z-index:45;display:none;flex-direction:column;font-family:'DM Sans',sans-serif;overflow:hidden;">
+  <div style="display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;">
+    <span style="flex:1;font-size:17px;font-weight:600;color:#1a1714;">Phrasebooks</span>
+    <button onclick="document.getElementById('pb-books-modal').style.display='none'" style="background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;">×</button>
+  </div>
+  <div id="pb-books-list" style="flex:1;overflow-y:auto;padding:10px 14px;"></div>
+  <div style="padding:12px 14px;border-top:1px solid #e0dbd6;background:#fff;color:#9a9592;font-size:11px;">Import a phrasebook to add it here. Default cannot be deleted.</div>
+</div>
+<input id="pb-file-input" type="file" accept=".json" style="display:none" onchange="pbHandleFile(event)">
+<div id="toast"></div>
+
+<script>
+'use strict';
+var RELAY_BASE='talk-signal.myacctfortracking.workers.dev/signal';
+var RELAY_WS='wss://'+RELAY_BASE;
+var RELAY_APP='talk-say-v1';
+var LANGS=[
+  {code:'en',label:'English',flag:'🇺🇸'},{code:'th',label:'Thai',flag:'🇹🇭'},
+  {code:'es',label:'Spanish',flag:'🇪🇸'},{code:'ja',label:'Japanese',flag:'🇯🇵'},
+  {code:'ko',label:'Korean',flag:'🇰🇷'},{code:'zh',label:'Chinese (Mandarin)',flag:'🇨🇳'},
+  {code:'ar',label:'Arabic',flag:'🇸🇦'},{code:'hi',label:'Hindi',flag:'🇮🇳'},
+  {code:'ru',label:'Russian',flag:'🇷🇺'},{code:'fr',label:'French',flag:'🇫🇷'},
+  {code:'de',label:'German',flag:'🇩🇪'},{code:'it',label:'Italian',flag:'🇮🇹'},
+  {code:'pt',label:'Portuguese',flag:'🇧🇷'},{code:'vi',label:'Vietnamese',flag:'🇻🇳'},
+  {code:'id',label:'Indonesian',flag:'🇮🇩'},{code:'ms',label:'Malay',flag:'🇲🇾'},
+  {code:'fil',label:'Filipino',flag:'🇵🇭'},{code:'nl',label:'Dutch',flag:'🇳🇱'},
+  {code:'sv',label:'Swedish',flag:'🇸🇪'},{code:'pl',label:'Polish',flag:'🇵🇱'},
+  {code:'tr',label:'Turkish',flag:'🇹🇷'}
+];
+var TTS_LOCALE={en:'en-US',th:'th-TH',ja:'ja-JP',ko:'ko-KR',zh:'zh-CN',ar:'ar-SA',hi:'hi-IN',ru:'ru-RU',fr:'fr-FR',de:'de-DE',es:'es-ES',it:'it-IT',pt:'pt-BR',vi:'vi-VN',id:'id-ID',ms:'ms-MY',fil:'fil-PH',nl:'nl-NL',sv:'sv-SE',pl:'pl-PL',tr:'tr-TR'};
+var DG_LANGS={en:'en-US',th:'th',ja:'ja',ko:'ko',zh:'zh-CN',ar:'ar',hi:'hi',ru:'ru',fr:'fr',de:'de',es:'es',it:'it',pt:'pt-BR',vi:'vi',id:'id',ms:'ms',fil:'fil',nl:'nl',sv:'sv',pl:'pl',tr:'tr'};
+
+
+// ─── AUDIO WORKLET — single-file Blob URL, falls back to ScriptProcessor ────
+var DG_WORKLET_CODE='class TBAudioCapture extends AudioWorkletProcessor{constructor(){super();this._b=[];this._n=4096;}process(inputs){var ch=inputs[0]&&inputs[0][0];if(ch){for(var i=0;i<ch.length;i++)this._b.push(ch[i]);}while(this._b.length>=this._n){var out=new Float32Array(this._b.splice(0,this._n));this.port.postMessage(out,[out.buffer]);}return true;}}registerProcessor(\'tb-audio-capture\',TBAudioCapture);';
+
+// ─── NORTHERN THAI → CENTRAL THAI dialect map ────────────────────────────────
+var NT_PHRASE_MAP={
+  'ไปไสมาเจ้า':'ไปไหนมาครับ','กิ๋นข้าวแล้วเจ้า':'กินข้าวแล้วครับ',
+  'สวัสดีเจ้า':'สวัสดีครับ','ลาก่อนเจ้า':'ลาก่อนครับ',
+  'ขอบใจเจ้า':'ขอบคุณครับ','สบายดีเจ้า':'สบายดีครับ',
+  'บ่เป็นหยัง':'ไม่เป็นไร','เจ้าเป็นไง':'คุณเป็นยังไง',
+  'จอยเป็นไง':'ฉันเป็นยังไง','เว้ากันก่อน':'คุยกันก่อน',
+  'ฮักเจ้า':'รักคุณ','ม่วนหลาย':'สนุกมาก',
+  'แซ่บหลาย':'อร่อยมาก','เมินแล้ว':'นานแล้ว',
+  'ก็ได้เจ้า':'ก็ได้ครับ','มื้อนี้ตอนเช้า':'เช้านี้',
+  'ม่วนใจ๋':'มีความสุข','ดีใจ๋':'ดีใจ'
+};
+var NT_WORD_MAP={
+  'ฮู้สึก':'รู้สึก','ฮ้องไห้':'ร้องไห้',
+  'บ่อยาก':'ไม่อยาก','บ่ชอบ':'ไม่ชอบ',
+  'บ่เป็น':'ไม่เป็น','บ่รู้':'ไม่รู้',
+  'บ่มี':'ไม่มี','บ่ได้':'ไม่ได้','บ่ดี':'ไม่ดี',
+  'จั๋งใด':'ยังไง','เป็นไง':'เป็นยังไง',
+  'ไปไส':'ไปไหน','ทำหยัง':'ทำอะไร',
+  'อะหยัง':'อะไร','เป๋นหยัง':'เป็นอะไร',
+  'มื้อวาน':'เมื่อวาน','มื้อนี้':'วันนี้','มื้ออื่น':'วันอื่น',
+  'ขอบใจ':'ขอบคุณ',
+  'จอย':'ฉัน','เปิ้น':'เขา','เฮา':'เรา',
+  'เน้อ':'นะ','เนาะ':'นะ','ก้อ':'ก็',
+  'กิ๋น':'กิน','ผ่อ':'ดู','แอ่ว':'เที่ยว',
+  'กึ๊ด':'คิด','เว้า':'พูด','หื้อ':'ให้',
+  'หลาย':'มาก','คัก':'มาก',
+  'ม่วน':'สนุก','แซ่บ':'อร่อย',
+  'งาม':'สวย','เมิน':'นาน',
+  'ฮู้':'รู้','ฮัก':'รัก','ฮับ':'รับ',
+  'ฮ้อน':'ร้อน','ฮอด':'ถึง','ฮ่ม':'ร่ม',
+  'หั้น':'นั้น','อั้น':'อัน','ตี้':'ที่',
+  'ใจ๋':'ใจ','มื้อ':'วัน','หยัง':'อะไร'
+};
+function applyNorthernThaiMap(text){
+  if(!text||room.myLang!=='th')return text;
+  var keys,i;
+  keys=Object.keys(NT_PHRASE_MAP).sort(function(a,b){return b.length-a.length;});
+  for(i=0;i<keys.length;i++){if(text.indexOf(keys[i])>=0)text=text.split(keys[i]).join(NT_PHRASE_MAP[keys[i]]);}
+  keys=Object.keys(NT_WORD_MAP).sort(function(a,b){return b.length-a.length;});
+  for(i=0;i<keys.length;i++){if(text.indexOf(keys[i])>=0)text=text.split(keys[i]).join(NT_WORD_MAP[keys[i]]);}
+  // บ่ prefix rule: any remaining บ่ + Thai chars = ไม่ + those chars
+  text=text.replace(/บ่([\u0E00-\u0E7F]+)/g,'ไม่$1');
+  return text;
+}
+
+var room={id:null,myLang:'',theirLang:'',role:null,name:''};
+var deviceId=localStorage.getItem('tb_dev')||(function(){var id=crypto.randomUUID();localStorage.setItem('tb_dev',id);return id})();
+
+// ─── SESSION STATE (Phase 1) ───────────────────────────────────────────────
+var sessionEpoch=0;
+// callPhase: idle|prejoin|joining_media|call_connecting|call_live|call_degraded|ending_local|ending_remote|postcall_joiner|postcall_creator
+var callPhase='idle';
+var lastSessionContext={role:null,myLang:'',theirLang:'',roomName:'',pendingJoinSnapshot:null};
+var micMutedByUser=false;
+var dgDesired=false;
+// Chat reliability (Phase 6)
+var _chatOutbox=new Map();   // chatId → relay msg object, cleared on ack
+var _chatReceived=new Set(); // chatId dedupe set
+
+function setCallPhase(next,reason){
+  log('phase',{from:callPhase,to:next,why:reason||''});
+  callPhase=next;
+}
+function bumpSessionEpoch(reason){
+  sessionEpoch++;
+  log('epoch',{n:sessionEpoch,why:reason||''});
+  return sessionEpoch;
+}
+function isActiveCallPhase(){
+  return ['call_connecting','call_live','call_degraded'].indexOf(callPhase)>=0;
+}
+// ──────────────────────────────────────────────────────────────────────────
+
+var _relayWs=null;
+var pc=null,videoStream=null,remoteStream=null;
+var micOn=true,camOn=true,makingOffer=false;
+var dgWs=null,dgAudioCtx=null,dgProc=null,dgSrc=null,dgActive=false;
+var _dgLastMsg=0,_dgWatchdogTimer=null;
+var DG_WATCHDOG_MS=20000; // restart DG if no WS messages in 20s during live call
+var recentFinals=[],DEDUP_MS=4000,DEDUP_MAX=5;
+var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;
+var hbTimer=null,seq=0,wsReconnectTimer=null;
+var debugLog=[],HEARTBEAT_MS=30000,SUB_LINGER=5000,MAX_TR=300;
+var RK='tb_recent_rooms',TP='tb_transcript_',RL=12;
+var viewingRoomId=null,callHistoryPushed=false;
+var transcriptCollapsed=false,showTranscriptMore=false,partnerSpeakTimer=null,transcriptTtsOn=false;
+var dgKeyVerified=false,dgKeyVerifyTimer=null;
+var pendingCandidates=[];
+var savedOffer=null;
+var savedCandidates=[];
+var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_connectTimeoutTimer=null,_seenRemoteCand=new Set();
+var _remoteVideoWatchdogTimer=null,_remoteVideoLastTime=0,_remoteVideoStallCount=0;
+
+// ─── Phase 3: Canonical audio constraints ─────────────────────────────────
+function getMicConstraints(){
+  return {echoCancellation:true,noiseSuppression:true,autoGainControl:true};
+}
+
+// ─── Phase 5: Text normalization ──────────────────────────────────────────
+function normalizeText(raw,mode){
+  if(!raw)return'';
+  var s=raw.normalize?raw.normalize('NFKC'):raw;
+  s=s.trim().replace(/\s+/g,' ');
+  s=s.replace(/[\u200B-\u200D\uFEFF\u2060]/g,'');
+  if(mode==='speech'){
+    // Strip XLIFF/TMX markup tags from MyMemory translation memory output
+    // e.g. สอง<bx id="2"/> → สอง
+    s=s.replace(/<\/?[a-zA-Z][^>]*>/g,'');
+    s=s.trim().replace(/\s+/g,' ');
+  }
+  if(mode==='compare'){
+    s=s.toLowerCase();
+    s=s.replace(/[\u2018\u2019]/g,"'").replace(/[\u201C\u201D]/g,'"');
+  }
+  return s;
+}
+
+// ─── Phase 4: DG helpers ──────────────────────────────────────────────────
+var _silentAudioCtx=null;
+var _silentOsc=null;
+var _silentAudioTrack=null;
+var _micToggleInFlight=false;
+function isLiveMicTrackPresent(){
+  if(!videoStream)return false;
+  return videoStream.getAudioTracks().some(function(t){
+    return t.readyState==='live'&&t!==_silentAudioTrack;
+  });
+}
+function reconcileDeepgramState(reason){
+  var should=dgDesired&&isCallActive()&&isLiveMicTrackPresent()&&!micMutedByUser&&isActiveCallPhase();
+  log('dg_reconcile',{why:reason,desired:dgDesired,muted:micMutedByUser,phase:callPhase,active:dgActive,should:should});
+  if(should&&!dgActive)startDeepgram();
+  else if(!should&&dgActive)stopDeepgram();
+}
+
+// ─── Phase 7: Unified teardown ────────────────────────────────────────────
+function _cleanupSilentAudioHelper(){
+  if(_silentOsc){try{_silentOsc.stop();}catch(_){}try{_silentOsc.disconnect();}catch(_){} _silentOsc=null;}
+  if(_silentAudioTrack){try{_silentAudioTrack.stop();}catch(_){} _silentAudioTrack=null;}
+  if(_silentAudioCtx){try{_silentAudioCtx.close();}catch(_){} _silentAudioCtx=null;}
+}
+
+function teardownSession(mode,reason){
+  log('teardown',{mode:mode,why:reason});
+  bumpSessionEpoch('teardown_'+mode);
+  dgDesired=false;
+  stopDeepgram();
+  if(videoStream){videoStream.getTracks().forEach(function(t){t.stop();});videoStream=null;}
+  _cleanupSilentAudioHelper();
+  if(pc){try{pc.close();}catch(_){}pc=null;}
+  stopKeepalive();stopHB();
+  if(_relayWs)try{_relayWs.close();}catch(_){}
+  _relayWs=null;
+  clearTimeout(wsReconnectTimer);wsReconnectTimer=null;
+  makingOffer=false;
+  pendingCandidates=[];savedOffer=null;savedCandidates=[];
+  resetRecoveryState();
+  saveTr();
+  callHistoryPushed=false;
+}
+
+// ─── Phase 2: Role-based post-call routing ────────────────────────────────
+function routePostCallByRole(sourceReason){
+  var role=room.role||lastSessionContext.role;
+  log('post_call_route',{role:role,why:sourceReason});
+  if(role==='creator'){
+    setCallPhase('postcall_creator',sourceReason);
+    cleanUp();
+  }else{
+    setCallPhase('postcall_joiner',sourceReason);
+    showThankYou();
+  }
+}
+
+// Safe stub — returns current lang so the race fallback never throws
+function detectLang(text,src){return src||'en';}
+
+/* === FASTTEXT WASM === */
+var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];
+var FT_CONF=0.5,FT_LOAD_TIMEOUT_MS=5000;
+var FT_WRAPPER_JS='fastType/fasttext-wrapper.umd.js';
+var FT_CORE_JS='fastType/core/fasttext.mjs';
+var FT_CORE_WASM='fastType/core/fasttext.wasm';
+var FT_MODEL='fastType/model/lid.176.ftz';
+var FT_ASSETS=[FT_WRAPPER_JS,FT_CORE_JS,FT_CORE_WASM,FT_MODEL];
+var FT_SMOKE=[['hello how are you today','en'],['hola como estas hoy','es'],['bonjour comment allez vous','fr'],['guten morgen wie geht es dir','de']];
+var _ftStartupOverlay=null,_ftStartupStatus=null;
+function _ftEnsureStartupOverlay(){
+  if(_ftStartupOverlay)return;
+  var el=document.createElement('div');
+  el.style.cssText='position:fixed;inset:0;z-index:120;background:#0a0a0a;display:flex;align-items:center;justify-content:center;flex-direction:column;gap:10px;font-family:DM Sans,sans-serif;color:#e8e4df;';
+  el.innerHTML='<div style="font-size:15px;font-weight:700;color:#3FC1C1;">TalkBridge startup</div><div id="ft-startup-status" style="font-size:13px;color:#aaa;">Initializing language detector…</div>';
+  document.body.appendChild(el);
+  _ftStartupOverlay=el;
+  _ftStartupStatus=el.querySelector('#ft-startup-status');
+}
+function _ftStartupStep(step,extra){ _ftEnsureStartupOverlay(); var msg='Startup: '+step+(extra?(' · '+extra):''); if(_ftStartupStatus)_ftStartupStatus.textContent=msg; log('ft_startup_step',{step:step,extra:extra||null}); }
+function _ftStartupDone(ok,msg){
+  _ftEnsureStartupOverlay();
+  if(_ftStartupStatus)_ftStartupStatus.textContent=ok?'Detector ready':'Degraded mode: language detector unavailable';
+  log('ft_startup_'+(ok?'ready':'degraded'),{message:msg||null},ok?'ok':'warn');
+  if(ok){setTimeout(function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';},400);}
+  else{
+    if(_ftStartupOverlay){
+      _ftStartupOverlay.style.cursor='pointer';
+      _ftStartupOverlay.onclick=function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';};
+    }
+    setTimeout(function(){if(_ftStartupOverlay)_ftStartupOverlay.style.display='none';},1800);
+  }
+}
+function _ftWhitelist(){return Object.keys(LANGS||{});} 
+function _ftAllowed(code){return _ftWhitelist().indexOf(code)>=0;}
+function _syncFtStatus(){
+  var dot=$('ft-dot'),label=$('ft-label'),pill=$('ft-lobby-status');
+  if(!dot||!label||!pill)return;
+  if(_ftReady){pill.classList.add('ready');}
+  else if(_ftLoadFailed){dot.className='ft-status-dot err';label.textContent='Lang detect unavailable';}
+  else{dot.className='ft-status-dot loading';label.textContent='Lang model loading…';}
+}
+function _probeFtAsset(path){
+  log('ft_asset_probe',{path:path});
+  return fetch(path,{cache:'no-store'}).then(function(res){
+    if(!res.ok)throw new Error('status_'+res.status);
+    return res.arrayBuffer().then(function(buf){
+      if(!buf||!buf.byteLength)throw new Error('empty');
+      log('ft_asset_ok',{path:path,size:buf.byteLength},'ok');
+      return true;
+    });
+  }).catch(function(e){
+    log('ft_asset_err',{path:path,e:String(e)},'error');
+    throw e;
+  });
+}
+function _ftErrDetail(e,ctx){
+  var t=(e===null)?'null':typeof e;
+  var raw;
+  try{raw=(t==='object'&&e&&e.message)?String(e.message):String(e);}catch(_){raw='[unstringifiable]';}
+  return {context:ctx||null,type:t,detail:raw};
+}
+function _ftPredictLabel(ft,text){
+  var r=ft.predict(text,1);
+  var item=null,label=null,score=null;
+  function _normLabel(v){
+    if(v==null)return null;
+    return String(v).replace(/^(__label__|label__)/,'');
+  }
+  if(r instanceof Map){
+    var first=r.entries().next();
+    if(!first.done){label=_normLabel(first.value[0]);score=first.value[1];}
+  }else if(Array.isArray(r)){
+    item=r.length?r[0]:null;
+    if(Array.isArray(item)){label=_normLabel(item[0]);score=item[1];}
+    else if(item&&typeof item==='object'){label=_normLabel(item.label);score=(item.prob!=null?item.prob:(item.score!=null?item.score:item.probability));}
+    else if(typeof item==='string'){label=_normLabel(item);}
+  }else if(r&&typeof r==='object'){
+    label=_normLabel(r.label!=null?r.label:r[0]);
+    score=(r.prob!=null?r.prob:(r.score!=null?r.score:r.probability));
+  }else if(typeof r==='string'){
+    label=_normLabel(r);
+  }
+  if(!label||!_ftAllowed(label))return null;
+  if(score==null)return label;
+  var n=Number(score);
+  if(!isFinite(n))return null;
+  return n>=FT_CONF?label:null;
+}
+function _loadFastText(){
+  if(_ftReady||_ftLoadFailed)return;
+  _ftStartupStep('asset probes');
+  Promise.all(FT_ASSETS.map(_probeFtAsset)).then(function(){
+    _ftStartupStep('runtime bootstrap load');
+    var ftModuleConfig={locateFile:function(path){
+      var p=String(path||'');
+      if(/\.wasm$/i.test(p))return FT_CORE_WASM;
+      var base=p.split('/').pop().split('\\').pop();
+      return 'fastType/'+base;
+    }};
+    window.Module=ftModuleConfig;
+    window.FastTextModule=ftModuleConfig;
+    log('ft_load_start',{src:FT_WRAPPER_JS});
+    var s=document.createElement('script');s.src=FT_WRAPPER_JS;
+    s.onerror=function(){ log('ft_load_err',Object.assign({src:s.src,reason:'runtime wrapper script failed to load'},_ftErrDetail(null,'script.onerror')),'error'); _ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'runtime_load_err'); _ftPending.forEach(function(cb){cb(null);});_ftPending=[]; };
+    s.onload=function(){
+      if(typeof FastText==='undefined'){log('ft_no_global',{reason:'FastText global missing after wrapper load'},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'runtime_init_err: FastText global missing');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];return;}
+      try{
+        var ft=new FastText();
+        _ftStartupStep('model load');
+        log('ft_model_load',{model:FT_MODEL});
+        var timer=setTimeout(function(){log('ft_model_timeout',{ms:FT_LOAD_TIMEOUT_MS,reason:'FastText model load timeout'},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'timeout: model load exceeded '+FT_LOAD_TIMEOUT_MS+'ms');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];},FT_LOAD_TIMEOUT_MS);
+        ft.loadModel(FT_MODEL).then(function(){
+          _ftStartupStep('smoke tests');
+          return Promise.all(FT_SMOKE.map(function(pair){
+            var got=_ftPredictLabel(ft,pair[0]);
+            if(got!==pair[1])throw new Error('smoke mismatch: input="'+pair[0]+'" expected="'+pair[1]+'" got="'+got+'"');
+            return got;
+          }));
+        }).then(function(){
+          clearTimeout(timer);_ftModule=ft;_ftReady=true;_syncFtStatus();_ftStartupDone(true,'ready');log('ft_ready',{},'ok');_ftPending.forEach(function(cb){cb(ft);});_ftPending=[];
+        }).catch(function(e){
+          clearTimeout(timer);log('ft_model_err',{reason:'runtime/model init or smoke failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];
+        });
+      }catch(e){log('ft_init_err',{reason:'FastText constructor/init failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];}
+    };
+    document.head.appendChild(s);
+  }).catch(function(e){log('ft_probe_err',{reason:'asset probe failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];});
+}
+function _detectLangAsync(text){
+  var t=(text||'').trim();if(!t)return Promise.resolve(null);
+  if(/[\u0E00-\u0E7F]/.test(t))return Promise.resolve('th');
+  if(/[\u3040-\u30FF\u31F0-\u31FF]/.test(t))return Promise.resolve('ja');
+  if(/[\u4E00-\u9FFF]/.test(t))return Promise.resolve('zh');
+  if(/[\uAC00-\uD7A3]/.test(t))return Promise.resolve('ko');
+  if(/[\u0600-\u06FF]/.test(t))return Promise.resolve('ar');
+  if(/[\u0900-\u097F]/.test(t))return Promise.resolve('hi');
+  if(/[\u0400-\u04FF]/.test(t))return Promise.resolve('ru');
+  if(_ftLoadFailed)return Promise.resolve(null);
+  if(_ftReady&&_ftModule){
+    return new Promise(function(resolve){
+      try{var r=_ftModule.predict(t,1);resolve(_ftPredictLabel(_ftModule,t));}catch(_){resolve(null);}
+    });
+  }
+  return new Promise(function(resolve){
+    _ftPending.push(function(ft){
+      if(!ft){resolve(null);return;}
+      try{var r=ft.predict(t,1);resolve(_ftPredictLabel(ft,t));}catch(_){resolve(null);}
+    });
+    if(!_ftReady&&!_ftLoadFailed&&_ftPending.length===1)_loadFastText();
+  });
+}
+
+/* === CHAT === */
+var _pbMutedMic=false;
+function composeFocusMute(){
+  if(!isCallActive())return;
+  if(micOn&&!micMutedByUser){_pbMutedMic=true;toggleMic();}
+  else if(!micOn){toast('Mic is muted — tap mic button to speak');}
+}
+function _pbRestoreMic(){
+  if(_pbMutedMic&&!micOn&&isCallActive()){_pbMutedMic=false;toggleMic();}else{_pbMutedMic=false;}
+}
+function chatInputEvt(){
+  var ta=$('chat-input');if(!ta)return;
+  var raw=ta.value||'';
+  ta.style.height='auto';
+  ta.style.height=Math.min(ta.scrollHeight,80)+'px';
+  $('chat-send-btn').disabled=!raw.trim();
+  // Filter search drawer live if open
+  if(_pbDrawerMode==='search')pbRunSearch();
+}
+function chatKeydown(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}}
+
+function handleChatFile(ev){
+  var file=ev&&ev.target&&ev.target.files&&ev.target.files[0];
+  if(!file)return;
+  ev.target.value='';
+  var maxMb=5;
+  if(file.size>maxMb*1024*1024){toast('File must be under '+maxMb+'MB');return;}
+  var reader=new FileReader();
+  reader.onload=function(){
+    var dataUrl=reader.result;
+    var srcText='[file:'+file.name+']';
+    var entry={id:'cf-'+uid(),type:'chat',who:'me',sourceText:srcText,translatedText:srcText,srcLang:room.myLang,tgtLang:room.theirLang,ts:Date.now(),attachment:{name:file.name,dataUrl:dataUrl,type:file.type}};
+    _attCache[entry.id]={name:file.name,dataUrl:dataUrl,type:file.type};
+    transcript.push(entry);saveTr();appendTrDom(entry);
+    var relayMsg={type:'chat-msg',chatId:entry.id,srcText:srcText,tgtText:srcText,srcLang:room.myLang,tgtLang:room.theirLang,attachment:{name:file.name,dataUrl:dataUrl,type:file.type}};
+    _chatOutbox.set(entry.id,relayMsg);
+    relaySend(relayMsg);
+    log('chat_file',{name:file.name},'ok');
+  };
+  reader.readAsDataURL(file);
+}
+
+async function sendChat(){
+  var ta=$('chat-input');
+  var text=normalizeText((ta&&ta.value||''),'chat');if(!text||!room.id)return;
+  if(!text)return;
+  ta.value='';ta.style.height='';$('chat-send-btn').disabled=true;
+  pbCloseDrawer();
+  var src=room.myLang,tgt=room.theirLang;
+  var srcText=text;
+  log('chat_norm_start',{src:src,tgt:tgt,ft_ready:_ftReady,text:text.slice(0,60)});
+  try{
+    var _ftWonC=false;
+    var detected=await Promise.race([
+      _detectLangAsync(text).then(function(d){_ftWonC=true;return d;}),
+      new Promise(function(res){setTimeout(function(){
+        if(!_ftWonC)log('chat_norm_timeout',{ft_ready:_ftReady,fallback:src},'warn');
+        res(detectLang(text,src));
+      },150);})
+    ]);
+    log('chat_norm_detect',{detected:detected||'(none)',src:src,needs_norm:!!(detected&&detected!==src),via:_ftWonC?'wasm':'stub'});
+    if(detected&&detected!==src){
+      log('chat_norm_step',{from:detected,to:src,text:text.slice(0,60)});
+      var normed=await translateWithRetry(text,detected,src,2);
+      if(normed){srcText=normalizeText(normed,'chat');log('chat_norm_result',{srcText:srcText.slice(0,60)});}
+    }
+  }catch(e){log('chat_norm_err',{e:String(e)},'error');}
+  var tgtText=srcText;
+  if(src&&tgt&&src!==tgt){
+    try{
+      var tr=await translateWithRetry(srcText,src,tgt,1);
+      if(tr)tgtText=normalizeText(tr,'chat');
+      if(normalizeText(tgtText,'compare')===normalizeText(srcText,'compare')){var tr2=await translateWithRetry(srcText,src,tgt,0);if(tr2)tgtText=normalizeText(tr2,'chat');}
+      log('chat_trans_result',{from:src,to:tgt,tgtText:tgtText.slice(0,60)},'ok');
+    }catch(e){log('chat_trans_err',{e:String(e)},'error');}
+  }
+  var id='cm-'+uid();
+  var entry={id:id,type:'chat',who:'me',sourceText:srcText,translatedText:tgtText,srcLang:src,tgtLang:tgt,ts:Date.now()};
+  transcript.push(entry);saveTr();
+  appendTrDom(entry);
+  var relayMsg={type:'chat-msg',chatId:id,srcText:srcText,tgtText:tgtText,srcLang:src,tgtLang:tgt};
+  _chatOutbox.set(id,relayMsg);
+  relaySend(relayMsg);
+  log('chat_sent',{t:srcText.slice(0,40)},'ok');
+}
+
+function handleChatMsg(d){
+  if(!d)return;
+  // Dedupe by chatId (Phase 6)
+  if(d.chatId){
+    if(_chatReceived.has(d.chatId))return;
+    _chatReceived.add(d.chatId);
+    // Ack back so sender can clear outbox
+    relaySend({type:'chat-ack',chatId:d.chatId,transient:true});
+  }
+  // Also ignore echoes of our own sent messages
+  if(d.chatId&&transcript.some(function(e){return e.id===d.chatId&&e.who==='me';}))return;
+  var entry={
+    id:d.chatId||('ci-'+uid()),
+    type:'chat',
+    who:'partner',
+    sourceText:normalizeText(d.srcText||'','chat'),
+    translatedText:normalizeText(d.tgtText||d.srcText||'','chat'),
+    srcLang:d.srcLang||room.theirLang,
+    tgtLang:d.tgtLang||room.myLang,
+    ts:d.ts||Date.now(),
+    attachment:d.attachment||null
+  };
+  if(entry.attachment&&entry.attachment.dataUrl)_attCache[entry.id]=entry.attachment;
+  transcript.push(entry);saveTr();
+  appendTrDom(entry);
+  markPartnerTalking();
+  if(transcriptTtsOn&&entry.translatedText&&entry.who==='partner')speakText(entry.translatedText,entry.tgtLang||room.myLang);
+  log('chat_rx',{t:(d.srcText||'').slice(0,40)},'ok');
+}
+
+var LS={setup:'setup',call:'call'};
+var lobbyState=LS.setup;
+
+function $(id){return document.getElementById(id)}
+function attModalOpenById(id){var att=_attCache[id];if(att)attModalOpen(att);}
+function attModalOpen(att){
+  var m=document.getElementById('att-modal');
+  var nm=document.getElementById('att-modal-name');
+  var dl=document.getElementById('att-modal-dl');
+  var body=document.getElementById('att-modal-body');
+  if(!m||!body)return;
+  if(nm)nm.textContent=att.name||'Attachment';
+  if(dl){dl.href=att.dataUrl||'#';dl.download=att.name||'file';}
+  var isImg=/^image\//.test(att.type||'');
+  if(isImg){body.innerHTML='<img src="'+att.dataUrl+'" style="max-width:100%;border-radius:8px;">';}
+  else{body.innerHTML='<iframe src="'+att.dataUrl+'" sandbox="allow-same-origin"></iframe>';}
+  m.classList.add('show');
+}
+function attModalClose(){
+  var m=document.getElementById('att-modal');if(m)m.classList.remove('show');
+  var b=document.getElementById('att-modal-body');if(b)b.innerHTML='';
+}
+function removeTrEntry(id){
+  transcript=transcript.filter(function(e){return e.id!==id;});
+  saveTr();
+  delete _attCache[id];
+  var el=document.querySelector('[data-tr-id="'+id+'"]');
+  if(el)el.remove();
+}
+function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');clearTimeout(toast._t);toast._t=setTimeout(function(){e.classList.remove('show')},dur||2800)}
+function uid(){return Date.now().toString(36)+Math.random().toString(36).slice(2,8)}
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML}
+function norm(s){return(s||'').replace(/\s+/g,' ').trim()}
+// ═══════════════════════════════════════════════════
+// PHRASEBOOK v2 — test.html-compatible schema
+// Storage: say_cards · say_catalogs · say_tags
+// Drawer: // = commands, / = omnisearch (call-only)
+// ═══════════════════════════════════════════════════
+'use strict';
+
+/* ── Storage keys ── */
+var PB_BASE_URL='https://github.acmeproducts.com/stuff/phrase/';
+var PB_CARDS='say_cards',PB_CATS='say_catalogs',PB_TAGS_K='say_tags',PB_SEEDED='pb_bridge_v2';
+var PB_BOOKS_KEY='pb_books_registry'; // [{id,name,createdAt,isDefault}]
+
+/* ── Embedded seed data ── */
+var PB_SEED={"type":"phrasebook","cards":[{"id":"mnhd6ozl7hxlpp","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ขอโทษ ฉันพูดไทยไม่ค่อยได้","target":"Sorry, I don't speak Thai very well.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Sorry, I don't speak Thai very well.","resultText":"","verdict":"","contentHash":"ขอโทษ ฉันพูดไทยไม่ค่อยได้||Sorry, I don't speak Thai very well.","updatedAt":1775127670421},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127676161,"updatedAt":1775127676161},{"id":"mnhd5sqhkvcmbj","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณชื่ออะไร","target":"What is your name? ","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"What is your name? ","resultText":"","verdict":"","contentHash":"คุณชื่ออะไร||What is your name?","updatedAt":1775127521508},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127634361,"updatedAt":1775127634361},{"id":"mnhd5rc2ivpbkc","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันชื่อ...","target":"My name is ...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"My name is ...","resultText":"","verdict":"","contentHash":"ฉันชื่อ...||My name is ...","updatedAt":1775127525221},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127632546,"updatedAt":1775127632546},{"id":"mnhd5pimpgxr40","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณอายุเท่าไหร่","target":"How old are you?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How old are you?","resultText":"","verdict":"","contentHash":"คุณอายุเท่าไหร่||How old are you?","updatedAt":1775127528762},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127630190,"updatedAt":1775127630190},{"id":"mnhd5nb7t16q6d","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณช่วยฉันได้ไหม","target":"Can you help me?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Can you help me?","resultText":"","verdict":"","contentHash":"คุณช่วยฉันได้ไหม||Can you help me?","updatedAt":1775127543356},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127627331,"updatedAt":1775127627331},{"id":"mnhd5heb3ge0bg","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันอายุ....ปี","target":"I am.... years old.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I am.... years old.","resultText":"","verdict":"","contentHash":"ฉันอายุ....ปี||I am.... years old.","updatedAt":1775127609337},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127619667,"updatedAt":1775127619667},{"id":"mnhbaipi7n2g3o","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"อรุณสวัสดิ์","target":"Good morning","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Good morning","resultText":"","verdict":"","contentHash":"อรุณสวัสดิ์||Good morning","updatedAt":1775124430577},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124495414,"updatedAt":1775124495414},{"id":"mnhba9ggtikgc7","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ซ้าย/ขวา/ตรงไป","target":"Left/Right/Straight","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Left/Right/Straight","resultText":"","verdict":"","contentHash":"ซ้าย/ขวา/ตรงไป||Left/Right/Straight","updatedAt":1775124477253},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124483424,"updatedAt":1775124483424},{"id":"mnhba8ehouyhzp","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันอยากไป...","target":"I want to go...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I want to go...","resultText":"","verdict":"","contentHash":"ฉันอยากไป...||I want to go...","updatedAt":1775124467845},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124482057,"updatedAt":1775124482057},{"id":"mnhb9p4i5y4z0w","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ราตรีสวัสดิ์","target":"good night","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"good night","resultText":"","verdict":"","contentHash":"ราตรีสวัสดิ์||good night","updatedAt":1775124442677},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124457074,"updatedAt":1775124457074},{"id":"mnhb9nsgvvfg0y","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เจอกันใหม่","target":"See you later.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"See you later.","resultText":"","verdict":"","contentHash":"เจอกันใหม่||See you later.","updatedAt":1775124446261},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124455344,"updatedAt":1775124455344},{"id":"mnhb9mr2rznooq","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เท่าไหร่","target":"How much is it?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How much is it?","resultText":"","verdict":"","contentHash":"เท่าไหร่||How much is it?","updatedAt":1775124450852},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124453998,"updatedAt":1775124453998},{"id":"mnhb89mv3u4zo3","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ช่วยด้วย","target":"Help.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Help.","resultText":"","verdict":"","contentHash":"ช่วยด้วย||Help.","updatedAt":1775124368359},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124390343,"updatedAt":1775124390343},{"id":"mnhb88qc00qe6t","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันหลงทาง","target":"I'm lost.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I'm lost.","resultText":"","verdict":"","contentHash":"ฉันหลงทาง||I'm lost.","updatedAt":1775124371739},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124389172,"updatedAt":1775124389172},{"id":"mnhb87nl5ghaaq","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เรียกตำรวจ","target":"Call the police.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Call the police.","resultText":"","verdict":"","contentHash":"เรียกตำรวจ||Call the police.","updatedAt":1775124377835},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124387777,"updatedAt":1775124387777},{"id":"mnhb86m19cxq5u","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันต้องการหมอ","target":"I need a doctor","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I need a doctor","resultText":"","verdict":"","contentHash":"ฉันต้องการหมอ||I need a doctor","updatedAt":1775124382380},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124386425,"updatedAt":1775124386425},{"id":"mnhb7h1wzbqmpp","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"I want this","target":"ฉันเอาอันนี้","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันเอาอันนี้","resultText":"","verdict":"","contentHash":"I want this||ฉันต้องการแบบนี้","updatedAt":1775124322105},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124353300,"updatedAt":1775124353300},{"id":"mnhb6ra1x98obt","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Can you lower the price?","target":"ลดราคาหน่อยได้ไหม","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ลดราคาหน่อยได้ไหม","resultText":"","verdict":"","contentHash":"Can you lower the price?||ลดราคาหน่อยได้ไหม","updatedAt":1775124296076},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124319897,"updatedAt":1775124319897},{"id":"mnhb671p3dgige","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"How much is this?","target":"อันนี้ราคาเท่าไหร่","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"อันนี้ราคาเท่าไหร่","resultText":"","verdict":"","contentHash":"How much is this?||นี่เท่าไหร่","updatedAt":1775124257766},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124293677,"updatedAt":1775124293677},{"id":"mnhb4whppegmz4","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันเอาอันนี้","target":"I'll take this one.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I'll take this one.","resultText":"","verdict":"","contentHash":"ฉันเอาอันนี้||I'll take this one.","updatedAt":1775124208507},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124233341,"updatedAt":1775124233341},{"id":"mnhb4tqrrylp94","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณมี..ไหม","target":"Do you have..?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Do you have..?","resultText":"","verdict":"","contentHash":"คุณมี..ไหม||Do you have..?","updatedAt":1775124226415},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124229779,"updatedAt":1775124229779},{"id":"mnhb3qzifksu90","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Check, please","target":"เช็คบิลด้วย","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"เช็คบิลด้วย","resultText":"","verdict":"","contentHash":"Check, please||ตรวจสอบได้โปรด","updatedAt":1775124139994},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124179550,"updatedAt":1775124179550},{"id":"mnhb2l5e2yj4jl","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Menu, please","target":"ขอเมนูหน่อย","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอเมนูหน่อย","resultText":"","verdict":"","contentHash":"Menu, please||เมนูได้โปรด","updatedAt":1775124094266},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124125330,"updatedAt":1775124125330},{"id":"mnhb1pfnvwo41g","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"อร่อย","target":"Delicious","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Delicious","resultText":"","verdict":"","contentHash":"อร่อย||Delicious","updatedAt":1775124062936},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124084227,"updatedAt":1775124084227},{"id":"mnhb1lqwob2ysb","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"น้ำอัดลม","target":"Carbonated drink","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Carbonated drink","resultText":"","verdict":"","contentHash":"น้ำอัดลม||Carbonated drink","updatedAt":1775124037951},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124079448,"updatedAt":1775124079448},{"id":"mnhb1dxdoeuxpd","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"น้ำเปล่า","target":"Water","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Water","resultText":"","verdict":"","contentHash":"น้ำเปล่า||Water","updatedAt":1775124034461},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124069313,"updatedAt":1775124069313},{"id":"mnhb1ar98mw7x3","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เช็คบิล","target":"Check Bills","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Check Bills","resultText":"","verdict":"","contentHash":"เช็คบิล||Check Bills","updatedAt":1775124060719},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124065205,"updatedAt":1775124065205},{"id":"mnhb0i55fatnud","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันกินมังสวิรัติ","target":"I am a vegetarian.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I am a vegetarian.","resultText":"","verdict":"","contentHash":"ฉันกินมังสวิรัติ||I am a vegetarian.","updatedAt":1775124022710},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124028121,"updatedAt":1775124028121},{"id":"mnhazuhsabexw1","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"สถานีรถไฟ","target":"Train station","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Train station","resultText":"","verdict":"","contentHash":"สถานีรถไฟ||Train station","updatedAt":1775123982780},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123997472,"updatedAt":1775123997472},{"id":"mnhazsg7yh1yc4","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ป้ายรถเมล์","target":"Bus stop","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Bus stop","resultText":"","verdict":"","contentHash":"ป้ายรถเมล์||Bus stop","updatedAt":1775123976729},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123994823,"updatedAt":1775123994823},{"id":"mnhazrfvpdal4i","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ค่าโดยสารเท่าไหร่","target":"How much is the fare?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How much is the fare?","resultText":"","verdict":"","contentHash":"ค่าโดยสารเท่าไหร่||How much is the fare?","updatedAt":1775123971900},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123993515,"updatedAt":1775123993515},{"id":"mnhazq8se0tg1f","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"แท็กซี่อยู่ไหน","target":"Where's the taxi?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Where's the taxi?","resultText":"","verdict":"","contentHash":"แท็กซี่อยู่ไหน||Where's the taxi?","updatedAt":1775123964993},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123991964,"updatedAt":1775123991964},{"id":"mnhayzu33872p1","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ไม่ใช่","target":"NO","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"NO","resultText":"","verdict":"","contentHash":"ไม่ใช่||NO","updatedAt":1775123953876},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123957739,"updatedAt":1775123957739},{"id":"mnhayyoioghmhx","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ใช่","target":"Yes","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Yes","resultText":"","verdict":"","contentHash":"ใช่||Yes","updatedAt":1775123952083},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123956242,"updatedAt":1775123956242},{"id":"mnhay9psbcymxo","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"I'm fine, thank you","target":"ฉันสบายดี ขอบคุณ","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันสบายดี ขอบคุณ","resultText":"","verdict":"","contentHash":"I'm fine, thank you||ฉันสบายดี ขอบคุณค่ะ","updatedAt":1775123880780},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123923888,"updatedAt":1775123923888},{"id":"mnhax9ua30pb0m","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Excuse me","target":"ขอโทษ","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอโทษ","resultText":"","verdict":"","contentHash":"Excuse me||ขอโทษ","updatedAt":1775123863947},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123877394,"updatedAt":1775123877394},{"id":"mnhavy4sxlyxp5","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ขอโทษ","target":"Sorry...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Sorry...","resultText":"","verdict":"","contentHash":"ขอโทษ||Sorry...","updatedAt":1775123785278},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123815564,"updatedAt":1775123815564},{"id":"mnhatx7ik6bvn9","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"How are you?","target":"สบายดีไหม","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"en","inputText":"สบายดีไหม","resultText":"","verdict":"","contentHash":"How are you?||สบายดีใช่ไหม","updatedAt":1775123661449},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123721054,"updatedAt":1775123721054},{"id":"s0","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Hello","target":"สวัสดี","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"สวัสดี","resultText":"","verdict":"","contentHash":"Hello||สวัสดี","updatedAt":1774111157235},"clarifyChain":[],"savedBy":"seed","createdAt":1774111157235,"updatedAt":1774111157235},{"id":"s1","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Thank you","target":"ขอบคุณ","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอบคุณ","resultText":"","verdict":"","contentHash":"Thank you||ขอบคุณ","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111156237,"updatedAt":1774111157237},{"id":"s2","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"How much?","target":"เท่าไหร่?","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"เท่าไหร่?","resultText":"","verdict":"","contentHash":"How much?||เท่าไหร่?","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111155237,"updatedAt":1774111157237},{"id":"s3","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Where is the bathroom?","target":"ห้องน้ำอยู่ที่ไหน?","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ห้องน้ำอยู่ที่ไหน?","resultText":"","verdict":"","contentHash":"Where is the bathroom?||ห้องน้ำอยู่ที่ไหน?","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111154237,"updatedAt":1774111157237},{"id":"s4","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"I don't understand","target":"ฉันไม่เข้าใจ","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันไม่เข้าใจ","resultText":"","verdict":"","contentHash":"I don't understand||ฉันไม่เข้าใจ","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111153237,"updatedAt":1774111157237}],"catalogs":[{"id":"cat-th","name":"Thailand Travel","emoji":"🇹🇭","desc":"Essential phrases","createdAt":1774111157234}],"tags":["essential"]};
+
+/* ── Helpers ── */
+var PB_ICON_TTS='<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>';
+var ICO={
+  plus:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
+  book:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>',
+  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
+  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg>',
+  warn:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  link:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+  trash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>',
+  hardtrash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#c0392b" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>',
+  tag:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>',
+  chat:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+  verify:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>',
+  chevdown:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>',
+  restore:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg>',
+  speaker:PB_ICON_TTS,
+  use:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>',
+  clip:'<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>',
+  x:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>'
+};
+var _attCache={}; // entryId -> {name,dataUrl,type}
+var _btCache={};  // cardId -> {text,lang}
+function pbEsc(s){var d=document.createElement('div');d.textContent=String(s||'');return d.innerHTML;}
+function pbLangFlag(c){var l=LANGS.find(function(x){return x.code===c;});return l?l.flag:'🌐';}
+function pbLangLabel(c){var l=LANGS.find(function(x){return x.code===c;});return l?l.label:(c||'?');}
+function pbNow(){return Date.now();}
+
+/* ── Card normalize ── */
+function pbNorm(c){
+  var now=pbNow();c=c||{};
+  var bt=c.backtranslate||{};
+  return {
+    id:c.id||(Date.now().toString(36)+Math.random().toString(36).slice(2,6)),
+    catalogIds:Array.isArray(c.catalogIds)?c.catalogIds:[],
+    sourceLang:c.sourceLang||'en',
+    targetLang:c.targetLang||'en',
+    source:(c.source||'').trim(),
+    target:(c.target||'').trim(),
+    notes:(c.notes||'').trim(),
+    tags:Array.isArray(c.tags)?c.tags.filter(Boolean):[],
+    backtranslate:{sourceLang:bt.sourceLang||c.targetLang||'en',targetLang:bt.targetLang||c.sourceLang||'en',inputText:bt.inputText||c.target||'',resultText:bt.resultText||'',verdict:bt.verdict||'',contentHash:bt.contentHash||'',updatedAt:bt.updatedAt||now},
+    clarifyChain:Array.isArray(c.clarifyChain)?c.clarifyChain:[],
+    savedBy:c.savedBy||'',
+    deletedAt:c.deletedAt||null,
+    createdAt:c.createdAt||now,
+    updatedAt:c.updatedAt||now
+  };
+}
+
+/* ── Storage CRUD ── */
+function pbGetAllCards(){try{return JSON.parse(localStorage.getItem(PB_CARDS)||'[]').map(pbNorm);}catch(_){return[];}}
+function pbGetCards(){return pbGetAllCards().filter(function(c){return !c.deletedAt;});}
+function pbSaveCards(a){try{localStorage.setItem(PB_CARDS,JSON.stringify(a));}catch(_){toast('Storage full');}}
+function pbGetCats(){try{return JSON.parse(localStorage.getItem(PB_CATS)||'[]');}catch(_){return[];}}
+function pbSaveCats(a){try{localStorage.setItem(PB_CATS,JSON.stringify(a));}catch(_){}}
+function pbGetTags(){try{return JSON.parse(localStorage.getItem(PB_TAGS_K)||'[]');}catch(_){return[];}}
+function pbSaveTags(a){try{localStorage.setItem(PB_TAGS_K,JSON.stringify(a));}catch(_){}}
+function pbCardKey(c){return (c.sourceLang||'')+'|'+(c.source||'').trim().toLowerCase()+'|'+(c.targetLang||'')+'|'+(c.target||'').trim().toLowerCase();}
+function pbUpsert(card){
+  var cards=pbGetCards();var key=pbCardKey(card);
+  var i=cards.findIndex(function(c){return pbCardKey(c)===key;});
+  var next=pbNorm(card);if(i>=0)cards[i]=next;else cards.unshift(next);
+  pbSaveCards(cards);return next;
+}
+function pbGetCardById(id){return pbGetAllCards().find(function(c){return c.id===id;})||null;}
+function pbSaveCard(card){
+  var cards=pbGetCards();var i=cards.findIndex(function(c){return c.id===card.id;});
+  var next=pbNorm(card);next.updatedAt=pbNow();
+  if(i>=0)cards[i]=next;else cards.unshift(next);
+  pbSaveCards(cards);
+}
+function pbSoftDelete(id){
+  var card=pbGetCardById(id);if(!card)return;
+  card.deletedAt=pbNow();pbSaveCard(card);
+  var el=document.getElementById('pbb-'+id);
+  if(el){el.classList.add('deleted');pbReRenderBubbleChevron(id);}
+  toast('Moved to trash');
+}
+function pbHardDelete(id){
+  if(!confirm('Permanently delete this phrase?'))return;
+  pbSaveCards(pbGetAllCards().filter(function(c){return c.id!==id;}));
+  var el=document.getElementById('pbb-'+id);if(el)el.remove();
+  toast('Permanently deleted');
+}
+function pbRestoreCard(id){
+  var card=pbGetCardById(id);if(!card)return;
+  card.deletedAt=null;pbSaveCard(card);
+  var el=document.getElementById('pbb-'+id);
+  if(el){el.classList.remove('deleted');pbReRenderBubbleChevron(id);}
+  toast('Phrase restored');
+}
+function pbReRenderBubbleChevron(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var row=document.getElementById('pbchev-'+id);if(!row)return;
+  row.innerHTML=pbChevRowHtml(card);
+  row.className='pb-chevron-row'+(card.deletedAt?' deleted':'');
+}
+function pbChevRowHtml(card){
+  var id=card.id;
+  if(card.deletedAt){
+    return '<span style="font-size:10px;color:#c0392b;flex:1;padding-left:4px;">In trash</span>'
+      +'<button class="pb-icon-btn restore" onclick="pbRestoreCard(\'' +id+ '\')" title="Restore">'+ICO.restore+'</button>'
+      +'<button class="pb-icon-btn danger" onclick="pbHardDelete(\'' +id+ '\')" title="Delete permanently">'+ICO.hardtrash+'</button>';
+  }
+  return '<button class="pb-icon-btn danger" onclick="pbSoftDelete(\''+id+'\')" title="Move to trash">'+ICO.trash+'</button>';
+}
+function pbAddTagToReg(t){var tags=pbGetTags();if(tags.indexOf(t)<0){tags.push(t);pbSaveTags(tags);}}
+
+/* ── Auto-seed ── */
+function pbGetBooks(){try{return JSON.parse(localStorage.getItem(PB_BOOKS_KEY)||'null')||[{id:'default',name:'Default',createdAt:0,isDefault:true}];}catch(_){return [{id:'default',name:'Default',createdAt:0,isDefault:true}];}}
+function pbSaveBooks(a){try{localStorage.setItem(PB_BOOKS_KEY,JSON.stringify(a));}catch(_){}}
+function pbOpenBooksModal(){
+  var books=pbGetBooks();var m=document.getElementById('pb-books-modal');if(!m)return;
+  var list=document.getElementById('pb-books-list');
+  if(list)list.innerHTML=books.map(function(b){
+    var ts=b.createdAt?new Date(b.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+    var cnt=b.cardCount?(' · '+b.cardCount+' phrases'):'';
+    var del=b.isDefault
+      ?'<span style="font-size:10px;color:#9a9592;">default</span>'
+      :'<button onclick="pbDeleteBook(\''+b.id+'\')" style="background:none;border:none;cursor:pointer;color:#c0392b;padding:2px 6px;line-height:0;" title="Remove">'+ICO.trash+'</button>';
+    return '<div class="pb-book-row"><div style="flex:1;min-width:0;"><div style="font-size:14px;font-weight:600;color:#1a1714;">'+pbEsc(b.name)+'</div>'
+      +'<div style="font-size:11px;color:#9a9592;">'+pbEsc(ts+cnt)+'</div></div>'+del+'</div>';
+  }).join('');
+  m.style.display='flex';
+}
+function pbDeleteBook(id){
+  var books=pbGetBooks().filter(function(b){return b.id!==id;});pbSaveBooks(books);pbOpenBooksModal();toast('Removed');
+}
+function pbAutoSeed(){
+  localStorage.removeItem('tb_standard_phrasebook');
+  if(localStorage.getItem(PB_SEEDED))return;
+  pbApplyImport(PB_SEED,{silent:true});
+  localStorage.setItem(PB_SEEDED,'1');
+}
+
+/* ── Import/export ── */
+function pbApplyImport(data,opts){
+  var cards=(data.cards||[]).map(pbNorm);
+  var existing=pbGetCards();var byKey={};
+  existing.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  cards.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  pbSaveCards(Object.values(byKey));
+  var cats=pbGetCats();var catIds=cats.map(function(c){return c.id;});
+  (data.catalogs||[]).forEach(function(cat){if(cat&&cat.id&&catIds.indexOf(cat.id)<0)cats.push(cat);});
+  pbSaveCats(cats);
+  var tags=pbGetTags();(data.tags||[]).forEach(function(t){if(tags.indexOf(t)<0)tags.push(t);});
+  pbSaveTags(tags);
+  if(!opts||!opts.silent)toast('Imported '+cards.length+' phrases');
+}
+function pbExport(name){
+  var payload={type:'phrasebook',cards:pbGetCards(),catalogs:pbGetCats(),tags:pbGetTags(),exportedAt:pbNow()};
+  var fn=(name||('phrases-'+Date.now()))+'.json';
+  var a=document.createElement('a');
+  a.href=URL.createObjectURL(new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}));
+  a.download=fn;a.click();
+  setTimeout(function(){URL.revokeObjectURL(a.href);},0);
+  toast('Exported: '+fn);
+}
+function pbReset(){pbResetConfirm();}
+
+/* ── Active language pair ── */
+function pbActivePair(){
+  if(!room.id||!room.myLang||!room.theirLang)return null;
+  return{src:room.myLang,tgt:room.theirLang};
+}
+function pbCardMatchesPair(card,pair){
+  if(!pair)return true;
+  return(card.sourceLang===pair.src&&card.targetLang===pair.tgt)||
+         (card.sourceLang===pair.tgt&&card.targetLang===pair.src);
+}
+
+/* ── Search (supports - exclude) ── */
+function pbSearch(q,cards){
+  if(!q||!q.trim())return cards;
+  var tokens=q.trim().toLowerCase().split(/\s+/);
+  var inc=tokens.filter(function(t){return t[0]!=='-';});
+  var exc=tokens.filter(function(t){return t[0]==='-';}).map(function(t){return t.slice(1);});
+  return cards.filter(function(c){
+    var hay=[c.source,c.target,c.notes,(c.tags||[]).join(' '),
+             (c.clarifyChain||[]).map(function(x){return x.text||'';}).join(' '),
+             (c.backtranslate&&c.backtranslate.resultText)||'',
+             c.sourceLang,c.targetLang].join(' ').toLowerCase();
+    var verdict=(c.backtranslate&&c.backtranslate.verdict)||'';
+    if(exc.some(function(t){return t&&hay.indexOf(t)>=0;}))return false;
+    return inc.every(function(t){
+      if(!t)return true;
+      if(t.indexOf('verdict:')===0)return verdict===t.slice(8);
+      if(t.indexOf('tag:')===0)return(c.tags||[]).indexOf(t.slice(4))>=0;
+      return hay.indexOf(t)>=0;
+    });
+  });
+}
+
+/* ─────────────────────────────────────────────────
+   DRAWER
+───────────────────────────────────────────────── */
+var _pbDrawerMode=''; // 'commands'|'search'
+function pbToggleDrawer(){
+  if(_pbDrawerMode==='search'){pbCloseDrawer();return;}
+  pbOpenSearchDrawer('');
+  var btn=document.getElementById('pb-strip-btn');
+  if(btn)btn.classList.add('active');
+}
+function pbOpenCmdDrawer(){
+  _pbDrawerMode='commands';
+  var c=document.getElementById('pb-drawer-content');
+  if(c)c.innerHTML=pbCmdDrawerHtml();
+  var d=document.getElementById('pb-drawer');if(d)d.classList.add('open');
+}
+function pbOpenSearchDrawer(q){
+  _pbDrawerMode='search';
+  var c=document.getElementById('pb-drawer-content');
+  if(c)c.innerHTML=pbSearchDrawerHtml();
+  var d=document.getElementById('pb-drawer');if(d)d.classList.add('open');
+  var btn=document.getElementById('pb-strip-btn');if(btn)btn.classList.add('active');
+  setTimeout(function(){
+    var si=document.getElementById('pb-search-input');
+    if(si){si.value=q||'';pbRunSearch();si.focus();}
+  },40);
+}
+function pbCloseDrawer(){
+  var d=document.getElementById('pb-drawer');if(d)d.classList.remove('open');
+  _pbDrawerMode='';
+  var btn=document.getElementById('pb-strip-btn');
+  if(btn)btn.classList.remove('active');
+  _pbRestoreMic();
+}
+function pbCmdDrawerHtml(){
+  return '<div class="pb-drawer-hdr"><span class="pb-drawer-title" style="font-size:11px;color:var(--text-muted);">Phrasebook (//) management</span>'    +'<button class="pb-drawer-x" onclick="pbCloseDrawer();pbClearComposeSlash()">×</button></div>'    +'<div class="pb-cmd-chips" style="justify-content:flex-start;">'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenBooksModal()" title="Open / switch phrasebook">'+ICO.book+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenNewCard({})" title="New phrase">'+ICO.plus+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbTriggerImport()" title="Import file">'+ICO.upload+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbExportPrompt()" title="Export">'+ICO.download+'</button>'    +'<button class="pb-ico-chip danger" onclick="pbCloseDrawer();pbClearCompose();pbResetConfirm()" title="Reset phrasebook">'+ICO.warn+'</button>'    +'</div>';
+}
+function pbSearchDrawerHtml(){
+  var pair=pbActivePair();
+  var badge=pair?('<span class="pb-pair-badge">'+pbEsc(pbLangFlag(pair.src)+' → '+pbLangFlag(pair.tgt))+'</span>'):'';
+  return '<div class="pb-drawer-hdr" style="flex-shrink:0;">'    +'<input id="pb-search-input" class="pb-search-inp" placeholder="Search phrases…" oninput="pbRunSearch()" onkeydown="pbSearchKD(event)">'    +badge    +'<button class="pb-ov-act" onclick="pbOpenOverlay()" title="Manage phrasebook" style="color:var(--text-dim);padding:4px 6px;">'+ICO.book+'</button>'    +'<button class="pb-drawer-x" onclick="pbCloseDrawer()" style="line-height:0;">'+ICO.x+'</button></div>'    +'<div id="pb-search-results" class="pb-search-results"></div>';
+}
+var _PB_BASE='https://github.acmeproducts.com/stuff/phrase/';
+function pbBuildUrl(){
+  var src=(document.getElementById('pb-url-src')||{}).value||'en';
+  var tgt=(document.getElementById('pb-url-tgt')||{}).value||'th';
+  var url=_PB_BASE+'phrasebook-'+src+'-'+tgt+'-default.json';
+  var inp=document.getElementById('pb-ov-url-inp');if(inp)inp.value=url;
+  var nm=document.getElementById('pb-ov-url-name');
+  if(nm&&!nm._userEdited)nm.value='Standard '+src.toUpperCase()+'↔'+tgt.toUpperCase()+' Phrasebook';
+}
+
+
+
+
+
+function pbExportPrompt(){
+  var pair=pbActivePair();
+  var pairStr=pair?(pair.src+'-'+pair.tgt+'-'):'';
+  var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\/:, ]+/g,'-');
+  var name=prompt('Export filename:',def);if(name===null)return;
+  pbExport(name);
+  document.getElementById('pb-overlay').style.display='flex';
+}
+function pbResetConfirm(){
+  var pair=pbActivePair();
+  var pairStr=pair?(pair.src+'-'+pair.tgt+'-'):'';
+  var def='phrases-backup-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[/:, ]+/g,'-');
+  var name=prompt('Backup filename (exported before reset):',def);if(name===null)return;
+  pbExport(name);
+  setTimeout(function(){
+    if(!confirm('Exported. Permanently reset phrasebook to default?'))return;
+    localStorage.removeItem(PB_CARDS);localStorage.removeItem(PB_CATS);
+    localStorage.removeItem(PB_TAGS_K);localStorage.removeItem(PB_SEEDED);
+    pbAutoSeed();pbRenderOverlayFilter();pbRenderOverlay();document.getElementById('pb-overlay').style.display='flex';
+    toast('Phrasebook reset to default');
+  },600);
+}
+
+function pbRunSearch(){
+  var si=document.getElementById('pb-search-input');
+  // Also pick up any text the user has typed in compose
+  var ta=document.getElementById('chat-input');
+  var q=(si?si.value:'')||(ta&&ta.value)||'';
+  var pair=pbActivePair();
+  var cards=pbGetCards().slice().sort(function(a,b){return (b.createdAt||0)-(a.createdAt||0);});
+  if(pair)cards=cards.filter(function(c){return pbCardMatchesPair(c,pair);});
+  if(q.trim())cards=pbSearch(q,cards);
+  var host=document.getElementById('pb-search-results');if(!host)return;
+  if(!cards.length){host.innerHTML='<div class="pb-empty">No matching phrases.</div>';return;}
+  host.innerHTML=cards.slice(0,40).map(function(c){return pbBubbleHtml(c,'search');}).join('');
+}
+function pbSearchKD(e){if(e.key==='Escape'){pbCloseDrawer();pbClearComposeSlash();}}
+function pbClearCompose(){
+  var ta=document.getElementById('chat-input');if(!ta)return;
+  ta.value='';ta.style.height='';
+  var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=true;
+}
+function pbClearComposeSlash(){
+  var ta=document.getElementById('chat-input');if(!ta)return;
+  if(ta.value==='/'||ta.value==='//'){ta.value='';ta.style.height='';}
+  var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!ta.value.trim();
+  ta.focus();
+}
+
+/* ── Use text ── */
+function pbUseText(id,side){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=side==='src'?card.source:card.target;
+  var ta=document.getElementById('chat-input');
+  if(ta){ta.value=text;ta.style.height='auto';ta.style.height=Math.min(ta.scrollHeight,80)+'px';
+    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}
+  pbCloseDrawer();
+  pbCloseOverlay();
+}
+
+/* ── Speak ── */
+function pbSpeakCard(id,side,btn){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=side==='src'?card.source:card.target;
+  var lang=side==='src'?card.sourceLang:card.targetLang;
+  speakText(text,lang);
+}
+
+/* ── Bubble HTML ── */
+var _pbCardState={}; // id→{tagsOpen,clarifyOpen,btOpen}
+function _pbCS(id){if(!_pbCardState[id])_pbCardState[id]={tagsOpen:false,clarifyOpen:false,btOpen:false};return _pbCardState[id];}
+function pbBubbleHtml(card,ctx){
+  var id=card.id;var src=card.sourceLang||'en';var tgt=card.targetLang||'en';
+  var sf=pbLangFlag(src);var tf=pbLangFlag(tgt);
+  var bt=card.backtranslate||{};var cc=(card.clarifyChain||[]).length;
+  var verdict=bt.verdict||'';var tags=card.tags||[];
+  var cs=_pbCS(id);var isDel=!!card.deletedAt;
+  var useL=L('use_word',src);var useR=L('use_word',tgt);
+  var vBadge=verdict==='good'?'<span class="pb-vbadge good">\u2713</span>':verdict==='flag'?'<span class="pb-vbadge flag">\u2691</span>':'';
+  var _hdrDate=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+  var _hdrTime=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
+  var _savedBy=card.savedBy?(' · '+card.savedBy):'';
+  return '<div class="pb-bubble'+(isDel?' deleted':'')+'" id="pbb-'+id+'">'
+    +'<div class="pb-bbl-hdr">'+vBadge+'<span class="pb-bbl-ts">'+pbEsc(_hdrDate+' '+_hdrTime+_savedBy)+'</span></div>'
+    +'<div class="pb-bbl-body">'
+    +'<div class="pb-bbl-col"><div class="pb-bbl-txt" id="pbsrc-'+id+'">'+pbEsc(card.source)+'</div>'
+    +'<div class="pb-bbl-acts"><button class="pb-use-btn" onclick="pbUseText(\''+id+'\',\'src\')" title="'+pbEsc(useL)+'">'+pbEsc(useL)+'</button>'
+    +'<button class="pb-tts-btn" onclick="pbSpeakCard(\''+id+'\',\'src\',this)" title="Play">'+PB_ICON_TTS+'</button></div></div>'
+    +'<div class="pb-bbl-div"></div>'
+    +'<div class="pb-bbl-col"><div class="pb-bbl-txt" id="pbtgt-'+id+'">'+pbEsc(card.target)+'</div>'
+    +'<div class="pb-bbl-acts"><button class="pb-use-btn" onclick="pbUseText(\''+id+'\',\'tgt\')" title="'+pbEsc(useR)+'">'+pbEsc(useR)+'</button>'
+    +'<button class="pb-tts-btn" onclick="pbSpeakCard(\''+id+'\',\'tgt\',this)" title="Play">'+PB_ICON_TTS+'</button></div></div>'
+    +'</div>'
+    +'<div class="pb-bbl-foot">'
+    +'<button class="pb-fbt'+(cs.tagsOpen?' on':'')+'" id="pbft-'+id+'" onclick="pbTogTags(\''+id+'\')" title="Tags">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.clarifyOpen?' on':'')+'" id="pbfc-'+id+'" onclick="pbTogClarify(\''+id+'\')" title="Clarify">'+ICO.chat+' Clarify'+(cc?' ('+cc+')':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ✓':'')+'</button>'
+    +'</div>'
+    +'<div class="pb-panel" id="pbtags-'+id+'" style="display:'+(cs.tagsOpen?'block':'none')+';">'+pbTagPanelHtml(card)+'</div>'
+    +'<div class="pb-panel" id="pbclarify-'+id+'" style="display:'+(cs.clarifyOpen?'block':'none')+';">'+pbClarifyPanelHtml(card)+'</div>'
+    +'<div class="pb-panel" id="pbbt-'+id+'" style="display:'+(cs.btOpen?'block':'none')+';">'+pbBtPanelHtml(card)+'</div>'
+    +'<div class="pb-chevron-row'+(isDel?' deleted':'')+'" id="pbchev-'+id+'">'+pbChevRowHtml(card)+'</div>'
+    +'</div>';
+}
+function pbTagPanelHtml(card){
+  var id=card.id;var tags=card.tags||[];
+  var pills=tags.map(function(t){return'<span class="pb-tp">#'+pbEsc(t)
+    +'<button onclick="pbRemoveTag(\''+id+'\',\''+pbEsc(t)+'\')" style="background:none;border:none;cursor:pointer;color:inherit;margin-left:2px;font-size:10px;">×</button></span>';}).join('');
+  return '<div style="padding:8px 10px;">'
+    +'<div class="pb-tpills" id="pb-atags-'+id+'">'+pills+'</div>'
+    +'<input class="pb-tag-inp" id="pb-ti-'+id+'" placeholder="Add tag…" oninput="pbTagSugg(\''+id+'\')" onkeydown="if(event.key===\'Enter\'){event.preventDefault();pbAddTagI(\''+id+'\');}">'
+    +'<div class="pb-tsugg" id="pb-ts-'+id+'"></div>'
+    +'</div>';
+}
+function pbAddTag(id,tag){
+  var t=(tag||'').toLowerCase().trim().replace(/\s+/g,'-').replace(/[^a-z0-9\-]/g,'').slice(0,24);
+  if(!t)return;
+  var card=pbGetCardById(id);if(!card)return;
+  card.tags=card.tags||[];if(card.tags.indexOf(t)<0)card.tags.push(t);
+  pbAddTagToReg(t);pbSaveCard(card);
+  pbReRenderCardPanel('tags',id);
+}
+function pbAddTagI(id){
+  var inp=document.getElementById('pb-ti-'+id);if(!inp)return;
+  pbAddTag(id,inp.value);inp.value='';
+}
+function pbRemoveTag(id,tag){
+  var card=pbGetCardById(id);if(!card)return;
+  card.tags=(card.tags||[]).filter(function(t){return t!==tag;});
+  pbSaveCard(card);pbReRenderCardPanel('tags',id);
+}
+function pbTagSugg(id){
+  var inp=document.getElementById('pb-ti-'+id);var q=(inp?inp.value:'').toLowerCase();
+  var out=document.getElementById('pb-ts-'+id);if(!out)return;
+  if(!q){out.innerHTML='';return;}
+  var tags=pbGetTags().filter(function(t){return t.indexOf(q)>=0;}).slice(0,8);
+  out.innerHTML=tags.map(function(t){return'<button class="pb-tsugg-chip" onclick="pbAddTag(\''+id+'\',\''+pbEsc(t)+'\')">'+pbEsc(t)+'</button>';}).join('');
+}
+
+/* ── Clarify panel ── */
+function pbClarifyPanelHtml(card){
+  var id=card.id;var chain=card.clarifyChain||[];
+  var thread=chain.length?chain.map(function(item,i){
+    var ts=item.timestamp?new Date(item.timestamp).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';
+    return'<div class="pb-clarify-item"><div class="pb-clarify-meta" style="display:flex;align-items:center;gap:5px;">'
+      +'<span class="pb-clarify-author">'+pbEsc(item.author||'')+'</span>'
+      +(ts?'<span style="font-size:10px;color:#b0aba8;">'+pbEsc(ts)+'</span>':'')
+      +'<button onclick="pbRemoveClarify(\''+id+'\','+i+')" style="background:none;border:none;cursor:pointer;color:#aaa;font-size:11px;margin-left:auto;">×</button>'
+      +'</div><div class="pb-clarify-body">'+pbEsc(item.text||'')+'</div></div>';
+  }).join(''):'<div style="color:#aaa;font-size:12px;padding:4px 0;">No clarifications yet.</div>';
+  return'<div style="padding:8px 10px;"><div id="pb-cthread-'+id+'">'+thread+'</div>'
+    +'<div style="display:flex;gap:6px;margin-top:8px;">'
+    +'<input class="pb-clarify-inp" id="pb-ci-'+id+'" placeholder="Add clarification…" onkeydown="if(event.key===\'Enter\'){event.preventDefault();pbAddClarify(\''+id+'\');}">'
+    +'<button class="pb-clarify-send" onclick="pbAddClarify(\''+id+'\')">Add</button>'
+    +'</div></div>';
+}
+function pbAddClarify(id){
+  var inp=document.getElementById('pb-ci-'+id);if(!inp)return;
+  var text=(inp.value||'').trim();if(!text)return;
+  var card=pbGetCardById(id);if(!card)return;
+  card.clarifyChain=card.clarifyChain||[];
+  card.clarifyChain.push({text:text,author:'Me',timestamp:pbNow()});
+  inp.value='';pbSaveCard(card);pbReRenderCardPanel('clarify',id);
+}
+function pbRemoveClarify(id,idx){
+  var card=pbGetCardById(id);if(!card)return;
+  card.clarifyChain=(card.clarifyChain||[]).filter(function(_,i){return i!==idx;});
+  pbSaveCard(card);pbReRenderCardPanel('clarify',id);
+}
+
+/* ── Back-translate panel ── */
+function pbBtPanelHtml(card){
+  var id=card.id;var bt=card.backtranslate||{};var result=bt.resultText||'';var verdict=bt.verdict||'';
+  var btLang=(card.backtranslate&&card.backtranslate.targetLang)||card.sourceLang||'en';
+  if(result)_btCache[id]={text:result,lang:btLang};
+  var resultHtml=result?('<div style="display:flex;align-items:flex-start;gap:6px;margin:6px 0;"><span style="font-style:italic;color:#555;font-size:13px;flex:1;">'+pbEsc(result)+'</span><button class="pb-bt-tts" onclick="pbPlayBT(\''+id+'\')" title="Play">'+PB_ICON_TTS+'</button></div>'):('<div style="color:#aaa;font-size:12px;">No result yet.</div>');
+  var verdictHtml='';
+  if(result){
+    if(!verdict)verdictHtml='<button class="pb-vbtn good" onclick="pbSetVerdict(\''+id+'\',\'good\')">✓ Sounds right</button> <button class="pb-vbtn flag" onclick="pbSetVerdict(\''+id+'\',\'flag\')">⚑ Flag</button>';
+    else if(verdict==='good')verdictHtml='<span class="pb-vbadge good">✓ Sounds right</span> <button class="pb-vbtn sm" onclick="pbSetVerdict(\''+id+'\',\'\')">Reset</button>';
+    else verdictHtml='<span class="pb-vbadge flag">⚑ Flagged</span> <button class="pb-vbtn sm" onclick="pbSetVerdict(\''+id+'\',\'\')">Reset</button>';
+  }
+  return'<div style="padding:8px 10px;">'
+    +'<button class="pb-bt-run" onclick="pbRunBT(\''+id+'\')"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg> Back-translate</button>'
+    +resultHtml+'<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:4px;">'+verdictHtml+'</div></div>';
+}
+function pbPlayBT(id){var e=_btCache[id];if(e&&e.text)speakText(e.text,e.lang);}
+function pbRunBT(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=card.target||'';var from=card.targetLang||'en';var to=card.sourceLang||'en';
+  var host=document.getElementById('pbbt-'+id);
+  if(host){var old=host.querySelector('div[style*="italic"]');if(old)old.textContent='Checking…';}
+  translateWithRetry(text,from,to,2).then(function(result){
+    card=pbGetCardById(id);if(!card)return;
+    // Strip phonetic romanization appended by MyMemory e.g. "สวัสดี (Sa-wat-dee)"
+    var clean=(result||'').replace(/\s*\([^)]*[a-zA-Z][^)]*\)\s*$/,'').trim()||result||'';
+    card.backtranslate.resultText=clean;card.backtranslate.updatedAt=pbNow();
+    pbSaveCard(card);pbReRenderCardPanel('bt',id);
+  });
+}
+function pbSetVerdict(id,val){
+  var card=pbGetCardById(id);if(!card)return;
+  card.backtranslate=card.backtranslate||{};
+  card.backtranslate.verdict=val;card.backtranslate.updatedAt=pbNow();
+  pbSaveCard(card);pbReRenderCardPanel('bt',id);
+  pbReRenderBubbleHeader(id);
+  toast(val==='good'?'Verified ✓':val==='flag'?'Flagged':'Verdict cleared');
+}
+
+/* ── Panel toggle helpers ── */
+function pbTogTags(id){var cs=_pbCS(id);cs.tagsOpen=!cs.tagsOpen;pbSyncPanel('tags',id);}
+function pbTogClarify(id){var cs=_pbCS(id);cs.clarifyOpen=!cs.clarifyOpen;pbSyncPanel('clarify',id);}
+function pbTogBt(id){var cs=_pbCS(id);cs.btOpen=!cs.btOpen;pbSyncPanel('bt',id);}
+function pbSyncPanel(type,id){
+  var cs=_pbCS(id);
+  var open=type==='tags'?cs.tagsOpen:type==='clarify'?cs.clarifyOpen:cs.btOpen;
+  var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';
+  var panel=document.getElementById(panelId+id);
+  if(panel)panel.style.display=open?'block':'none';
+  var btnId=type==='tags'?'pbft-':type==='clarify'?'pbfc-':'pbfb-';
+  var btn=document.getElementById(btnId+id);
+  if(btn)btn.classList.toggle('on',open);
+}
+function pbReRenderCardPanel(type,id){
+  var card=pbGetCardById(id);if(!card)return;
+  var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';
+  var el=document.getElementById(panelId+id);if(!el)return;
+  var fn=type==='tags'?pbTagPanelHtml:type==='clarify'?pbClarifyPanelHtml:pbBtPanelHtml;
+  el.innerHTML=fn(card);
+  if(type==='tags'){
+    var btn=document.getElementById('pbft-'+id);
+    if(btn){var tags=card.tags||[];btn.innerHTML=ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'');}
+  }
+  if(type==='clarify'){
+    var btn2=document.getElementById('pbfc-'+id);
+    if(btn2){var cc=(card.clarifyChain||[]).length;btn2.innerHTML=ICO.chat+' Clarify'+(cc?' ('+cc+')':'');}
+  }
+  if(type==='bt'){
+    var btn3=document.getElementById('pbfb-'+id);
+    if(btn3){var bt=card.backtranslate||{};btn3.innerHTML=ICO.verify+' Verify'+(bt.resultText?' ✓':'');}
+  }
+}
+function pbReRenderBubbleHeader(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var hdr=document.querySelector('#pbb-'+id+' .pb-bbl-hdr');if(!hdr)return;
+  var bt=card.backtranslate||{};var verdict=bt.verdict||'';
+  var vBadge=verdict==='good'?'<span class="pb-vbadge good">✓</span>':verdict==='flag'?'<span class="pb-vbadge flag">⚑</span>':'';
+  var tags=card.tags||[];var tagBadge=tags.length?'<span class="pb-tag-ct">#'+tags.length+'</span>':'';
+  var srcLang=card.sourceLang||'en';var tgtLang=card.targetLang||'en';
+  var sf=pbLangFlag(srcLang);var tf=pbLangFlag(tgtLang);
+  // preserve delete button if in overlay
+  var _hd=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+  var _ht=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
+  var _sb=card.savedBy?(' · '+card.savedBy):'';
+  hdr.innerHTML=vBadge+'<span class="pb-bbl-ts">'+pbEsc(_hd+' '+_ht+_sb)+'</span>';
+}
+
+/* ─────────────────────────────────────────────────
+   FULL-SCREEN OVERLAY
+───────────────────────────────────────────────── */
+var _pbFilter='all';
+
+function pbOpenOverlay(){
+  var d=document.getElementById('pb-overlay');if(d)d.style.display='flex';
+  var pair=pbActivePair();
+  _pbFilter=(pair&&pair.src&&pair.tgt)?(pair.src+'|'+pair.tgt):'all';
+  pbRenderOverlayFilter();pbRenderOverlay();
+}
+function pbCloseOverlay(){
+  var d=document.getElementById('pb-overlay');if(d)d.style.display='none';
+}
+function pbSetFilter(f){_pbFilter=f;pbRenderOverlayFilter();pbRenderOverlay();}
+function pbRenderOverlayFilter(){
+  var host=document.getElementById('pb-ov-filter');if(!host)return;
+  var cards=pbGetCards();var pairs={};
+  cards.forEach(function(c){var k=(c.sourceLang||'en')+'|'+(c.targetLang||'en');pairs[k]=true;});
+  var html='<button class="pb-fc'+(_pbFilter==='all'?' act':'')+'" onclick="pbSetFilter(\'all\')">All</button>';
+  Object.keys(pairs).forEach(function(k){
+    var p=k.split('|');
+    html+='<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'
+      +pbEsc(pbLangFlag(p[0])+' '+p[0].toUpperCase())+' → '+pbEsc(pbLangFlag(p[1])+' '+p[1].toUpperCase())+'</button>';
+  });
+  host.innerHTML=html;
+}
+function pbRenderOverlay(){
+  var host=document.getElementById('pb-ov-cards');if(!host)return;
+  var q=((document.getElementById('pb-ov-search')||{}).value||'').trim();
+  var cards=pbGetCards();
+  if(_pbFilter!=='all'){var p=_pbFilter.split('|');cards=cards.filter(function(c){return (c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});}
+  if(q)cards=pbSearch(q,cards);
+  if(!cards.length){host.innerHTML='<div class="pb-empty" style="padding:24px;text-align:center;">No phrases found.</div>';return;}
+  host.innerHTML=cards.map(function(c){return pbBubbleHtml(c,'overlay');}).join('');
+}
+function pbOvSearch(){pbRenderOverlay();}
+
+/* ─────────────────────────────────────────────────
+   IMPORT MODAL
+───────────────────────────────────────────────── */
+var _pbImportData=null;
+
+function pbTriggerImport(){document.getElementById('pb-file-input').click();}
+function pbHandleFile(e){
+  var file=e&&e.target&&e.target.files&&e.target.files[0];
+  if(!file){return;}e.target.value='';
+  var def=file.name.replace(/\.json$/i,'')||new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'});
+  var name=prompt('Name for this phrasebook?',def);if(name===null)return;
+  var reader=new FileReader();
+  reader.onload=function(){
+    try{
+      var data=JSON.parse(reader.result||'{}');
+      if(!data||!Array.isArray(data.cards)){toast('Invalid phrasebook file');return;}
+      data._importName=name||def;
+      pbOpenImportModal(data);
+    }catch(_){toast('Could not read file');}
+  };
+  reader.readAsText(file);
+}
+function pbOpenImportModal(data){
+  _pbImportData=data;var cards=data.cards||[];
+  var list=document.getElementById('pb-import-list');if(!list)return;
+  list.innerHTML=cards.map(function(c,i){
+    var src=(c.sourceLang||'en');var tgt=(c.targetLang||'en');
+    return'<label class="pb-import-row">'
+      +'<input type="checkbox" checked class="pb-import-cb" data-idx="'+i+'">'
+      +'<div class="pb-import-info">'
+      +'<span class="pb-import-pair">'+pbEsc(pbLangFlag(src)+' '+src.toUpperCase())+' → '+pbEsc(pbLangFlag(tgt)+' '+tgt.toUpperCase())+'</span>'
+      +'<span class="pb-import-src">'+pbEsc((c.source||'').slice(0,50))+'</span>'
+      +'<span class="pb-import-tgt">'+pbEsc((c.target||'').slice(0,50))+'</span>'
+      +'</div></label>';
+  }).join('');
+  pbSyncImportBtn();
+  document.getElementById('pb-import-modal').style.display='flex';
+}
+function pbSelectAllImport(on){
+  document.querySelectorAll('.pb-import-cb').forEach(function(cb){cb.checked=!!on;});
+  pbSyncImportBtn();
+}
+function pbSyncImportBtn(){
+  var cbs=document.querySelectorAll('.pb-import-cb');
+  var n=Array.from(cbs).filter(function(cb){return cb.checked;}).length;
+  var btn=document.getElementById('pb-import-ok');
+  if(btn)btn.textContent='Import '+n+' phrase'+(n!==1?'s':'');
+}
+function pbConfirmImport(){
+  if(!_pbImportData)return;
+  var cbs=document.querySelectorAll('.pb-import-cb');
+  var selected=[];
+  cbs.forEach(function(cb,i){if(cb.checked&&_pbImportData.cards[i])selected.push(_pbImportData.cards[i]);});
+  var importName=(_pbImportData._importName||'').trim();
+  pbApplyImport({cards:selected,catalogs:_pbImportData.catalogs||[],tags:_pbImportData.tags||[]},{});
+  // Register named book in registry
+  if(importName){
+    var books=pbGetBooks();
+    var alreadyExists=books.some(function(b){return b.name===importName;});
+    if(!alreadyExists){
+      books.push({id:'book-'+Date.now(),name:importName,createdAt:Date.now(),isDefault:false,cardCount:selected.length});
+      pbSaveBooks(books);
+    }
+  }
+  document.getElementById('pb-import-modal').style.display='none';
+  _pbImportData=null;
+  pbRenderOverlayFilter();pbRenderOverlay();
+  document.getElementById('pb-overlay').style.display='flex';
+  if(importName)toast('Saved: '+importName+' ('+selected.length+' phrases)');
+}
+function pbCloseImportModal(){
+  document.getElementById('pb-import-modal').style.display='none';_pbImportData=null;
+  document.getElementById('pb-overlay').style.display='flex';
+  pbRenderOverlayFilter();pbRenderOverlay();
+}
+
+/* ─────────────────────────────────────────────────
+   NEW CARD SHEET
+───────────────────────────────────────────────── */
+function pbPopLangSel(id,def){
+  var s=document.getElementById(id);if(!s)return;
+  s.innerHTML=LANGS.map(function(l){return'<option value="'+l.code+'"'+(l.code===def?' selected':'')+'>'+l.flag+' '+l.label+'</option>';}).join('');
+}
+function pbOpenNewCard(opts){
+  opts=opts||{};
+  var srcLang=opts.sourceLang||(room.myLang||'en');
+  var tgtLang=opts.targetLang||(room.theirLang||'en');
+  pbPopLangSel('pbnc-sl',srcLang);pbPopLangSel('pbnc-tl',tgtLang);
+  var st=document.getElementById('pbnc-src');var tt=document.getElementById('pbnc-tgt');
+  if(st)st.value=opts.source||'';if(tt)tt.value=opts.target||'';
+  document.getElementById('pb-new-card-sheet').classList.add('open');
+  setTimeout(function(){var s=document.getElementById('pbnc-src');if(s)s.focus();},40);
+}
+function pbCloseNewCard(){document.getElementById('pb-new-card-sheet').classList.remove('open');if(document.getElementById('pb-overlay').style.display!=='flex'){document.getElementById('pb-overlay').style.display='flex';pbRenderOverlayFilter();pbRenderOverlay();}}
+function pbNcAutoTranslate(){
+  var src=(document.getElementById('pbnc-src')||{}).value||'';
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!src.trim()){toast('Enter a source phrase first');return;}
+  translateWithRetry(src,sl,tl,2).then(function(out){
+    var tt=document.getElementById('pbnc-tgt');if(tt)tt.value=out||src;
+  });
+}
+function pbSaveNewCard(){
+  var src=((document.getElementById('pbnc-src')||{}).value||'').trim();
+  var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!src){toast('Enter a source phrase');return;}
+  if(!tgt){toast('Enter a translation');return;}
+  pbUpsert(pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()}));
+  pbCloseNewCard();toast('Saved to phrasebook');
+  pbRenderOverlayFilter();pbRenderOverlay();
+  document.getElementById('pb-overlay').style.display='flex';
+}
+
+
+
+// ─── Phase 8: Structured log ──────────────────────────────────────────────
+function log(ev,d,l){
+  var meta={phase:callPhase,role:room.role||lastSessionContext.role||'?',epoch:sessionEpoch};
+  var r={ts:new Date().toISOString(),ev:ev,d:Object.assign({},meta,d||{}),l:l||'info'};
+  debugLog.push(r);if(debugLog.length>400)debugLog.shift();
+  var b=$('log-body');if(!b)return;
+  var div=document.createElement('div');div.className='log-row '+(l||'info');
+  div.innerHTML='<span class="ts">'+r.ts.slice(11,23)+'</span> <span class="ev">'+esc(ev)+'</span> '+esc(JSON.stringify(d||{}));
+  b.appendChild(div);b.scrollTop=b.scrollHeight;
+}
+
+var L_STRINGS={
+  join_call:{en:"Join Call",es:"Unirse",zh:"加入通话",fr:"Rejoindre",de:"Beitreten",ja:"通話に参加",ko:"참여하기",ar:"انضم",hi:"जुड़ें",ru:"Присоединиться",pt:"Entrar",it:"Partecipa",vi:"Tham gia",id:"Bergabung",ms:"Sertai",fil:"Sumali",nl:"Deelnemen",sv:"Gå med",pl:"Dołącz",tr:"Katıl",th:"เข้าร่วม"},
+  tap_camera:{en:"Tap to allow camera & microphone",es:"Toca para permitir cámara y micrófono",zh:"点击允许摄像头和麦克风",fr:"Appuyez pour caméra & micro",de:"Kamera & Mikro erlauben",ja:"カメラとマイクを許可",ko:"카메라와 마이크 허용",ar:"اضغط للكاميرا والميكروفون",hi:"कैमरा व माइक अनुमति दें",ru:"Разрешить камеру и микрофон",pt:"Permitir câmera e microfone",it:"Consenti fotocamera e microfono",vi:"Cho phép camera và micro",id:"Izinkan kamera & mikrofon",ms:"Benarkan kamera & mikrofon",fil:"Payagan ang camera at mikropono",nl:"Sta camera en microfoon toe",sv:"Tillåt kamera och mikrofon",pl:"Zezwól na kamerę i mikrofon",tr:"Kamera ve mikrofona izin ver",th:"อนุญาตกล้องและไมค์"},
+  joining:{en:"Joining call…",es:"Uniéndose…",zh:"加入中…",fr:"Connexion…",de:"Verbinden…",ja:"参加中…",ko:"참여 중…",ar:"جارٍ الانضمام…",hi:"जुड़ रहे हैं…",ru:"Подключение…",pt:"Entrando…",it:"Connessione…",vi:"Đang tham gia…",id:"Bergabung…",ms:"Menyertai…",fil:"Sumasali…",nl:"Deelnemen…",sv:"Ansluter…",pl:"Dołączanie…",tr:"Katılıyor…",th:"กำลังเข้าร่วม…"},
+  thanks:{en:"Thanks for calling.",es:"Gracias por llamar.",zh:"感谢通话。",fr:"Merci d'avoir appelé.",de:"Danke fürs Anrufen.",ja:"お電話ありがとう。",ko:"전화해 주셔서 감사합니다.",ar:"شكراً على الاتصال.",hi:"कॉल के लिए धन्यवाद।",ru:"Спасибо за звонок.",pt:"Obrigado pela ligação.",it:"Grazie per la chiamata.",vi:"Cảm ơn đã gọi.",id:"Terima kasih telah menelepon.",ms:"Terima kasih kerana menghubungi.",fil:"Salamat sa pagtawag.",nl:"Bedankt voor het bellen.",sv:"Tack för samtalet.",pl:"Dziękujemy za rozmowę.",tr:"Aradığınız için teşekkürler.",th:"ขอบคุณสำหรับการโทร"},
+  close_tab:{en:"You can close this tab.",es:"Puedes cerrar esta pestaña.",zh:"您可以关闭此标签页。",fr:"Vous pouvez fermer cet onglet.",de:"Sie können diesen Tab schließen.",ja:"このタブを閉じてください。",ko:"이 탭을 닫아도 됩니다.",ar:"يمكنك إغلاق هذا التبويب.",hi:"आप यह टैब बंद कर सकते हैं।",ru:"Вы можете закрыть эту вкладку.",pt:"Você pode fechar esta aba.",it:"Puoi chiudere questa scheda.",vi:"Bạn có thể đóng tab này.",id:"Anda bisa menutup tab ini.",ms:"Anda boleh tutup tab ini.",fil:"Maaari mong isara ang tab na ito.",nl:"U kunt dit tabblad sluiten.",sv:"Du kan stänga den här fliken.",pl:"Możesz zamknąć tę kartę.",tr:"Bu sekmeyi kapatabilirsiniz.",th:"คุณสามารถปิดแท็บนี้ได้"},
+  rejoin:{en:"🔄 Rejoin",es:"🔄 Volver",zh:"🔄 重新加入",fr:"🔄 Rejoindre",de:"🔄 Erneut",ja:"🔄 再参加",ko:"🔄 재참여",ar:"🔄 إعادة الانضمام",hi:"🔄 फिर जुड़ें",ru:"🔄 Переподключиться",pt:"🔄 Voltar",it:"🔄 Rientra",vi:"🔄 Tham gia lại",id:"🔄 Gabung lagi",ms:"🔄 Sertai semula",fil:"🔄 Sumali muli",nl:"🔄 Opnieuw",sv:"🔄 Gå med igen",pl:"🔄 Dołącz ponownie",tr:"🔄 Tekrar katıl",th:"🔄 เข้าร่วมอีกครั้ง"},
+  dl_transcript:{en:"⬇ Download transcript",es:"⬇ Descargar transcripción",zh:"⬇ 下载记录",fr:"⬇ Télécharger",de:"⬇ Transkript laden",ja:"⬇ 記録をダウンロード",ko:"⬇ 기록 다운로드",ar:"⬇ تنزيل النص",hi:"⬇ डाउनलोड",ru:"⬇ Скачать",pt:"⬇ Baixar",it:"⬇ Scarica",vi:"⬇ Tải xuống",id:"⬇ Unduh",ms:"⬇ Muat turun",fil:"⬇ I-download",nl:"⬇ Download",sv:"⬇ Ladda ner",pl:"⬇ Pobierz",tr:"⬇ İndir",th:"⬇ ดาวน์โหลด"},
+  camera_off:{en:"Camera off",es:"Cámara apagada",zh:"摄像头关闭",fr:"Caméra éteinte",de:"Kamera aus",ja:"カメラオフ",ko:"카메라 꺼짐",ar:"الكاميرا معطلة",hi:"कैमरा बंद",ru:"Камера выкл.",pt:"Câmera desligada",it:"Fotocamera spenta",vi:"Camera tắt",id:"Kamera mati",ms:"Kamera dimatikan",fil:"Camera naka-off",nl:"Camera uit",sv:"Kamera av",pl:"Kamera wyłączona",tr:"Kamera kapalı",th:"ปิดกล้อง"},
+  disconnected:{en:"Partner has disconnected",es:"El compañero se desconectó",zh:"对方已断开连接",fr:"Le partenaire s'est déconnecté",de:"Partner getrennt",ja:"相手が切断しました",ko:"상대방이 연결을 끊었습니다",ar:"انقطع اتصال الشريك",hi:"पार्टनर डिसकनेक्ट हो गया",ru:"Партнёр отключился",pt:"Parceiro desconectado",it:"Partner disconnesso",vi:"Đối tác đã ngắt kết nối",id:"Mitra terputus",ms:"Rakan terputus",fil:"Nadiskonekta ang kasama",nl:"Partner verbroken",sv:"Partner kopplad från",pl:"Partner rozłączony",tr:"Ortak bağlantısı kesildi",th:"คู่หูตัดการเชื่อมต่อ"},
+  waiting:{en:"Waiting to reconnect…",es:"Esperando reconexión…",zh:"等待重新连接…",fr:"En attente…",de:"Warte auf Wiederverbindung…",ja:"再接続待ち…",ko:"재연결 대기 중…",ar:"في انتظار إعادة الاتصال…",hi:"पुनः कनेक्ट होने की प्रतीक्षा…",ru:"Ожидание переподключения…",pt:"Aguardando reconexão…",it:"In attesa…",vi:"Đang chờ kết nối lại…",id:"Menunggu rekoneksi…",ms:"Menunggu sambungan semula…",fil:"Naghihintay na muling kumonekta…",nl:"Wachten op herverbinding…",sv:"Väntar på återanslutning…",pl:"Oczekiwanie…",tr:"Yeniden bağlanmayı bekliyor…",th:"รอการเชื่อมต่อใหม่…"},
+  type_msg:{en:"Type a message…",es:"Escribe un mensaje…",zh:"输入消息…",fr:"Tapez un message…",de:"Nachricht eingeben…",ja:"メッセージを入力…",ko:"메시지 입력…",ar:"اكتب رسالة…",hi:"संदेश लिखें…",ru:"Введите сообщение…",pt:"Digite uma mensagem…",it:"Scrivi un messaggio…",vi:"Nhập tin nhắn…",id:"Ketik pesan…",ms:"Taip mesej…",fil:"Mag-type ng mensahe…",nl:"Typ een bericht…",sv:"Skriv ett meddelande…",pl:"Wpisz wiadomość…",tr:"Mesaj yaz…",th:"พิมพ์ข้อความ…"},
+  use_word:{en:"Use",es:"Usar",zh:"使用",fr:"Utiliser",de:"Nutzen",ja:"使う",ko:"사용",ar:"استخدم",hi:"उपयोग",ru:"Исп.",pt:"Usar",it:"Usa",vi:"Dùng",id:"Gunakan",ms:"Guna",fil:"Gamitin",nl:"Gebruik",sv:"Använd",pl:"Użyj",tr:"Kullan",th:"ใช้"},
+  you_word:{en:"You",es:"Yo",zh:"我",fr:"Moi",de:"Ich",ja:"私",ko:"나",ar:"أنا",hi:"मैं",ru:"Я",pt:"Eu",it:"Io",vi:"Tôi",id:"Saya",ms:"Saya",fil:"Ako",nl:"Ik",sv:"Jag",pl:"Ja",tr:"Ben",th:"ฉัน"},
+  partner_word:{en:"Partner",es:"Compañero",zh:"伙伴",fr:"Partenaire",de:"Partner",ja:"パートナー",ko:"파트너",ar:"شريك",hi:"साथी",ru:"Партнёр",pt:"Parceiro",it:"Partner",vi:"Đối tác",id:"Mitra",ms:"Rakan",fil:"Kasama",nl:"Partner",sv:"Partner",pl:"Partner",tr:"Ortak",th:"คู่หู"}
+};
+function L(key,lang){var m=L_STRINGS[key];if(!m)return key;return m[lang||room.myLang||'en']||m.en||key;}
+function gL(c){c=(c||'').toLowerCase();for(var i=0;i<LANGS.length;i++)if(LANGS[i].code===c)return LANGS[i];return{code:c||'?',label:(c||'?').toUpperCase(),flag:'🌐'}}
+function updateCallChip(){
+  var n=$('room-name-chip'),f=$('lang-flags-chip');if(!n||!f)return;
+  n.textContent=room.name||'No room';
+  f.textContent=gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
+}
+function syncMic(){var btn=$('top-mic-btn');if(btn)btn.classList.toggle('muted',!micOn);}
+function syncCam(){var btn=$('top-cam-btn');if(btn)btn.classList.toggle('muted',!camOn);$('local-video').style.opacity=camOn?'1':'0.12';}
+function markPartnerTalking(){var i=$('partner-speaking-indicator');if(!i)return;i.classList.add('show');clearTimeout(partnerSpeakTimer);partnerSpeakTimer=setTimeout(function(){i.classList.remove('show')},1200)}
+function syncTranscriptToggleButton(){var b=$('transcript-toggle-btn');if(!b)return;var e=!transcriptCollapsed;b.title=e?'Collapse transcript':'Expand transcript';b.setAttribute('aria-label',b.title);b.setAttribute('aria-expanded',e?'true':'false')}
+function syncTranscriptTtsButton(){var b=$('transcript-tts-toggle');if(!b)return;b.style.color=transcriptTtsOn?'#b6bcc3':'#8f959d';b.title=transcriptTtsOn?'Transcript TTS on':'Transcript TTS off';b.setAttribute('aria-pressed',transcriptTtsOn?'true':'false');var onIcon=b.querySelector('.tts-on'),offIcon=b.querySelector('.tts-off');if(onIcon)onIcon.style.display=transcriptTtsOn?'':'none';if(offIcon)offIcon.style.display=transcriptTtsOn?'none':''}
+function toggleTranscriptTts(){transcriptTtsOn=!transcriptTtsOn;syncTranscriptTtsButton();if(!transcriptTtsOn&&window.speechSynthesis)window.speechSynthesis.cancel()}
+function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)return;window.speechSynthesis.cancel();var u=new SpeechSynthesisUtterance(text);u.lang=TTS_LOCALE[lang]||lang||TTS_LOCALE[room.myLang]||'en-US';window.speechSynthesis.speak(u)}
+function toggleTranscript(){transcriptCollapsed=!transcriptCollapsed;$('call-screen').classList.toggle('transcript-collapsed',transcriptCollapsed);syncTranscriptToggleButton()}
+function swapVideos(){document.querySelector('.call-videos').classList.toggle('swapped')}
+
+function cleanTranslationText(t){
+  if(!t)return'';
+  return normalizeText(String(t).replace(/<\/?[a-zA-Z][^>]*>/g,''),'speech');
+}
+
+function translateWithRetry(text,from,to,retries){
+  if(!text||!from||!to||from===to)return Promise.resolve(text);
+  var k=from+'|'+to+'|'+text;
+  if(trCache.has(k)){var v=trCache.get(k);trCache.delete(k);trCache.set(k,v);return Promise.resolve(v);}
+  var attempt=function(n){
+    return fetch('https://api.mymemory.translated.net/get?q='+encodeURIComponent(text)+'&langpair='+from+'|'+to)
+      .then(function(r){return r.json()})
+      .then(function(d){
+        if(d&&d.responseStatus===200&&d.responseData){
+          var t=d.responseData.translatedText;
+          if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);
+            if(trCache.size>=TR_CACHE_MAX){var first=trCache.keys().next().value;trCache.delete(first);}
+            trCache.set(k,t);return t;
+          }
+        }
+        throw new Error('Invalid response');
+      })
+      .catch(function(e){
+        if(n>0){
+          log('trans_retry',{from:from,to:to,left:n},'warn');
+          return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});
+        }
+        log('trans_fail',{from:from,to:to,e:String(e)},'error');
+        return text;
+      });
+  };
+  return attempt(retries||0);
+}
+function translate(text,from,to){
+  if(!text||!from||!to||from===to)return Promise.resolve(text);
+  var k=from+'|'+to+'|'+text;
+  if(trCache.has(k)){var v=trCache.get(k);trCache.delete(k);trCache.set(k,v);return Promise.resolve(v);}
+  return fetch('https://api.mymemory.translated.net/get?q='+encodeURIComponent(text)+'&langpair='+from+'|'+to)
+    .then(function(r){return r.json()}).then(function(d){
+      if(d&&d.responseStatus===200&&d.responseData){
+        var t=d.responseData.translatedText;
+        if(t&&t.indexOf('MYMEMORY')<0){
+          t=cleanTranslationText(t);
+          if(trCache.size>=TR_CACHE_MAX){var first=trCache.keys().next().value;trCache.delete(first);}
+          trCache.set(k,t);return t;
+        }
+      }
+      return text;
+    }).catch(function(){return text});
+}
+
+function openLog(){log('log_open',{dev:deviceId,dg:!!localStorage.getItem('tb_dg_key')});$('log-overlay').classList.add('show')}
+function closeLog(){$('log-overlay').classList.remove('show')}
+function clearLogText(){debugLog=[];$('log-body').innerHTML='';toast('Cleared')}
+function copyLogText(){var t=debugLog.map(function(r){return r.ts+' ['+r.ev+'] '+JSON.stringify(r.d)}).join('\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}
+
+function trKey(id){return TP+(id||room.id)}
+function saveTr(){if(room.id)try{localStorage.setItem(trKey(),JSON.stringify(transcript))}catch(_){}}
+function loadTr(id){try{var r=localStorage.getItem(trKey(id||room.id));return r?JSON.parse(r):[]}catch(_){return[]}}
+function clearTrS(id){try{localStorage.removeItem(trKey(id))}catch(_){}}
+
+function encInv(p){try{return btoa(unescape(encodeURIComponent(JSON.stringify(p)))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}catch(_){return''}}
+function decInv(s){if(!s)return null;try{var b=s.replace(/-/g,'+').replace(/_/g,'/');while(b.length%4)b+='=';return JSON.parse(decodeURIComponent(escape(atob(b))))}catch(_){return null}}
+function invUrl(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';var tid=(($('cf-turn-id')&&$('cf-turn-id').value)||localStorage.getItem('tb_cf_tid')||'').trim();var tok=(($('cf-turn-tok')&&$('cf-turn-tok').value)||localStorage.getItem('tb_cf_tok')||'').trim();return location.href.split('?')[0].split('#')[0]+'#j='+encInv({r:room.id,ml:room.myLang,tl:room.theirLang,n:room.name||'',k:k,tid:tid,tok:tok})}
+
+function setLS(s){lobbyState=s;$('lobby-setup').style.display=s===LS.setup?'':'none';}
+function getRecent(){try{return JSON.parse(localStorage.getItem(RK)||'[]')}catch(_){return[]}}
+function setRecent(r){localStorage.setItem(RK,JSON.stringify(r.slice(0,RL)))}
+function saveRecent(){
+  if(!room.id)return;var rows=getRecent().filter(function(r){return r.id!==room.id});
+  rows.unshift({id:room.id,name:room.name||(gL(room.myLang).flag+' ↔ '+gL(room.theirLang).flag),myLang:room.myLang,theirLang:room.theirLang,ts:Date.now()});
+  setRecent(rows);renderRecent();
+}
+function delRecent(id){
+  var rooms=getRecent();
+  var r=rooms.find(function(x){return x.id===id});
+  if(r){r.deletedAt=Date.now();setRecent(rooms);}
+  renderRecent();
+}
+function hardDelRecent(id){
+  setRecent(getRecent().filter(function(r){return r.id!==id}));
+  clearTrS(id);renderRecent();
+}
+function restoreRecent(id){
+  var rooms=getRecent();
+  var r=rooms.find(function(x){return x.id===id});
+  if(r){delete r.deletedAt;setRecent(rooms);}
+  renderRecent();
+}
+
+async function reuseRoom(id){
+  var rec=getRecent().find(function(r){return r.id===id});if(!rec)return;
+  room.id=rec.id;room.myLang=rec.myLang;room.theirLang=rec.theirLang;room.role='creator';room.name=rec.name||'';
+  lastSessionContext.role='creator';lastSessionContext.myLang=rec.myLang;lastSessionContext.theirLang=rec.theirLang;lastSessionContext.roomName=rec.name||'';
+  $('my-lang').value=rec.myLang;$('their-lang').value=rec.theirLang;$('room-name').value=rec.name||'';syncBtn();
+  try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}catch(_){toast('Camera needed');return}
+  $('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name||'';
+  saveRecent();enterCall();
+}
+function viewRoomTr(id){
+  var rec=getRecent().find(function(r){return r.id===id});var entries=loadTr(id);viewingRoomId=id;
+  $('room-tr-title').textContent=(rec&&rec.name?rec.name:'Room')+' — Transcript';
+  var b=$('room-tr-body');
+  if(!entries.length){b.innerHTML='<div style="color:var(--text-muted);padding:16px;font-style:italic;">No transcript saved.</div>'}
+  else{b.innerHTML=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});var w=e.who==='me'?'You':'Partner';var wc=e.who==='me'?'color:var(--teal-bright)':'color:var(--text-dim)';var s=e.sourceText===e.translatedText;return '<div style="padding:8px 0;border-bottom:1px solid rgba(255,255,255,.05)"><div style="font-size:10px;font-weight:700;text-transform:uppercase;'+wc+'">'+w+' · '+(e.srcLang||'').toUpperCase()+' · '+ts+'</div><div style="color:var(--text-dim);margin-top:2px">'+esc(e.sourceText)+'</div>'+(s?'':'<div style="color:var(--text);margin-top:2px">→ '+esc(e.translatedText)+'</div>')+'</div>'}).join('')}
+  $('room-tr-overlay').classList.add('show');
+}
+function closeRoomTr(){$('room-tr-overlay').classList.remove('show')}
+function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toast('No transcript');return}var t=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}
+
+function renderRecent(){
+  var w=$('recent-rooms'),l=$('recent-rooms-list'),rows=getRecent();
+  var live=rows.filter(function(r){return !r.deletedAt;});
+  var dead=rows.filter(function(r){return !!r.deletedAt;});
+  w.style.display=rows.length?'':' none';
+  function liveRow(r){
+    var t=new Date(r.ts).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+    var h=!!loadTr(r.id).length;
+    var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';
+    return '<div class="recent-item"><div class="recent-item-top">'
+      +'<button class="recent-open jr" data-id="'+esc(r.id)+'">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'
+      +(flags?'<span style="font-size:15px;flex-shrink:0;">'+flags+'</span>':'')+'</div><div class="recent-actions">'
+      +'<button class="recent-act jr" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"/></svg> Reopen</button>'
+      +(h?'<button class="recent-act jv" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg> Transcript</button>':'')+'<button class="recent-act danger jd" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg> Delete</button>'
+      +'</div></div>';
+  }
+  function trashRow(r){
+    var t=new Date(r.ts).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+    var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';
+    return '<div class="recent-item" style="opacity:.6;">'
+      +'<div class="recent-item-top"><span class="recent-open" style="flex:1;font-size:13px;">'+esc(r.name)+'<small>'+esc(t)+'</small></span>'
+      +(flags?'<span style="font-size:15px;flex-shrink:0;">'+flags+'</span>':'')+'</div>'
+      +'<div class="recent-actions">'
+      +'<button class="recent-act jr2" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg> Restore</button>'
+      +'<button class="recent-act danger jd2" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg> Delete forever</button>'
+      +'</div></div>';
+  }
+  var html=live.map(liveRow).join('');
+  if(dead.length){
+    html+='<details class="room-trash-details"><summary><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg> Trash ('+dead.length+')</summary>'
+      +dead.map(trashRow).join('')+'</details>';
+  }
+  w.style.display=rows.length?'':' none';
+  l.innerHTML=html;
+  l.querySelectorAll('.jr').forEach(function(b){b.onclick=function(){reuseRoom(b.dataset.id)}});
+  l.querySelectorAll('.jv').forEach(function(b){b.onclick=function(){viewRoomTr(b.dataset.id)}});
+  l.querySelectorAll('.jd').forEach(function(b){b.onclick=function(){delRecent(b.dataset.id)}});
+  l.querySelectorAll('.jr2').forEach(function(b){b.onclick=function(){restoreRecent(b.dataset.id)}});
+  l.querySelectorAll('.jd2').forEach(function(b){b.onclick=function(){hardDelRecent(b.dataset.id)}});
+}
+
+function openCreateRoomModal(){
+  var bd=$("create-room-backdrop");if(!bd)return;
+  var mml=$("modal-my-lang"),mtl=$("modal-their-lang");
+  var opts=LANGS.map(function(l){return'<option value="'+l.code+'">'+l.flag+' '+l.label+'</option>';}).join('');
+  if(mml)mml.innerHTML='<option value="" disabled selected>I speak</option>'+opts;
+  if(mtl)mtl.innerHTML='<option value="" disabled selected>They speak</option>'+opts;
+  var sl=localStorage.getItem("tb_my_lang")||"",tl=localStorage.getItem("tb_their_lang")||"";
+  if(mml&&sl){try{mml.value=sl;}catch(_){}}
+  if(mtl&&tl){try{mtl.value=tl;}catch(_){}}
+  var mn=$("modal-room-name");if(mn)mn.value="";
+  syncModalBtn();
+  bd.classList.add("show");
+  setTimeout(function(){var mn=$("modal-room-name");if(mn)mn.focus();},60);
+}
+function closeCreateRoomModal(){var bd=$("create-room-backdrop");if(bd)bd.classList.remove("show");}
+function syncModalBtn(){
+  var ml=$("modal-my-lang"),tl=$("modal-their-lang"),btn=$("modal-create-btn");
+  var k=(localStorage.getItem("tb_dg_key")||"").trim();
+  var tid=(localStorage.getItem("tb_cf_tid")||"").trim();
+  var tok=(localStorage.getItem("tb_cf_tok")||"").trim();
+  if(btn)btn.disabled=!(ml&&ml.value&&tl&&tl.value&&k&&dgKeyVerified&&tid&&tok);
+}
+function confirmCreateRoom(){
+  var ml=$("modal-my-lang"),tl=$("modal-their-lang"),mn=$("modal-room-name");
+  if(!ml||!ml.value||!tl||!tl.value)return;
+  $("room-name").value=(mn&&mn.value||"").trim();
+  $("my-lang").value=ml.value;
+  $("their-lang").value=tl.value;
+  localStorage.setItem("tb_my_lang",ml.value);
+  localStorage.setItem("tb_their_lang",tl.value);
+  closeCreateRoomModal();
+  createRoom();
+}
+function populateLangs(){['my-lang','their-lang'].forEach(function(id){var s=$(id);s.innerHTML='<option value="" disabled selected>'+(id==='my-lang'?'I speak':'They speak')+'</option>'+LANGS.map(function(l){return'<option value="'+l.code+'">'+l.flag+' '+l.label+'</option>'}).join('');s.onchange=syncBtn});syncBtn()}
+function toggleKeysPanel(){
+  var p=document.getElementById('keys-panel');var btn=document.getElementById('keys-gear-btn');if(!p)return;
+  var open=p.style.display==='flex';p.style.display=open?'none':'flex';
+  if(btn)btn.style.background=open?'':'var(--teal)';if(btn)btn.style.color=open?'':'#fff';
+}
+function syncBtn(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';var tid=(($('cf-turn-id')&&$('cf-turn-id').value)||localStorage.getItem('tb_cf_tid')||'').trim();var tok2=(($('cf-turn-tok')&&$('cf-turn-tok').value)||localStorage.getItem('tb_cf_tok')||'').trim();var cb=$('create-btn');if(cb)cb.disabled=!($('my-lang').value&&$('their-lang').value&&k&&dgKeyVerified&&tid&&tok2);syncModalBtn();}
+function setCfTurnStatus(msg,color){var el=$('cf-turn-status');if(!el)return;el.textContent=msg;el.style.color=color||'#888';}
+function onCfTurnInput(){var tid=($('cf-turn-id').value||'').trim();var tok=($('cf-turn-tok').value||'').trim();if(tid)localStorage.setItem('tb_cf_tid',tid);if(tok)localStorage.setItem('tb_cf_tok',tok);if(tid&&tok)setCfTurnStatus('✅ Saved','#2ecc71');else setCfTurnStatus('','');syncBtn();}
+function setDgKeyStatus(msg,color){var el=$('dg-key-status');if(!el)return;el.textContent=msg;el.style.color=color||'#888';}
+function onDgKeyInput(){
+  var raw=$('dg-key').value,k=raw.trim();
+  if(raw!==k)$('dg-key').value=k;
+  dgKeyVerified=false;clearTimeout(dgKeyVerifyTimer);
+  if(!k){setDgKeyStatus('','');syncBtn();return;}
+  setDgKeyStatus('Verifying…','#f39c12');syncBtn();
+  dgKeyVerifyTimer=setTimeout(function(){verifyDgKey(k)},800);
+}
+function verifyDgKey(key){
+  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language=en-US&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';
+  var vws=new WebSocket(url,['token',key]),done=false;
+  var timer=setTimeout(function(){vws.close();if(!done){done=true;setDgKeyStatus('❌ Timed out — check key','#e74c3c');dgKeyVerified=false;syncBtn();}},8000);
+  vws.onopen=function(){if(done)return;done=true;clearTimeout(timer);vws.close();dgKeyVerified=true;localStorage.setItem('tb_dg_key',key);setDgKeyStatus('✅ Key verified','#2ecc71');syncBtn();log('dg_key_verified',{},'ok');};
+  vws.onerror=function(){};
+  vws.onclose=function(ev){clearTimeout(timer);if(!done){done=true;setDgKeyStatus('❌ Invalid key ('+ev.code+') — re-paste and try again','#e74c3c');dgKeyVerified=false;syncBtn();}};
+}
+
+async function createRoom(){
+  room.myLang=$('my-lang').value;room.theirLang=$('their-lang').value;room.name=($('room-name').value||'').trim();
+  if(!room.myLang||!room.theirLang){toast('Select both languages');return}
+  room.id=uid();room.role='creator';
+  lastSessionContext.role='creator';lastSessionContext.myLang=room.myLang;lastSessionContext.theirLang=room.theirLang;lastSessionContext.roomName=room.name;
+  try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}catch(_){toast('Camera needed');return}
+  var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name||'';
+  if(navigator.clipboard)navigator.clipboard.writeText(url).catch(function(){});
+  saveRecent();enterCall();
+}
+
+var _pendingJoin=null,inviteDgKey='',inviteCfTid='',inviteCfTok='';
+function handleHash(p){
+  if(!p||!p.r)return;
+  setCallPhase('prejoin','hash');
+  if(p.k){inviteDgKey=p.k;if($('dg-key'))$('dg-key').value=p.k;dgKeyVerified=true;} // invite credentials are session-only (no localStorage persistence)
+  if(p.tid){inviteCfTid=p.tid;if($('cf-turn-id'))$('cf-turn-id').value=p.tid;} // keep invite TURN credentials in-memory for this tab only
+  if(p.tok){inviteCfTok=p.tok;if($('cf-turn-tok'))$('cf-turn-tok').value=p.tok;} // keep invite TURN credentials in-memory for this tab only
+  _pendingJoin=p;
+  lastSessionContext.pendingJoinSnapshot=p;
+  var ne=$('joiner-room-name'),fe=$('joiner-flags'),lp=$('joiner-lang-pill'),sub=$('joiner-sub'),jjb=$('joiner-join-btn');
+  var jl=p.tl||'';
+  var rawName=p.n||'';
+  if(ne)ne.textContent=rawName||'You are invited to join a call';
+  if(fe)fe.textContent=(p.ml&&p.tl)?gL(p.ml).flag+' \u2192 '+gL(p.tl).flag:'';
+  if(lp)lp.textContent=jl?gL(jl).flag:'';
+  if(sub)sub.textContent=L('tap_camera',jl);
+  if(jjb)jjb.textContent=L('join_call',jl);
+  if(rawName&&p.ml&&p.tl&&p.ml!==p.tl)translate(rawName,p.ml,p.tl).then(function(tr){if(tr&&tr!==rawName&&ne)ne.textContent=tr;}).catch(function(){});
+  $('joiner-landing').classList.add('show');
+  history.replaceState({},'',location.pathname);
+}
+function joinerProceed(){
+  var p=_pendingJoin;if(!p)return;
+  var captureEpoch=bumpSessionEpoch('joiner_proceed');
+  setCallPhase('joining_media','joiner_proceed');
+  $('joiner-landing').classList.remove('show');
+  $('joining-screen').classList.add('show');
+  if(videoStream){videoStream.getTracks().forEach(function(t){t.stop();});videoStream=null;}
+  navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()}).then(function(s){
+    if(captureEpoch!==sessionEpoch){log('joiner_stale_media',{captureEpoch:captureEpoch,current:sessionEpoch},'warn');s.getTracks().forEach(function(t){t.stop();});$('joining-screen').classList.remove('show');return;}
+    videoStream=s;$('joining-screen').classList.remove('show');
+    room.id=p.r;room.myLang=p.tl;room.theirLang=p.ml;room.name=p.n||'';room.role='joiner';
+    lastSessionContext.role='joiner';lastSessionContext.myLang=p.tl;lastSessionContext.theirLang=p.ml;lastSessionContext.roomName=p.n||'';
+    saveRecent();enterCall();
+  }).catch(function(){
+    $('joining-screen').classList.remove('show');$('joiner-landing').classList.add('show');
+    setCallPhase('prejoin','media_denied');
+    toast('Camera access required');
+  });
+}
+function copyLink(){var u=room.id?invUrl():($('lobby-link').textContent||invUrl());if(navigator.clipboard)navigator.clipboard.writeText(u).then(function(){toast('Link copied')})}
+function shareLink(){var u=room.id?invUrl():($('lobby-link').textContent||invUrl());if(navigator.share)navigator.share({title:'TalkBridge',url:u}).catch(function(){});else copyLink()}
+
+// === RELAY ===
+var _relayFailCount=0;
+function showReconnectBanner(){var b=$('reconnect-banner');if(b)b.classList.add('show');}
+function hideReconnectBanner(){var b=$('reconnect-banner');if(b)b.classList.remove('show');}
+function forceReconnect(){_relayFailCount=0;hideReconnectBanner();if(_relayWs)try{_relayWs.close()}catch(_){}_relayWs=null;if(room.id&&lobbyState===LS.call)connectRelay();}
+function connectRelay(){
+  if(_relayWs)try{_relayWs.close()}catch(_){}
+  var ws=new WebSocket(RELAY_WS+'?app='+encodeURIComponent(RELAY_APP)+'&session='+encodeURIComponent(room.id)+'&client='+encodeURIComponent(deviceId));
+  _relayWs=ws;
+  ws.onopen=function(){
+    if(ws!==_relayWs)return;
+    _relayFailCount=0;hideReconnectBanner();log('relay_open',{},'ok');
+    relaySend({type:'hello',lang:room.myLang,targetLang:room.theirLang,role:room.role});
+    startHB();
+    // Resend any unacked chat messages after reconnect
+    _chatOutbox.forEach(function(msg){relaySend(msg);});
+    if(_chatOutbox.size)log('chat_resend',{n:_chatOutbox.size});
+    if(room.role==='creator'&&!pc)(async()=>{await setupPC();})();
+    // Reconcile DG after relay reconnect
+    reconcileDeepgramState('relay_reconnect');
+  };
+  ws.onmessage=function(e){try{handleRelay(JSON.parse(e.data))}catch(_){}};
+  ws.onclose=function(ev){
+    if(ws!==_relayWs)return;
+    _relayFailCount++;log('relay_close',{code:ev.code},'warn');stopHB();clearTimeout(wsReconnectTimer);
+    if(_relayFailCount>8){showReconnectBanner();return;}
+    if(room.id&&lobbyState===LS.call)wsReconnectTimer=setTimeout(function(){wsReconnectTimer=null;if(room.id)connectRelay()},2000);
+  };
+  ws.onerror=function(){log('relay_err',{},'error')};
+}
+function relaySend(m){if(!_relayWs||_relayWs.readyState!==1)return;m.session=room.id;m.from=deviceId;m.ts=Date.now();m.seq=++seq;try{_relayWs.send(JSON.stringify(m))}catch(_){}}
+function startHB(){stopHB();hbTimer=setInterval(function(){relaySend({type:'ping',transient:true})},HEARTBEAT_MS)}
+function stopHB(){if(hbTimer){clearInterval(hbTimer);hbTimer=null}}
+
+function handleRelay(d){
+  if(!d||d.from===deviceId)return;
+  if(d.type==='hello'){
+    if(room.role==='creator'){
+      $('solo-banner').style.display='none';
+      var state=pc&&pc.connectionState;
+      if(state==='connected'){log('rtc_hello_skip',{state:state});return;}
+      if(savedOffer){relaySend(savedOffer);log('rtc_offer_resent',{},'ok');savedCandidates.forEach(function(cm){relaySend(cm);});log('rtc_cands_resent',{n:savedCandidates.length});transcript.filter(function(e){return e.attachment&&e.attachment.dataUrl;}).forEach(function(e){relaySend({type:'chat-msg',chatId:e.id,srcText:e.sourceText,tgtText:e.translatedText,srcLang:e.srcLang,tgtLang:e.tgtLang,attachment:e.attachment});});}
+    }
+    return;
+  }
+  if(d.type==='ping'){relaySend({type:'pong',transient:true});return}
+  if(d.type==='pong')return;
+  // Phase 6: chat ack clears outbox
+  if(d.type==='chat-ack'){_chatOutbox.delete(d.chatId);log('chat_ack',{chatId:d.chatId});return;}
+  if(d.type==='webrtc-signal'){handleSig(d);return}
+  if(d.type==='subtitle'){
+    markPartnerTalking();
+    var normText=normalizeText(d.text, 'speech');
+    var normSrc=normalizeText(d.sourceText, 'speech')||normText;
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    addTr('partner',normSrc,normText,d.sourceLang,d.targetLang,d.subtitleSeq);return;
+  }
+  if(d.type==='subtitle-update'){
+    markPartnerTalking();
+    var normText=normalizeText(d.text, 'speech');
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    patchTr('partner',d.subtitleSeq,normText,d.sourceLang,d.targetLang);return;
+  }
+  if(d.type==='chat-msg'){handleChatMsg(d);return;}
+  if(d.type==='mic-state'){var rmo=$('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}
+  if(d.type==='cam-state'){var rco=$('remote-cam-off');if(rco){rco.classList.toggle('show',d.camOn===false);}var rcl=$('remote-cam-off-label');if(rcl)rcl.textContent=L('camera_off');return;}
+  if(d.type==='hangup'){
+    if(room.role==='joiner'){showHostLeftCountdown();}
+    else{
+      // Joiner left — creator stays in call, resets to solo waiting state
+      hidePartnerDisconnected();
+      resetRemoteMediaState();
+      pendingCandidates=[];savedOffer=null;savedCandidates=[];
+      resetRecoveryState();
+      if(pc){try{pc.close();}catch(_){}pc=null;}
+      $('solo-banner').style.display='';
+      setCallPhase('call_connecting','partner_left');
+      armConnectTimeout();
+      log('partner_left',{},'info');
+    }
+    return;
+  }
+}
+
+async function enterCall(){
+  if(!videoStream){
+    try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}
+    catch(_){toast('Camera needed');return}
+  }
+  $('lobby-link').textContent=invUrl();
+  transcript=loadTr()||[];
+  _chatOutbox.clear();_chatReceived.clear();
+  $('lobby').classList.add('hidden');$('joiner-landing').classList.remove('show');
+  hidePartnerDisconnected();hideReconnectBanner();_relayFailCount=0;
+  var sb=$('strip-share-btn');if(sb)sb.style.display=room.role==='creator'?'':'none';
+  var ci=$('chat-input');if(ci)ci.placeholder='type here to chat \u00b7 / for phrases';
+  if(!callHistoryPushed){history.pushState({tbView:'call'},'',location.href);callHistoryPushed=true}
+  $('call-screen').classList.add('active');lobbyState=LS.call;
+  setCallPhase('call_connecting','enter_call');
+  resetRecoveryState();
+  armConnectTimeout();
+  $('local-video').srcObject=videoStream;syncMic();syncCam();updateCallChip();
+  var roomMsg='Entering'+(room.name?' '+room.name:'')+'\n'+gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
+  toast(roomMsg);
+  $('solo-banner').style.display=room.role==='creator'?'':'none';
+  renderTr();
+  connectRelay();
+  dgDesired=true;
+  micMutedByUser=false;
+  reconcileDeepgramState('enter_call');
+}
+
+// === REMOTE VIDEO ===
+function refreshRemoteVideo(){
+  var rv=$('remote-video');
+  var tracks=remoteStream?remoteStream.getTracks():[];
+  var hasVideoTrack=tracks.some(function(t){return t.kind==='video'&&t.readyState==='live'});
+  var hasRemoteTrack=tracks.some(function(t){return t.readyState==='live'});
+  log('rtc_refresh',{tracks:tracks.map(function(t){return t.kind+':'+t.readyState}).join(',')});
+  if(hasRemoteTrack&&rv.srcObject!==remoteStream){rv.srcObject=remoteStream;}
+  rv.playsInline=true;rv.autoplay=true;
+  if(hasRemoteTrack){
+    rv.muted=true;
+    var tryPlay=rv.play&&rv.play();
+    if(tryPlay&&tryPlay.then){tryPlay.then(function(){rv.muted=false;log('rtc_unmuted',{},'ok');}).catch(function(e){log('rtc_play_err',{e:String(e)},'error');});}
+    $('solo-banner').style.display='none';
+  }
+  if(hasVideoTrack){$('no-video-msg').style.display='none';}
+  else{$('no-video-msg').style.display='';if(!hasRemoteTrack&&rv.srcObject)rv.srcObject=null;}
+}
+function bindRemoteTrackState(track){
+  if(!track||track._tbBound)return;track._tbBound=true;
+  track.onunmute=refreshRemoteVideo;track.onmute=refreshRemoteVideo;track.onended=refreshRemoteVideo;
+}
+function resetRemoteMediaState(){
+  var rv=$('remote-video');
+  if(remoteStream)remoteStream.getTracks().forEach(function(t){t.onunmute=null;t.onmute=null;t.onended=null;});
+  remoteStream=null;rv.srcObject=null;$('no-video-msg').style.display='';
+}
+function resetRecoveryState(){
+  _recoveryLock=false;_recoveryStep=0;_stableSince=null;_seenRemoteCand.clear();
+  clearTimeout(_recoveryTimer);_recoveryTimer=null;
+  clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+  clearInterval(_remoteVideoWatchdogTimer);_remoteVideoWatchdogTimer=null;
+  _remoteVideoLastTime=0;_remoteVideoStallCount=0;
+}
+function armConnectTimeout(){
+  clearTimeout(_connectTimeoutTimer);
+  _connectTimeoutTimer=setTimeout(function(){
+    if(callPhase==='call_connecting')runRecovery('connect_timeout');
+  },12000);
+}
+function startRemoteVideoWatchdog(){
+  clearInterval(_remoteVideoWatchdogTimer);
+  _remoteVideoWatchdogTimer=setInterval(function(){
+    if(callPhase!=='call_live')return;
+    var rv=$('remote-video');
+    if(!rv||!rv.srcObject)return;
+    var now=rv.currentTime||0;
+    if(now<=_remoteVideoLastTime+0.01)_remoteVideoStallCount++;
+    else _remoteVideoStallCount=0;
+    _remoteVideoLastTime=now;
+    if(_remoteVideoStallCount>=4){log('rtc_watchdog_stall',{t:now},'warn');runRecovery('video_stall');}
+  },1000);
+}
+async function runRecovery(reason){
+  if(_recoveryLock||!room.id||lobbyState!==LS.call)return;
+  _recoveryLock=true;
+  _recoveryStep=Math.min(_recoveryStep+1,3);
+  var step=_recoveryStep;
+  log('rtc_recovery_step',{step:step,why:reason},'warn');
+  try{
+    if(step===1){
+      refreshRemoteVideo();
+      startRemoteVideoWatchdog();
+      log('rtc_recovery_done',{step:step},'ok');
+    }else if(step===2){
+      if(pc&&pc.connectionState!=='closed'){
+        await pc.setLocalDescription(await pc.createOffer({iceRestart:true}));
+        var msg={type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}};
+        savedOffer=msg;relaySend(msg);log('rtc_recovery_ice_restart',{},'ok');
+      }
+    }else{
+      if(pc){try{pc.close();}catch(_){}pc=null;}
+      resetRemoteMediaState();
+      pendingCandidates=[];savedCandidates=[];savedOffer=null;
+      _seenRemoteCand.clear();
+      await setupPC();
+      connectRelay();
+      armConnectTimeout();
+      log('rtc_recovery_rebuild',{},'ok');
+    }
+  }catch(e){log('rtc_recovery_err',{step:step,e:String(e)},'error');}
+  finally{
+    clearTimeout(_recoveryTimer);
+    _recoveryTimer=setTimeout(function(){_recoveryLock=false;},800);
+  }
+}
+
+// === WEBRTC ===
+var _keepaliveChannel=null;var _keepaliveTimer=null;
+function startKeepalive(){stopKeepalive();_keepaliveTimer=setInterval(function(){if(_keepaliveChannel&&_keepaliveChannel.readyState==='open'){try{_keepaliveChannel.send('k')}catch(_){}}},4000);}
+function stopKeepalive(){clearInterval(_keepaliveTimer);_keepaliveTimer=null;}
+async function setupPC(){
+  if(pc)return;
+  var iceServers=[{urls:'stun:stun.l.google.com:19302'},{urls:'stun:stun1.l.google.com:19302'}];
+  var tid=((inviteCfTid||'')||(localStorage.getItem('tb_cf_tid')||'')).trim();
+  var tok=((inviteCfTok||'')||(localStorage.getItem('tb_cf_tok')||'')).trim();
+  if(tid&&tok){
+    try{
+      var r=await fetch('https://rtc.live.cloudflare.com/v1/turn/keys/'+tid+'/credentials/generate',{method:'POST',headers:{'Authorization':'Bearer '+tok,'Content-Type':'application/json'},body:JSON.stringify({ttl:86400})});
+      if(r.ok){var d=await r.json();if(d.iceServers)iceServers=Array.isArray(d.iceServers)?d.iceServers:[d.iceServers];log('turn_ok',{n:iceServers.length},'ok');}
+      else{log('turn_err',{s:r.status},'warn');}
+    }catch(e){log('turn_fetch_err',{e:String(e)},'warn');}
+  }
+  pc=new RTCPeerConnection({iceServers:iceServers});
+  pc.ondatachannel=function(e){if(e.channel&&e.channel.label==='ka'){e.channel.onmessage=function(){};try{_keepaliveChannel=e.channel;startKeepalive();}catch(_){}}};
+  if(room.role==='creator'){
+    pc.onnegotiationneeded=async function(){
+      try{makingOffer=true;savedCandidates=[];await pc.setLocalDescription(await pc.createOffer());var _offer={type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}};relaySend(_offer);savedOffer=_offer;log('rtc_offer_saved',{},'ok');}
+      catch(_){}finally{makingOffer=false}
+    };
+  }else{
+    pc.onnegotiationneeded=function(){};
+  }
+  var localTracks=videoStream?videoStream.getTracks():[];
+  localTracks.forEach(function(t){pc.addTrack(t,videoStream)});
+  try{_keepaliveChannel=pc.createDataChannel('ka',{ordered:false,maxRetransmits:0});startKeepalive();}catch(_){}
+  pc.onicecandidate=function(e){if(e.candidate){log('rtc_ice_emit',{type:e.candidate.type||'?'});var cm={type:'webrtc-signal',transient:true,signal:{candidate:e.candidate}};savedCandidates.push(cm);relaySend(cm);}};
+  pc.oniceconnectionstatechange=function(){log('rtc_ice',{s:pc.iceConnectionState},pc.iceConnectionState==='connected'?'ok':'info')};
+  pc.onconnectionstatechange=function(){
+    var s=pc.connectionState;
+    log('rtc_conn',{s:s},s==='connected'?'ok':s==='failed'?'error':'info');
+    if(s==='connected'){
+      hidePartnerDisconnected();
+      clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+      _stableSince=Date.now();
+      clearTimeout(_recoveryTimer);
+      _recoveryTimer=setTimeout(function(){
+        if(!pc||pc.connectionState!=='connected')return;
+        if(_stableSince&&Date.now()-_stableSince>=2000){
+          setCallPhase('call_live','pc_connected_stable');
+          _recoveryStep=0;
+          reconcileDeepgramState('pc_connected_stable');
+          startRemoteVideoWatchdog();
+        }
+      },2000);
+    }
+    if(s==='disconnected'){
+      _stableSince=null;clearTimeout(_recoveryTimer);
+      setCallPhase('call_degraded','pc_disconnected');
+      showPartnerDisconnected(L('disconnected'));
+      runRecovery('pc_disconnected');
+    }
+    if(s==='failed'&&room.id&&lobbyState===LS.call){
+      _stableSince=null;clearTimeout(_recoveryTimer);
+      log('rtc_restart',{},'warn');
+      setCallPhase('call_degraded','pc_failed');
+      runRecovery('pc_failed');
+    }
+  };
+  pc.ontrack=function(e){
+    log('rtc_track',{kind:e.track.kind,state:e.track.readyState},'ok');
+    if(!remoteStream)remoteStream=new MediaStream();
+    if(e.streams&&e.streams[0]){
+      e.streams[0].getTracks().forEach(function(track){
+        if(!remoteStream.getTracks().some(function(x){return x.id===track.id}))remoteStream.addTrack(track);
+        bindRemoteTrackState(track);
+      });
+    }else if(e.track){
+      if(!remoteStream.getTracks().some(function(x){return x.id===e.track.id}))remoteStream.addTrack(e.track);
+      bindRemoteTrackState(e.track);
+    }
+    refreshRemoteVideo();
+  };
+}
+
+async function flushPendingCandidates(){
+  while(pendingCandidates.length){
+    var c=pendingCandidates.shift();
+    try{await pc.addIceCandidate(c);log('rtc_ice_flushed',{},'ok')}catch(_){}
+  }
+}
+
+async function handleSig(d){
+  if(!d.signal)return;
+  try{
+    if(d.signal.description){
+      var desc=d.signal.description;
+      if(desc.type==='offer'){
+        if(pc&&pc.connectionState==='connected'){log('rtc_offer_skip',{state:pc.connectionState});return;}
+        if(pc&&pc.connectionState!=='closed'&&pc.connectionState!=='failed'){try{pc.close()}catch(_){}pc=null;remoteStream=null;pendingCandidates=[];savedCandidates=[];}
+        if(!pc)await setupPC();
+        await pc.setRemoteDescription(desc);
+        await flushPendingCandidates();
+        await pc.setLocalDescription(await pc.createAnswer());
+        relaySend({type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}});
+        $('solo-banner').style.display='none';
+        log('rtc_answered',{},'ok');
+      }else if(desc.type==='answer'){
+        await pc.setRemoteDescription(desc);
+        await flushPendingCandidates();
+        savedOffer=null;
+        log('rtc_got_answer',{},'ok');
+      }
+    }else if(d.signal.candidate){
+      var c=d.signal.candidate||{};
+      var cKey=[c.sdpMid||'',c.sdpMLineIndex==null?'':c.sdpMLineIndex,String(c.candidate||'')].join('|');
+      if(_seenRemoteCand.has(cKey)){log('rtc_ice_dupe_drop',{},'warn');return;}
+      _seenRemoteCand.add(cKey);
+      if(!pc||!pc.remoteDescription){
+        pendingCandidates.push(c);
+        log('rtc_ice_queued',{n:pendingCandidates.length});
+      }else{
+        try{await pc.addIceCandidate(c);log('rtc_ice_added',{type:c.type||'?'});}catch(e){log('rtc_ice_add_err',{e:String(e)},'error');}
+      }
+    }
+  }catch(e){log('rtc_sig_err',{e:String(e)},'error')}
+}
+
+// === DEEPGRAM STT ===
+function isCallActive(){return !!(room.id&&$('call-screen').classList.contains('active'))}
+function isDupe(text){
+  var now=Date.now();recentFinals=recentFinals.filter(function(f){return now-f.t<DEDUP_MS});
+  var lo=normalizeText(text,'compare');
+  for(var i=0;i<recentFinals.length;i++){var p=recentFinals[i].s;if(p===lo)return true;if(p.length>5&&lo.length>5&&(p.indexOf(lo)>=0||lo.indexOf(p)>=0))return true}
+  return false;
+}
+function recFinal(t){recentFinals.push({s:normalizeText(t,'compare'),t:Date.now()});if(recentFinals.length>DEDUP_MAX)recentFinals.shift()}
+function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim()}
+
+function onDGFinal(text){
+  text=normalizeText(stripDGTags(text),'speech');if(!text)return;
+  text=text.replace(/([\u0E34-\u0E37\u0E40-\u0E44]) ([\u0E00-\u0E7F])/g,'$1$2').replace(/([\u0E00-\u0E7F]) ([\u0E30-\u0E37\u0E47-\u0E4E])/g,'$1$2');
+  text=applyNorthernThaiMap(text);if(!text)return;
+  if(isDupe(text)){log('dg_dedup',{t:text.slice(0,40)},'warn');return}
+  recFinal(text);log('dg_final',{t:text.slice(0,60)},'ok');
+  var src=room.myLang,tgt=room.theirLang,ss=++localSubSeq;
+  showSub(text,'mine');
+  log('norm_start',{ss:ss,src:src,tgt:tgt,ft_ready:_ftReady,text:text.slice(0,60)});
+  var _ftWon=false;
+  Promise.race([
+    _detectLangAsync(text).then(function(d){_ftWon=true;return d;}),
+    new Promise(function(res){setTimeout(function(){
+      if(!_ftWon)log('norm_timeout',{ft_ready:_ftReady,ft_failed:_ftLoadFailed,fallback:src},'warn');
+      res(detectLang(text,src));
+    },150);})
+  ]).then(function(detected){
+    log('norm_detect',{detected:detected||'(none)',src:src,needs_norm:!!(detected&&detected!==src),via:_ftWon?'wasm':'stub'});
+    if(detected&&detected!==src){
+      log('norm_step',{from:detected,to:src,text:text.slice(0,60)});
+      return translateWithRetry(text,detected,src,2);
+    }
+    return Promise.resolve(text);
+  }).then(function(srcText){
+    srcText=normalizeText(srcText,'speech')||text;
+    log('norm_result',{srcText:srcText.slice(0,60),ss:ss});
+    relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});
+    addTr('me',srcText,srcText,src,tgt,ss);
+    return translateWithRetry(srcText,src,tgt,2).then(function(tr){
+      tr=normalizeText(tr,'speech')||srcText;
+      log('trans_result',{from:src,to:tgt,tr:tr.slice(0,60),ss:ss},'ok');
+      relaySend({type:'subtitle-update',subtitleSeq:ss,text:tr,sourceText:srcText,sourceLang:src,targetLang:tgt});
+      patchTr('me',ss,tr,src,tgt);
+    });
+  }).catch(function(e){log('dg_trans_err',{e:String(e),ss:ss},'error');});
+}
+
+function stopDGAudio(){
+  if(dgProc)try{dgProc.disconnect();}catch(_){}dgProc=null;
+  if(dgSrc)try{dgSrc.disconnect();}catch(_){}dgSrc=null;
+  if(dgAudioCtx)try{dgAudioCtx.close();}catch(_){}dgAudioCtx=null;
+}
+function stopDeepgram(){
+  _stopDgWatchdog();
+  dgActive=false;if(dgWs){try{dgWs.close()}catch(_){}dgWs=null;}stopDGAudio();log('dg_stopped',{});
+}
+function startDeepgram(){
+  var key=(($('dg-key')&&$('dg-key').value)||inviteDgKey||localStorage.getItem('tb_dg_key')||'').trim();
+  if(!key){toast('Deepgram key missing');return}
+  if(!inviteDgKey&&key)localStorage.setItem('tb_dg_key',key);
+  if(dgActive){log('dg_skip_active',{},'warn');return;}
+  if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'warn');return;}
+  if(!videoStream){log('dg_no_stream',{},'error');return}
+  if(micMutedByUser){log('dg_skip_muted',{},'warn');return;}
+  var langCode=DG_LANGS[room.myLang]||room.myLang||'en-US';
+  log('dg_lang_select',{role:role,myLang:room.myLang,theirLang:room.theirLang,dgLang:langCode});
+  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=false&endpointing=400';
+  var captureEpoch=sessionEpoch;
+  dgWs=new WebSocket(url,['token',key]);
+  dgWs.onopen=function(){
+    if(captureEpoch!==sessionEpoch||!dgDesired||micMutedByUser){log('dg_open_stale',{captureEpoch:captureEpoch,current:sessionEpoch},'warn');try{dgWs.close();}catch(_){}return;}
+    log('dg_open',{lang:langCode},'ok');
+    try{
+      var audioTracks=(videoStream?videoStream.getAudioTracks():[]).filter(function(t){return t.readyState==='live'&&t!==_silentAudioTrack;});
+      if(!audioTracks.length){log('dg_no_audio',{},'error');dgWs.close();return;}
+      var dgStream=new MediaStream(audioTracks);
+      dgAudioCtx=new(window.AudioContext||window.webkitAudioContext)({sampleRate:16000});
+      dgSrc=dgAudioCtx.createMediaStreamSource(dgStream);
+      var silentGain=dgAudioCtx.createGain();silentGain.gain.value=0;silentGain.connect(dgAudioCtx.destination);
+      function _setupScriptProc(){
+        dgProc=dgAudioCtx.createScriptProcessor(4096,1,1);
+        dgProc.onaudioprocess=function(e){
+          if(!dgWs||dgWs.readyState!==1)return;
+          var f=e.inputBuffer.getChannelData(0);
+          var b=new Int16Array(f.length);
+          for(var i=0;i<f.length;i++){var s=Math.max(-1,Math.min(1,f[i]));b[i]=s<0?s*0x8000:s*0x7FFF;}
+          dgWs.send(b.buffer);
+        };
+        dgSrc.connect(dgProc);dgProc.connect(silentGain);
+        dgActive=true;log('dg_scriptproc_active',{},'warn');
+      }
+      if(dgAudioCtx.audioWorklet&&typeof AudioWorkletNode!=='undefined'){
+        var _wblob=new Blob([DG_WORKLET_CODE],{type:'application/javascript'});
+        var _wurl=URL.createObjectURL(_wblob);
+        dgAudioCtx.audioWorklet.addModule(_wurl).then(function(){
+          URL.revokeObjectURL(_wurl);
+          if(!dgWs||dgWs.readyState!==1)return;
+          var _wnode=new AudioWorkletNode(dgAudioCtx,'tb-audio-capture');
+          _wnode.port.onmessage=function(ev){
+            if(!dgWs||dgWs.readyState!==1)return;
+            var f=ev.data;var b=new Int16Array(f.length);
+            for(var i=0;i<f.length;i++){var s=Math.max(-1,Math.min(1,f[i]));b[i]=s<0?s*0x8000:s*0x7FFF;}
+            dgWs.send(b.buffer);
+          };
+          dgSrc.connect(_wnode);_wnode.connect(silentGain);
+          dgProc=_wnode;dgActive=true;log('dg_worklet_active',{},'ok');
+        }).catch(function(e){
+          URL.revokeObjectURL(_wurl);
+          log('worklet_fallback',{e:String(e)},'warn');
+          toast('Audio: legacy processor active');
+          _setupScriptProc();
+        });
+      }else{
+        _setupScriptProc();
+      }
+    }catch(e){log('dg_audio_err',{e:String(e)},'error');dgActive=false;}
+  };
+  dgWs.onmessage=function(e){
+    _dgLastMsg=Date.now();
+    try{
+      var d=JSON.parse(e.data);
+      var alt=d.channel&&d.channel.alternatives&&d.channel.alternatives[0];
+      if(alt&&alt.transcript&&d.is_final)onDGFinal(alt.transcript);
+    }catch(_){}
+  };
+  dgWs.onerror=function(){log('dg_error',{},'error')};
+  dgWs.onclose=function(ev){
+    log('dg_close',{code:ev.code,captureEpoch:captureEpoch,current:sessionEpoch},'warn');
+    dgActive=false;stopDGAudio();_stopDgWatchdog();
+    if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+      setTimeout(function(){
+        if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+          reconcileDeepgramState('dg_onclose_retry');
+        }
+      },2000);
+    }
+  };
+  // Watchdog: if DG goes silent (no WS messages) during a live call, restart it
+  _dgLastMsg=Date.now();
+  _stopDgWatchdog();
+  _dgWatchdogTimer=setInterval(function(){
+    if(!dgActive||!dgDesired||micMutedByUser||captureEpoch!==sessionEpoch){_stopDgWatchdog();return;}
+    if(Date.now()-_dgLastMsg>DG_WATCHDOG_MS){
+      log('dg_watchdog_restart',{silent_ms:Date.now()-_dgLastMsg},'warn');
+      stopDeepgram();
+      setTimeout(function(){
+        if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+          reconcileDeepgramState('dg_watchdog');
+        }
+      },1000);
+    }
+  },5000);
+}
+function _stopDgWatchdog(){clearInterval(_dgWatchdogTimer);_dgWatchdogTimer=null;}
+
+function showSub(text,cls){
+  var a=$('subtitle-area'),el=document.createElement('div');
+  el.className='subtitle-line '+cls;el.textContent=text;a.appendChild(el);
+  while(a.children.length>2)a.children[0].remove();
+  setTimeout(function(){if(el.parentNode)el.remove()},SUB_LINGER);
+}
+
+function addTr(who,src,tr,sL,tL,ss){
+  src=normalizeText(src,'speech');tr=normalizeText(tr,'speech');if(!src&&!tr)return;if(!tr)tr=src;
+  if(ss){for(var j=transcript.length-1;j>=0;j--){if(transcript[j].who===who&&transcript[j].subtitleSeq===ss){transcript[j].sourceText=src;transcript[j].translatedText=tr;transcript[j].ts=Date.now();saveTr();renderTr();return;}}}
+  var prev=transcript.length?transcript[transcript.length-1]:null;
+  if(!ss&&prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;
+  var entry={id:(ss?('sp-'+(who==='me'?'m'+_ssNonce:'p')+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
+  transcript.push(entry);if(transcript.length>MAX_TR)transcript.splice(0,transcript.length-MAX_TR);
+  saveTr();appendTrDom(entry);
+  if(transcriptTtsOn&&who==='partner'&&tr&&!ss)speakText(tr,tL||room.myLang);
+}
+function patchTr(who,ss,newTr,sL,tL){
+  newTr=normalizeText(newTr,'speech');if(!newTr)return;
+  for(var i=transcript.length-1;i>=0;i--){
+    if(transcript[i].who===who&&transcript[i].subtitleSeq===ss){
+      if(normalizeText(transcript[i].translatedText,'compare')===normalizeText(newTr,'compare'))return;
+      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();
+      replaceTrDomById(transcript[i].id,transcript[i]);
+      if(transcriptTtsOn&&who==='partner'&&newTr)speakText(newTr,tL||room.myLang);
+      return;
+    }
+  }
+  addTr(who,newTr,newTr,sL,tL,ss);
+}
+function renderMd(txt){
+  if(!txt)return'';
+  var s=txt.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  s=s.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
+  s=s.replace(/\*(.+?)\*/g,'<em>$1</em>');
+  s=s.replace(/--([^|]+)\|([^-]+)--/g,'<a href="$2" target="_blank" rel="noopener" style="color:var(--teal-bright)">$1</a>');
+  s=s.replace(/(https?:\/\/[^\s<]+)/g,'<a href="$1" target="_blank" rel="noopener" style="color:var(--teal-bright)">$1</a>');
+  s=s.replace(/\n/g,'<br>');
+  return s;
+}
+function trHtml(e){
+  var srcLang=e.srcLang||(e.who==='me'?room.myLang:room.theirLang)||'en';
+  var tgtLang=e.tgtLang||(e.who==='me'?room.theirLang:room.myLang)||'en';
+  var locale=TTS_LOCALE[srcLang]||'en-US';
+  var ts=new Date(e.ts).toLocaleTimeString(locale,{hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  var speaker=e.who==='me'?L('you_word'):L('partner_word');
+  var srcText=e.sourceText||'';var tgtText=e.translatedText||srcText;
+  var isMine=e.who==='me';
+  var leftText,rightText,leftLang,rightLang;
+  if(isMine){leftText=srcText;rightText=tgtText;leftLang=srcLang;rightLang=tgtLang;}
+  else{leftText=tgtText;rightText=srcText;leftLang=tgtLang;rightLang=srcLang;}
+  var attachHtml='';
+  if(e.attachment&&e.attachment.dataUrl){
+    var att=e.attachment;var eid=e.id||'';var isImg=/^image\//.test(att.type||'');
+    if(!_attCache[eid])_attCache[eid]=att;
+    var imgPreview=isImg?'<img src="'+att.dataUrl+'" style="max-width:100%;max-height:120px;border-radius:6px;margin-top:4px;display:block;cursor:pointer;" onclick="attModalOpenById(\''+eid+'\')">':'';
+    attachHtml='<div style="margin-top:6px;">'
+      +'<div style="display:flex;align-items:center;gap:6px;">'
+      +'<a href="#" onclick="attModalOpenById(\''+eid+'\');return false;" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;text-decoration:underline;">'+ICO.clip+' '+esc(att.name||'file')+'</a>'
+      +(isMine?'<button onclick="removeTrEntry(\''+eid+'\');" style="background:none;border:none;cursor:pointer;color:#c4ccd4;padding:0;line-height:0;opacity:.7;" title="Remove"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg></button>':'')
+      +'</div>'+imgPreview+'</div>';
+  }
+  var chatClass=e.type==='chat'?' is-chat':'';
+  return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
+    +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
+    +'<div class="tr-body">'
+    +'<div class="tr-col"><div class="tr-text">'+(e.type==='chat'?renderMd(leftText):esc(leftText))+attachHtml+'</div>'
+    +'<div style="display:flex;gap:5px;align-items:center;">'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
+    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(leftText)+'" title="'+esc(L('use_word',leftLang))+'">'+esc(L('use_word',leftLang))+'</button>'
+    +'</div></div>'
+    +'<div class="tr-divider"></div>'
+    +'<div class="tr-col source"><div class="tr-text">'+(e.type==='chat'?renderMd(rightText):esc(rightText))+'</div>'
+    +'<div style="display:flex;gap:5px;align-items:center;">'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
+    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(rightText)+'" title="'+esc(L('use_word',rightLang))+'">'+esc(L('use_word',rightLang))+'</button>'
+    +'</div></div>'
+    +'</div></div></div>';
+}
+function appendTrDom(entry){
+  var b=$('transcript-body');if(!b)return;
+  var em=b.querySelector('.tr-empty');if(em)em.remove();
+  var wrap=document.createElement('div');
+  wrap.innerHTML=trHtml(entry);
+  var eid=entry.id||(entry.ts+'_'+entry.who);
+  wrap.firstChild.dataset.trId=eid;
+  b.insertBefore(wrap.firstChild,b.firstChild);
+  checkAutoScroll();
+}
+function replaceTrDomById(id,entry){
+  var b=$('transcript-body');if(!b||!id)return;
+  var old=b.querySelector('[data-tr-id="'+id+'"]');
+  if(!old){appendTrDom(entry);return;}
+  var wrap=document.createElement('div');
+  wrap.innerHTML=trHtml(entry);
+  var fresh=wrap.firstChild;
+  fresh.dataset.trId=id;
+  old.replaceWith(fresh);
+}
+function renderTr(){
+  var b=$('transcript-body');if(!b)return;
+  if(!transcript.length){b.innerHTML='<div class="tr-empty">Speak or type to see transcript here.</div>';setTranscriptMore(false);return}
+  var existing=Array.from(b.querySelectorAll('.tr-entry'));
+  var existingIds=new Set(existing.map(function(el){return el.dataset.trId;}));
+  var toRender=transcript.slice(-120).slice().reverse();
+  var newHtml='';
+  for(var i=0;i<toRender.length;i++){
+    var e=toRender[i];var eid=e.id||(e.ts+'_'+e.who);
+    if(!existingIds.has(eid)){var wrap=document.createElement('div');wrap.innerHTML=trHtml(e);wrap.firstChild.dataset.trId=eid;newHtml+=wrap.innerHTML;}
+  }
+  if(newHtml){var em=b.querySelector('.tr-empty');if(em)em.remove();b.insertAdjacentHTML('afterbegin',newHtml);}
+  while(b.children.length>120){b.lastChild.remove();}
+  setTranscriptMore(false);
+}
+
+function checkAutoScroll(){
+  var c=$('call-transcript');
+  if(transcriptNearBottom()){c.scrollTop=0;setTranscriptMore(false)}else{setTranscriptMore(true)}
+}
+function transcriptNearBottom(){var c=$('call-transcript');if(!c)return true;return c.scrollTop<100;}
+function setTranscriptMore(show){var ind=$('transcript-more-indicator');if(!ind)return;if(show)ind.classList.add('show');else ind.classList.remove('show');}
+function scrollToBottom(){var c=$('call-transcript');if(c){c.scrollTop=0;setTranscriptMore(false)}}
+
+function copyTr(){
+  if(!transcript.length){toast('No transcript');return}
+  var t=transcript.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText&&e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\n');
+  if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')});
+}
+function exportTxt(){
+  if(!transcript.length){toast('No transcript');return}
+  var _uid=function(){return Date.now().toString(36)+Math.random().toString(36).slice(2,8);};
+  var catId='tb-'+Date.now().toString(36);
+  var sessionName=(room.name||'TalkBridge')+' '+new Date().toLocaleDateString();
+  var cards=transcript.filter(function(e){return e.sourceText&&e.translatedText&&e.sourceText!==e.translatedText;}).map(function(e){
+    return {id:'c-'+_uid(),catalogIds:[catId],sourceLang:e.srcLang||'en',targetLang:e.tgtLang||'en',source:e.sourceText,target:e.translatedText,notes:'',tags:e.type==='chat'?['chat']:['speech'],backtranslate:{sourceLang:e.tgtLang||'en',targetLang:e.srcLang||'en',inputText:e.translatedText,resultText:'',verdict:'',contentHash:'',updatedAt:e.ts},clarifyChain:[],savedBy:e.who==='me'?'You':'Partner',createdAt:e.ts,updatedAt:e.ts};
+  });
+  if(!cards.length){toast('No translated content to export');return}
+  var payload={type:'phrasebook',cards:cards,catalogs:[{id:catId,name:sessionName,emoji:'\uD83C\uDFA4',desc:'Exported from TalkBridge',lang:room.myLang||'en',createdAt:Date.now()}],tags:['speech','chat'],exportedAt:Date.now()};
+  var blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'});
+  var u=URL.createObjectURL(blob);var a=document.createElement('a');a.href=u;a.download='talkbridge-'+new Date().toISOString().slice(0,10)+'.json';a.click();setTimeout(function(){URL.revokeObjectURL(u)},0);
+  toast('Exported '+cards.length+' phrases');
+}
+
+function _makeSilentTrack(){
+  try{
+    _cleanupSilentAudioHelper();
+    var ctx=new AudioContext();
+    var dst=ctx.createMediaStreamDestination();
+    var osc=ctx.createOscillator();
+    osc.frequency.value=0;
+    osc.connect(dst);
+    osc.start();
+    var t=dst.stream.getAudioTracks()[0]||null;
+    _silentAudioCtx=ctx;_silentOsc=osc;_silentAudioTrack=t;
+    return t;
+  }catch(_){
+    _cleanupSilentAudioHelper();
+    return null;
+  }
+}
+
+// Phase 4: toggleMic with intent tracking
+async function toggleMic(){
+  if(_micToggleInFlight)return;
+  _micToggleInFlight=true;
+  try{
+    micOn=!micOn;
+    if(!videoStream)return;
+    if(!micOn){
+      micMutedByUser=true;dgDesired=false;
+      relaySend({type:'mic-state',micOn:false});
+      stopDeepgram();
+      videoStream.getAudioTracks().forEach(function(t){try{videoStream.removeTrack(t);}catch(_){} if(t!==_silentAudioTrack)try{t.stop();}catch(_){};});
+      if(!_silentAudioTrack||_silentAudioTrack.readyState==='ended')_silentAudioTrack=_makeSilentTrack();
+      if(_silentAudioTrack){
+        videoStream.addTrack(_silentAudioTrack);
+        if(pc){
+          var sndMute=pc.getSenders().find(function(s){return s.track&&s.track.kind==='audio';});
+          if(sndMute){
+            log('replaceTrack_start',{phase:'mute'});
+            try{await sndMute.replaceTrack(_silentAudioTrack);log('replaceTrack_ok',{phase:'mute'});}catch(err){log('replaceTrack_fail',{phase:'mute',err:String(err)});}
+          }
+        }
+      }else{log('silent_track_unavailable',{});}
+      log('mic_muted',{});
+    }else{
+      var ms=null;var newTrack=null;
+      try{
+        ms=await navigator.mediaDevices.getUserMedia({audio:getMicConstraints()});
+        newTrack=ms.getAudioTracks()[0];
+        if(!newTrack)throw new Error('missing_audio_track');
+        if(pc){
+          var sndUnmute=pc.getSenders().find(function(s){return s.track&&(s.track.kind==='audio'||s.track.readyState==='ended');});
+          if(sndUnmute){
+            log('replaceTrack_start',{phase:'unmute'});
+            await sndUnmute.replaceTrack(newTrack);
+            log('replaceTrack_ok',{phase:'unmute'});
+          }
+        }
+        if(_silentAudioTrack){try{videoStream.removeTrack(_silentAudioTrack);}catch(_){}}
+        _cleanupSilentAudioHelper();
+        videoStream.getAudioTracks().forEach(function(t){ if(t!==newTrack){try{videoStream.removeTrack(t);}catch(_){} try{t.stop();}catch(_){}} });
+        videoStream.addTrack(newTrack);
+        micMutedByUser=false;dgDesired=true;
+        relaySend({type:'mic-state',micOn:true});
+        log('mic_unmuted',{});
+        log('dg_reactivate_intent',{why:'unmute'});
+        reconcileDeepgramState('unmute');
+      }catch(err){
+        if(newTrack)try{newTrack.stop();}catch(_){}
+        if(ms)ms.getTracks().forEach(function(t){if(t!==newTrack)try{t.stop();}catch(_){};});
+        micOn=false;micMutedByUser=true;dgDesired=false;
+        stopDeepgram();
+        log('replaceTrack_fail',{phase:'unmute',err:String(err)});
+        toast('Mic unavailable');
+      }
+    }
+  }finally{
+    syncMic();
+    _micToggleInFlight=false;
+  }
+}
+
+function toggleCam(){
+  if(!videoStream)return;camOn=!camOn;
+  videoStream.getVideoTracks().forEach(function(t){t.enabled=camOn});
+  syncCam();relaySend({type:'cam-state',camOn:camOn});
+}
+
+// Phase 2: rejoinCall — role-aware routing
+function rejoinCall(){
+  $('thankyou-page').classList.remove('show');
+  var role=lastSessionContext.role||(_pendingJoin?'joiner':'creator');
+  if(role==='joiner'&&_pendingJoin){
+    setCallPhase('prejoin','rejoin_joiner');
+    $('joiner-landing').classList.add('show');
+  }else{
+    setCallPhase('idle','rejoin_creator');
+    $('lobby').classList.remove('hidden');
+    setLS(LS.setup);
+  }
+}
+
+// Phase 7: showThankYou uses teardownSession
+function showThankYou(msg){
+  var savedRole=room.role;
+  var ty_lang=((_pendingJoin&&_pendingJoin.tl)||room.myLang||'en');
+  teardownSession('to_thankyou',msg||'local_end');
+  room.id=null;room.role=null;
+  setCallPhase('postcall_joiner','show_thankyou');
+  $('call-screen').classList.remove('active');
+  var t=$('thankyou-title'),s=$('thankyou-sub'),lp=$('thankyou-lang-pill');
+  if(t)t.textContent=msg||L('thanks',ty_lang);
+  if(s)s.textContent=L('close_tab',ty_lang);
+  if(lp)lp.textContent=_pendingJoin&&_pendingJoin.tl?gL(_pendingJoin.tl).flag:(ty_lang?gL(ty_lang).flag:'');
+  $('thankyou-page').classList.add('show');
+  history.replaceState({tbView:'thankyou'},'',location.pathname);
+  var rb=$('thankyou-rejoin-btn');if(rb&&_pendingJoin){rb.style.display='';rb.textContent=L('rejoin',ty_lang);}
+  var dl=$('thankyou-dl-btn');if(dl)dl.textContent=L('dl_transcript',ty_lang);
+  try{window.close();}catch(_){}
+}
+
+// Phase 7: showHostLeftCountdown uses teardownSession
+function showHostLeftCountdown(){
+  var ty_lang=((_pendingJoin&&_pendingJoin.tl)||room.myLang||'en');
+  teardownSession('to_host_left_countdown','host_ended');
+  room.id=null;room.role=null;
+  setCallPhase('postcall_joiner','host_left');
+  $('call-screen').classList.remove('active');
+  var n=5,t=$('thankyou-title'),s=$('thankyou-sub'),lp=$('thankyou-lang-pill');
+  if(t)t.textContent='Host ended the call.';
+  if(s)s.textContent=L('close_tab',ty_lang);
+  if(lp)lp.textContent=_pendingJoin&&_pendingJoin.tl?gL(_pendingJoin.tl).flag:(ty_lang?gL(ty_lang).flag:'');
+  var rb=$('thankyou-rejoin-btn');if(rb&&_pendingJoin){rb.style.display='';rb.textContent=L('rejoin',ty_lang);}
+  var dl=$('thankyou-dl-btn');if(dl)dl.textContent=L('dl_transcript',ty_lang);
+  if(s)s.textContent=L('close_tab',ty_lang);
+  $('thankyou-page').classList.add('show');
+  history.replaceState({tbView:'thankyou'},'',location.pathname);
+  var iv=setInterval(function(){n--;if(t)t.textContent=n>0?'Host ended the call. Closing in '+n+'s…':'Host ended the call.';if(n<=0){clearInterval(iv);try{window.close();}catch(_){}}},1000);
+}
+
+function downloadThankyouLog(){
+  var t=debugLog.map(function(r){return r.ts+' ['+r.ev+'] '+JSON.stringify(r.d)}).join('\n');
+  var blob=new Blob([t],{type:'text/plain'});var u=URL.createObjectURL(blob);var a=document.createElement('a');
+  a.href=u;a.download='talkbridge-log-'+new Date().toISOString().slice(0,10)+'.txt';a.click();setTimeout(function(){URL.revokeObjectURL(u)},0);
+}
+function showPartnerDisconnected(msg){
+  var ov=$('partner-disconnected-overlay'),lbl=$('partner-disconnected-label'),sub=$('partner-disconnected-sub');
+  if(!ov)return;
+  if(lbl)lbl.textContent=msg||L('disconnected');
+  if(sub)sub.textContent=L('waiting');
+  ov.classList.add('show');
+}
+function hidePartnerDisconnected(){
+  var ov=$('partner-disconnected-overlay');if(ov)ov.classList.remove('show');
+  var rco=$('remote-cam-off');if(rco)rco.classList.remove('show');
+}
+
+// Phase 2: hangUp — role-split enforced
+function hangUp(){
+  relaySend({type:'hangup'});
+  if(room.role==='creator'){
+    cleanUp();
+  }else{
+    showThankYou('You ended the call.');
+  }
+}
+
+// Phase 7: cleanUp uses teardownSession
+function cleanUp(){
+  var _ci=$('chat-input');if(_ci){_ci.value='';_ci.style.height='';}
+  teardownSession('to_lobby','cleanup');
+  recentFinals=[];
+  _chatOutbox.clear();_chatReceived.clear();
+  room.id=null;room.role=null;
+  setCallPhase('idle','cleanup_done');
+  $('call-screen').classList.remove('active');
+  $('lobby').classList.remove('hidden');setLS(LS.setup);
+  $('subtitle-area').innerHTML='';$('no-video-msg').style.display='';hidePartnerDisconnected();hideReconnectBanner();_relayFailCount=0;
+  $('partner-speaking-indicator').classList.remove('show');clearTimeout(partnerSpeakTimer);
+  $('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);syncTranscriptToggleButton();
+  transcriptTtsOn=false;syncTranscriptTtsButton();if(window.speechSynthesis)window.speechSynthesis.cancel();
+  document.querySelector('.call-videos').classList.remove('swapped');
+  resetRemoteMediaState();
+  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();
+}
+
+// === INIT ===
+if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem('tb_dg_key').trim();$('dg-key').value=_sk;setDgKeyStatus('Verifying saved key…','#f39c12');verifyDgKey(_sk);}
+if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
+if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
+if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
+log('startup',{v:'Omega',ua:navigator.userAgent.slice(0,80)});
+pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();_syncFtStatus();
+$('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
+$('call-transcript').addEventListener('click',function(ev){
+  var tts=ev.target.closest('.tr-tts');
+  if(tts){speakText(tts.getAttribute('data-tts-text')||'',tts.getAttribute('data-tts-lang')||room.myLang||'en');return;}
+  var use=ev.target.closest('.tr-use-ico');
+  if(use){var ci=$('chat-input');if(ci){ci.value=use.getAttribute('data-use-text')||'';ci.dispatchEvent(new Event('input'));}}
+});
+$('local-video').addEventListener('click',swapVideos);
+$('remote-video').addEventListener('click',swapVideos);
+$('remote-video').addEventListener('loadedmetadata',refreshRemoteVideo);
+var hp=new URLSearchParams((location.hash||'').replace(/^#/,''));var inv=hp.get('j');if(inv){var p=decInv(inv);if(p&&p.r)handleHash(p)}
+var _pipActive=false;
+function _pipOverlayFallback(){
+  if(_pipActive)return;_pipActive=true;
+  var po=$('pip-overlay');
+  var rv=$('remote-video');var lv=$('local-video');
+  var pr=$('pip-remote');var pl=$('pip-local');
+  if(rv&&rv.srcObject&&pr){pr.srcObject=rv.srcObject;pr.play().catch(function(){});}
+  if(lv&&lv.srcObject&&pl){pl.srcObject=lv.srcObject;pl.play().catch(function(){});}
+  if(po)po.classList.add('show');
+  $('call-screen').style.display='none';
+}
+function pipEnter(){
+  if(_pipActive)return;
+  var rv=$('remote-video');
+  if(rv&&document.pictureInPictureEnabled&&!document.pictureInPictureElement){
+    rv.requestPictureInPicture().then(function(){
+      _pipActive=true;
+      $('call-screen').style.display='none';
+    }).catch(function(){_pipOverlayFallback();});
+  } else {
+    _pipOverlayFallback();
+  }
+}
+function pipExpand(){
+  if(document.pictureInPictureElement){
+    document.exitPictureInPicture().catch(function(){});
+    return; // leavepictureinpicture listener restores screen
+  }
+  if(!_pipActive)return;_pipActive=false;
+  var po=$('pip-overlay');if(po)po.classList.remove('show');
+  $('call-screen').style.display='';
+}
+function pipClose(){
+  if(document.pictureInPictureElement){
+    document.exitPictureInPicture().catch(function(){});
+  }
+  _pipActive=false;
+  var po=$('pip-overlay');if(po)po.classList.remove('show');
+  $('call-screen').style.display='';
+  hangUp();
+}
+document.getElementById('remote-video').addEventListener('leavepictureinpicture',function(){
+  if(!_pipActive)return;
+  _pipActive=false;
+  $('call-screen').style.display='';
+  // Re-push so back button still works next time
+  if(lobbyState===LS.call)history.pushState({tbView:'call'},'',location.href);
+});
+window.addEventListener('popstate',function(){
+  var tyShowing=$('thankyou-page')&&$('thankyou-page').classList.contains('show');
+  var jlShowing=$('joiner-landing')&&$('joiner-landing').classList.contains('show');
+  if(tyShowing||jlShowing){history.pushState({},'',location.pathname);return;}
+  if(lobbyState===LS.call){
+    // Back during call → PiP mode, re-push so back again works
+    pipEnter();
+    history.pushState({tbView:'call'},'',location.href);
+    return;
+  }
+});
+window.addEventListener('visibilitychange',function(){
+  if(!document.hidden&&isCallActive())reconcileDeepgramState('visibility_restore');
+});
+window.addEventListener('pagehide',function(){stopDeepgram();if(room.id){saveTr();relaySend({type:'hangup',reason:'pagehide'})}});
+</script>
+</body>
+</html>

--- a/bridge-codex-v2.html
+++ b/bridge-codex-v2.html
@@ -1,0 +1,2993 @@
+<!DOCTYPE html>
+<!-- talkbridge · dcr · v2.0 -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+<title>TalkBridge</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Lora:wght@500;600&display=swap" rel="stylesheet">
+<style>
+*{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent;}
+:root{
+  --bg:#0a0a0a;--surface:#161616;--surface2:#222;
+  --teal:#2E8B8B;--teal-bright:#3FC1C1;
+  --text:#e8e4df;--text-dim:#888;--text-muted:#555;
+  --red:#e74c3c;--green:#2ecc71;
+  --radius:14px;
+}
+html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans",sans-serif;color:var(--text);}
+.lobby{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:0;z-index:10;background:var(--bg);transition:opacity .3s;overflow:hidden;}
+.lobby.hidden{opacity:0;pointer-events:none;}
+.lobby-card{width:min(100%,420px);height:100dvh;max-height:100dvh;display:flex;flex-direction:column;gap:0;overflow:hidden;padding:16px 20px 0;}
+.lobby-brand{font-family:"DM Sans",sans-serif;font-size:15px;font-weight:700;color:var(--teal-bright);text-align:left;letter-spacing:0;padding:14px 0 2px;}
+.lobby-sub{font-size:13px;color:var(--text-dim);text-align:center;margin-top:-8px;}
+.lobby-label{font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.6px;margin-bottom:-8px;}
+.lobby-input{width:100%;background:var(--surface);color:var(--text);border:1.5px solid var(--surface2);border-radius:10px;padding:12px 14px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;}
+.lobby-input:focus{border-color:var(--teal);}
+.lobby-input::placeholder{color:var(--text-muted);}
+.lobby-select{width:100%;background:var(--surface);color:var(--text);border:1.5px solid var(--surface2);border-radius:10px;padding:12px 14px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;-webkit-appearance:none;appearance:none;cursor:pointer;}
+.lobby-select:focus{border-color:var(--teal);}
+.lobby-btn{width:100%;background:var(--teal);color:#fff;border:none;border-radius:12px;padding:14px;font-size:16px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;transition:opacity .15s;margin-top:4px;}
+.lobby-btn:hover{opacity:.85;}
+.lobby-btn:disabled{opacity:.4;cursor:default;}
+.lobby-btn.secondary{background:var(--surface2);color:var(--text);}
+.lobby-btn.secondary:hover{background:var(--teal);color:#fff;opacity:1;}
+.modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:50;display:none;align-items:center;justify-content:center;}
+.modal-backdrop.show{display:flex;}
+.modal-card{background:var(--surface);border-radius:16px;padding:24px 20px;width:min(92vw,360px);display:flex;flex-direction:column;gap:14px;}
+.lobby-link-box{background:var(--surface);border:1.5px solid var(--surface2);border-radius:10px;padding:12px;word-break:break-all;font-size:11px;color:var(--teal-bright);margin-bottom:12px;cursor:pointer;}
+.recent-rooms{margin-top:6px;display:flex;flex-direction:column;gap:8px;}.recent-rooms-scroll{max-height:36dvh;overflow-y:auto;}.recent-item.deleted-room{opacity:.85;border-left:3px solid #c0392b;}.recent-act.restore{color:#2e7d4f;}
+.recent-title{font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.6px;}
+.recent-item{background:var(--surface);border:1px solid var(--surface2);border-radius:10px;padding:10px 12px;}
+.recent-item-top{display:flex;align-items:center;gap:8px;}
+.recent-open{flex:1;min-width:0;background:none;border:none;color:var(--text);text-align:left;cursor:pointer;font:inherit;font-size:14px;font-weight:500;}
+.recent-open small{display:block;color:var(--text-dim);font-size:11px;}
+.recent-actions{display:flex;gap:6px;margin-top:8px;}
+.recent-act{flex:1;background:rgba(255,255,255,.06);color:var(--text-dim);border:none;border-radius:8px;padding:6px;font-size:11px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.recent-act:hover{background:var(--teal);color:#fff;}
+.recent-act.danger{color:var(--red);}
+.recent-act.danger:hover{background:var(--red);color:#fff;}
+.lobby-footer{display:flex;gap:8px;margin-top:4px;}
+.lobby-footer-btn{background:none;border:none;color:var(--text-dim);padding:6px 10px;font-size:18px;cursor:pointer;font-family:"DM Sans",sans-serif;border-radius:8px;line-height:1;}
+.lobby-footer-btn:hover{background:var(--surface2);color:var(--text);}.lobby-footer-btn.active{color:var(--teal-bright);}
+.ft-status-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:20px;background:rgba(255,255,255,.05);font-size:10px;color:var(--text-muted);transition:opacity .4s;}
+.ft-status-pill.ready{opacity:0;pointer-events:none;}
+.ft-status-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0;background:var(--text-muted);}
+.ft-status-dot.loading{background:#f39c12;animation:ftPulse .8s ease-in-out infinite alternate;}
+.ft-status-dot.ok{background:var(--green);}
+.ft-status-dot.err{background:var(--red);}
+@keyframes ftPulse{from{opacity:.35}to{opacity:1}}
+.joining-screen{position:fixed;inset:0;background:var(--bg);z-index:20;display:none;align-items:center;justify-content:center;flex-direction:column;gap:16px;}
+.joining-screen.show{display:flex;}
+.joining-spinner{width:40px;height:40px;border:3px solid var(--surface2);border-top-color:var(--teal-bright);border-radius:50%;animation:spin .8s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg)}}
+.joining-label{font-size:14px;color:var(--text-dim);}
+.log-overlay{position:fixed;inset:0;background:rgba(0,0,0,.96);z-index:50;display:none;flex-direction:column;}
+.log-overlay.show{display:flex;}
+.log-header{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--surface2);flex-shrink:0;gap:8px;flex-wrap:wrap;}
+.log-title{font-family:"Lora",serif;font-size:17px;color:var(--teal-bright);}
+.log-actions{display:flex;gap:6px;flex-wrap:wrap;}
+.log-btn{background:var(--surface2);color:var(--text);border:none;border-radius:8px;padding:7px 12px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.log-btn:hover{background:var(--teal);color:#fff;}
+.log-body{flex:1;overflow-y:auto;padding:10px 16px 20px;font-family:monospace;font-size:11px;line-height:1.7;color:#aaa;}
+.log-row{border-bottom:1px solid rgba(255,255,255,.03);padding:1px 0;}
+.log-row .ts{color:#555;}.log-row .ev{color:var(--teal-bright);}
+.log-row.error .ev{color:#e74c3c;}.log-row.warn .ev{color:#f39c12;}.log-row.ok .ev{color:#2ecc71;}
+.call{position:fixed;inset:0;background:#000;z-index:5;display:none;flex-direction:column;}
+.call.active{display:flex;}
+.vc-btn{width:36px;height:36px;border-radius:50%;border:none;background:rgba(255,255,255,.1);color:#ccc;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .2s;flex-shrink:0;}
+.vc-btn:hover{background:rgba(255,255,255,.18);color:#fff;}
+.vc-btn svg{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;}
+.vc-btn.muted{background:rgba(231,76,60,.25);color:#e74c3c;}
+.vc-btn.end{background:#e74c3c;color:#fff;}
+.vc-btn.end:hover{background:#c0392b;}
+.call-videos{position:relative;background:#000;overflow:hidden;flex:1;min-height:0;}
+#remote-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000;z-index:1;}
+#local-video{position:absolute;top:8px;right:8px;width:min(14%,80px);aspect-ratio:9/16;border-radius:8px;object-fit:cover;transform:scaleX(-1);border:2px solid rgba(255,255,255,.2);box-shadow:0 2px 12px rgba(0,0,0,.5);z-index:3;background:var(--surface);}
+.no-video-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:48px;color:var(--text-muted);z-index:1;}.remote-cam-off{position:absolute;inset:0;background:rgba(0,0,0,.75);z-index:3;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;}.remote-cam-off.show{display:flex;}.remote-mic-off{position:absolute;top:8px;left:8px;z-index:5;background:rgba(0,0,0,.65);border:1px solid rgba(231,76,60,.4);border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;color:#ff6b5b;display:none;align-items:center;gap:4px;backdrop-filter:blur(4px);pointer-events:none;}.remote-mic-off.show{display:flex;}.remote-cam-off-icon{font-size:40px;opacity:.55;}.remote-cam-off-label{color:rgba(255,255,255,.5);font-size:12px;font-weight:600;}.partner-disconnected-overlay{position:absolute;inset:0;background:rgba(0,0,0,.72);z-index:4;display:none;flex-direction:column;align-items:center;justify-content:center;gap:10px;backdrop-filter:blur(6px);}.partner-disconnected-overlay.show{display:flex;}.partner-disconnected-label{color:#fff;font-size:15px;font-weight:600;font-family:"DM Sans",sans-serif;text-align:center;padding:0 24px;}.partner-disconnected-sub{color:rgba(255,255,255,.55);font-size:12px;text-align:center;}.reconnect-banner{position:absolute;top:12px;left:50%;transform:translateX(-50%);background:rgba(231,76,60,.9);color:#fff;border:none;border-radius:20px;padding:8px 18px;font-size:13px;font-weight:700;cursor:pointer;z-index:10;font-family:"DM Sans",sans-serif;display:none;}.reconnect-banner.show{display:block;}
+.solo-banner{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:2;text-align:center;pointer-events:none;}
+.solo-banner-text{background:rgba(0,0,0,.6);color:var(--text-dim);font-size:13px;padding:8px 18px;border-radius:20px;backdrop-filter:blur(6px);}
+.subtitle-area{position:absolute;bottom:0;left:0;right:0;z-index:4;padding:8px 14px 10px;pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:4px;background:linear-gradient(transparent,rgba(0,0,0,.6) 40%);}
+.subtitle-line{max-width:94%;padding:4px 12px;border-radius:6px;font-size:14px;line-height:1.35;text-align:center;word-break:break-word;}
+.subtitle-line.partner{background:rgba(0,0,0,.6);color:#fff;}
+.subtitle-line.mine{background:rgba(46,139,139,.2);color:rgba(255,255,255,.65);font-size:12px;}
+.partner-speaking-indicator{position:absolute;right:12px;bottom:56px;z-index:5;min-width:34px;height:24px;border-radius:999px;background:rgba(0,0,0,.55);border:1px solid rgba(255,255,255,.2);color:#fff;display:none;align-items:center;justify-content:center;font-size:18px;font-weight:700;line-height:1;backdrop-filter:blur(4px);}
+.partner-speaking-indicator.show{display:flex;animation:pulseSpeak .9s ease-in-out infinite alternate;}
+@keyframes pulseSpeak{from{opacity:.55;transform:scale(.98)}to{opacity:1;transform:scale(1.03)}}
+.call-transcript{position:relative;flex:0 0 30%;min-height:0;max-height:45%;overflow-y:auto;background:var(--bg);border-top:1px solid var(--surface2);padding:0 12px;transition:flex-basis .2s ease;}
+.call-transcript-header{display:flex;align-items:center;justify-content:flex-start;padding:6px 4px 6px 2px;position:sticky;top:0;background:var(--bg);z-index:1;gap:6px;}
+.call-transcript-title{font-size:12px;font-weight:700;color:var(--text-dim);letter-spacing:.3px;}
+.call-transcript-actions{display:flex;gap:6px;}
+.call-transcript-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,.06);color:#8f959d;border:1px solid rgba(255,255,255,.14);border-radius:8px;cursor:pointer;padding:0;}
+.call-transcript-btn:hover{background:rgba(255,255,255,.06);color:#b6bcc3;border-color:rgba(255,255,255,.26);}
+.call-transcript-btn svg{width:16px;height:16px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+.call.transcript-collapsed .chevron-down{display:none;}
+.call:not(.transcript-collapsed) .chevron-right{display:none;}
+.transcript-more-indicator{position:absolute;bottom:calc(env(safe-area-inset-bottom) + 60px);right:50%;transform:translateX(50%);z-index:3;min-width:36px;height:36px;border-radius:999px;background:var(--teal);color:#fff;border:2px solid var(--bg);display:none;align-items:center;justify-content:center;font-size:16px;font-weight:700;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);}
+.transcript-more-indicator.show{display:flex;}
+.transcript-more-indicator:hover{background:var(--teal-bright);}
+.call.transcript-collapsed .call-transcript{flex:0 0 32px;max-height:32px;overflow:hidden;}
+.call.transcript-collapsed #transcript-body{display:none;}
+.call-videos.swapped #remote-video{top:8px;right:8px;left:auto;bottom:auto;width:min(14%,80px);height:auto;aspect-ratio:9/16;border-radius:8px;border:2px solid rgba(255,255,255,.2);box-shadow:0 2px 12px rgba(0,0,0,.5);z-index:3;}
+.call-videos.swapped #local-video{inset:0;width:100%;height:100%;border-radius:0;border:none;box-shadow:none;z-index:1;}
+.tr-entry{padding:6px 0;}
+.tr-bubble{border:1px solid rgba(255,255,255,.14);border-radius:12px;overflow:hidden;background:rgba(255,255,255,.02);}
+.tr-bubble.is-chat{border-color:rgba(63,193,193,.25);background:rgba(46,139,139,.08);}
+.tr-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:6px 10px;border-bottom:1px solid rgba(255,255,255,.08);font-size:11px;}
+.tr-who{font-weight:700;color:var(--text-dim);}
+.tr-who.mine{color:var(--teal-bright);}
+.tr-time{font-size:10px;color:var(--text-muted);font-variant-numeric:tabular-nums;}
+.tr-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.tr-col{padding:8px 10px;display:flex;flex-direction:column;gap:6px;min-width:0;}
+.tr-divider{background:rgba(255,255,255,.08);}
+.tr-text{font-size:13px;line-height:1.4;color:var(--text);word-break:break-word;}
+.tr-col.source .tr-text{color:var(--text-dim);}
+.tr-tts{border:none;background:transparent;color:#8f959d;cursor:pointer;padding:0;display:flex;align-items:center;gap:4px;font-size:10px;line-height:1;}
+.tr-tts:hover{color:#c4ccd4;}
+.tr-tts svg{width:13px;height:13px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+.tr-empty{color:var(--text-muted);font-size:12px;font-style:italic;padding:12px 0;}
+.call-controls{display:flex;align-items:center;justify-content:center;gap:14px;padding:8px 16px max(8px,env(safe-area-inset-bottom));background:var(--surface);flex-shrink:0;}
+.ctrl-btn{width:48px;height:48px;border-radius:50%;border:none;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,transform .1s;background:rgba(255,255,255,.1);color:#fff;}
+.ctrl-btn:hover{background:rgba(255,255,255,.18);}
+.ctrl-btn:active{transform:scale(.93);}
+.ctrl-btn.off{background:rgba(231,76,60,.2);color:var(--red);}
+.ctrl-btn.end-call{background:var(--red);color:#fff;width:56px;height:48px;border-radius:24px;}
+.ctrl-btn.end-call:hover{background:#c0392b;}
+#toast{position:fixed;bottom:90px;left:50%;transform:translateX(-50%) translateY(20px);background:rgba(255,255,255,.15);backdrop-filter:blur(12px);color:#fff;font-size:13px;font-weight:600;padding:10px 20px;border-radius:22px;z-index:100;opacity:0;transition:opacity .2s,transform .2s;pointer-events:none;white-space:pre-line;text-align:center;max-width:90vw;}
+#toast.show{opacity:1;transform:translateX(-50%) translateY(0);}
+@media(min-width:768px){
+  .lobby-card{width:420px;}
+  #local-video{width:min(18%,160px);}
+  .call-controls{gap:20px;padding:10px 24px;}
+  .ctrl-btn{width:54px;height:54px;}
+  .ctrl-btn.end-call{width:64px;height:54px;}
+  .subtitle-line{font-size:16px;max-width:80%;}
+  .call-transcript{flex-basis:28%;}
+}
+@media(max-height:500px) and (orientation:landscape){
+  .call-transcript{flex-basis:34%;}
+  #local-video{width:min(16%,90px);top:6px;right:6px;}
+  .call-controls{gap:10px;padding:6px 12px;}
+  .ctrl-btn{width:40px;height:40px;}
+  .ctrl-btn.end-call{width:48px;height:40px;}
+  .subtitle-line{font-size:12px;padding:3px 8px;}
+}
+@media(max-width:400px){
+  .call-controls{gap:10px;}
+  .ctrl-btn{width:44px;height:44px;}
+  .ctrl-btn.end-call{width:52px;height:44px;}
+}
+.call-info-wrap{position:absolute;top:8px;left:50%;transform:translateX(-50%);z-index:5;display:flex;flex-direction:column;align-items:center;gap:3px;pointer-events:none;}
+.room-name-chip{background:rgba(0,0,0,.72);color:#fff;border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:600;white-space:nowrap;max-width:min(78vw,260px);overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(5px);}
+.lang-flags-chip{background:rgba(0,0,0,.55);color:#fff;border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:2px 10px;font-size:15px;backdrop-filter:blur(4px);}
+.chat-compose-strip{display:flex;align-items:flex-end;gap:8px;padding:8px 12px max(8px,env(safe-area-inset-bottom));background:var(--surface);border-top:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+.chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:"DM Sans",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}
+.chat-compose-ta::-webkit-scrollbar{display:none;}
+.chat-compose-ta::placeholder{color:var(--text-muted);}
+.chat-compose-ta:focus{border-color:var(--teal);}
+.chat-send-btn{width:38px;height:38px;border-radius:50%;border:none;background:var(--teal);color:#fff;cursor:pointer;flex-shrink:0;display:flex;align-items:center;justify-content:center;transition:opacity .15s;}
+.chat-send-btn:disabled{opacity:.3;cursor:default;}
+.chat-send-btn:hover:not(:disabled){opacity:.85;}
+/* ═══ PHRASEBOOK v2 STYLES ═══════════════════════════════════════════════ */
+.pb-drawer{position:fixed;left:0;right:0;bottom:-56dvh;height:56dvh;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);border-radius:14px 14px 0 0;z-index:20;transition:bottom .2s ease;display:flex;flex-direction:column;overflow:hidden;}
+.pb-drawer.open{bottom:0;}
+.pb-drawer-hdr{display:flex;align-items:center;gap:8px;padding:10px 12px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;}
+.pb-drawer-title{font-size:13px;font-weight:700;color:var(--text-dim);flex:1;}
+.pb-drawer-x{background:none;border:none;color:var(--text-dim);font-size:20px;cursor:pointer;line-height:1;padding:2px 6px;}
+.pb-drawer-x:hover{color:var(--text);}
+#pb-drawer-content{flex:1;display:flex;flex-direction:column;overflow:hidden;}
+.pb-chip-ribbon{display:flex;overflow-x:auto;gap:7px;padding:7px 10px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0;-webkit-overflow-scrolling:touch;scrollbar-width:none;}
+.pb-chip-ribbon::-webkit-scrollbar{display:none;}
+.pb-cr-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:999px;padding:5px 12px;font-size:12px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;flex-shrink:0;transition:background .12s,border-color .12s;}
+.pb-cr-chip:hover{background:var(--teal);border-color:var(--teal);color:#fff;}
+.pb-cr-chip.danger{color:var(--red);border-color:rgba(231,76,60,.4);}
+.pb-cr-chip.danger:hover{background:var(--red);border-color:var(--red);color:#fff;}
+.pb-ico-chip{background:rgba(255,255,255,.08);color:var(--text);border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:8px 10px;cursor:pointer;line-height:0;display:inline-flex;align-items:center;justify-content:center;transition:background .12s;flex-shrink:0;}
+.pb-ico-chip:hover{background:var(--teal);border-color:var(--teal);color:#fff;}
+.pb-ico-chip.danger:hover{background:var(--red);border-color:var(--red);}
+.pb-search-inp{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:10px;padding:8px 12px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;}
+.pb-search-inp:focus{border-color:var(--teal-bright);}
+.pb-search-inp::placeholder{color:var(--text-muted);}
+.pb-pair-badge{background:rgba(63,193,193,.15);color:var(--teal-bright);border-radius:999px;padding:3px 10px;font-size:11px;font-weight:700;flex-shrink:0;}
+.pb-search-results{overflow-y:auto;padding:8px 10px;flex:1;}
+.pb-empty{color:var(--text-muted);font-size:13px;padding:16px;text-align:center;}
+.pb-bubble{background:#fff;border-radius:12px;margin-bottom:10px;overflow:hidden;border:1px solid #e0dbd6;font-family:"DM Sans",sans-serif;}
+.pb-bbl-hdr{display:flex;align-items:center;gap:6px;padding:6px 10px;background:#f5f1ec;border-bottom:1px solid #e0dbd6;font-size:11px;min-height:28px;}
+.pb-bbl-pair{font-weight:700;color:#5a5552;flex:1;}
+.pb-bbl-ts{font-size:10px;color:#9a9592;flex:1;font-variant-numeric:tabular-nums;}
+.room-trash-details{margin-top:6px;}
+.room-trash-details summary{font-size:11px;color:var(--text-muted);padding:4px 2px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:5px;user-select:none;}
+.room-trash-details summary::-webkit-details-marker{display:none;}
+.pb-book-row{display:flex;align-items:center;padding:10px;border:1px solid #e0dbd6;border-radius:10px;margin-bottom:6px;background:#fff;gap:8px;}
+.pb-book-name{flex:1;font-size:14px;color:#1a1714;font-weight:500;}
+.pb-vbadge{font-size:11px;font-weight:700;padding:1px 5px;border-radius:4px;}
+.pb-vbadge.good{color:#2e7d4f;background:#e8f5ee;}
+.pb-vbadge.flag{color:#c0392b;background:#fdedec;}
+.pb-tag-ct{font-size:10px;color:#9a9592;}
+.pb-del-btn{background:none;border:none;cursor:pointer;color:#c0392b;font-size:13px;padding:0;margin-left:auto;opacity:.65;}
+.pb-del-btn:hover{opacity:1;}
+.pb-bbl-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.pb-bbl-col{padding:10px;display:flex;flex-direction:column;gap:6px;}
+.pb-bbl-div{background:#e0dbd6;}
+.pb-bbl-txt{font-size:15px;line-height:1.45;color:#1a1714;word-break:break-word;flex:1;}
+.pb-bbl-acts{display:flex;align-items:center;gap:6px;}
+.pb-tts-btn{background:none;border:none;cursor:pointer;color:#9a9592;padding:3px;line-height:0;display:flex;align-items:center;}
+.pb-tts-btn:hover{color:#1a1714;}
+.pb-bbl-foot{border-top:1px solid #e0dbd6;display:flex;gap:1px;padding:3px 5px;background:#fdfaf7;}
+.pb-fbt{background:none;border:none;cursor:pointer;font-size:11px;font-weight:600;color:#9a9592;padding:4px 8px;border-radius:6px;font-family:"DM Sans",sans-serif;white-space:nowrap;flex:1;text-align:center;transition:background .1s;}
+.pb-fbt:hover{background:rgba(0,0,0,.05);color:#5a5552;}
+.pb-fbt.on{background:rgba(46,139,139,.12);color:#2e8b8b;}
+.pb-panel{border-top:1px solid #e0dbd6;background:#fdfaf7;}
+.pb-tpills{display:flex;flex-wrap:wrap;gap:4px;min-height:18px;}
+.pb-tp{background:#eee8ff;color:#6b4fbb;border-radius:5px;padding:2px 6px;font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px;}
+.pb-tag-inp{width:100%;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;outline:none;margin-top:6px;background:#fff;color:#1a1714;}
+.pb-tag-inp:focus{border-color:#2e8b8b;}
+.pb-tsugg{display:flex;flex-wrap:wrap;gap:5px;margin-top:6px;}
+.pb-tsugg-chip{border:1px solid #e0dbd6;background:#fff;border-radius:999px;padding:2px 8px;font-size:11px;cursor:pointer;color:#5a5552;}
+.pb-tsugg-chip:hover{border-color:#2e8b8b;color:#2e8b8b;}
+.pb-clarify-item{margin-bottom:6px;}
+.pb-clarify-meta{display:flex;justify-content:space-between;align-items:center;}
+.pb-clarify-author{font-size:11px;font-weight:700;color:#5a5552;}
+.pb-clarify-body{font-size:13px;color:#1a1714;line-height:1.4;margin-top:2px;}
+.pb-clarify-inp{flex:1;border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;outline:none;background:#fff;color:#1a1714;}
+.pb-clarify-inp:focus{border-color:#2e8b8b;}
+.pb-clarify-send{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-bt-run{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;margin-bottom:8px;display:block;font-family:"DM Sans",sans-serif;}
+.pb-vbtn{border:none;border-radius:7px;padding:4px 10px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-vbtn.good{background:#e8f5ee;color:#2e7d4f;}
+.pb-vbtn.flag{background:#fdedec;color:#c0392b;}
+.pb-vbtn.sm{background:#f5f1ec;color:#5a5552;font-size:10px;}
+.pb-overlay{position:fixed;inset:0;background:#fdfaf7;z-index:30;display:none;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-ov-hdr{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;background:#fdfaf7;flex-shrink:0;}
+.pb-ov-back{background:none;border:none;cursor:pointer;color:#5a5552;font-size:22px;padding:4px 6px;border-radius:8px;line-height:1;}
+.pb-ov-back:hover{background:#eeede9;}
+.pb-ov-title{flex:1;font-family:"Lora",serif;font-size:17px;font-weight:600;color:#1a1714;}
+.pb-ov-act{background:none;border:none;cursor:pointer;color:#5a5552;padding:6px 8px;border-radius:8px;line-height:0;display:inline-flex;align-items:center;}
+.pb-ov-act:hover{background:#eeede9;color:#1a1714;}
+.pb-ov-act:hover{background:#eeede9;color:#1a1714;}
+.pb-ov-searchbar{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-ov-si{flex:1;border:1.5px solid #e0dbd6;border-radius:10px;padding:8px 12px;font-size:15px;font-family:"DM Sans",sans-serif;outline:none;background:#fff;color:#1a1714;}
+.pb-ov-si:focus{border-color:#2e8b8b;}
+.pb-ov-si::placeholder{color:#9a9592;}
+.pb-ov-filter-bar{display:flex;flex-wrap:wrap;gap:6px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fdfaf7;flex-shrink:0;}
+.pb-fc{background:#fff;border:1.5px solid #e0dbd6;border-radius:999px;padding:4px 12px;font-size:12px;font-weight:600;cursor:pointer;color:#5a5552;font-family:"DM Sans",sans-serif;transition:all .12s;}
+.pb-fc:hover{border-color:#2e8b8b;color:#2e8b8b;}
+.pb-fc.act{background:#2e8b8b;border-color:#2e8b8b;color:#fff;}
+#pb-ov-cards{flex:1;overflow-y:auto;padding:10px 14px 80px;}
+.pb-import-modal{position:fixed;inset:0;background:#fdfaf7;z-index:40;display:none;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-im-hdr{display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-im-title{flex:1;font-size:17px;font-weight:600;color:#1a1714;}
+.pb-im-x{background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;}
+.pb-im-sel-bar{display:flex;gap:10px;padding:8px 14px 0;flex-shrink:0;}
+.pb-im-sel-btn{background:none;border:none;color:#2e8b8b;font-size:12px;font-weight:700;cursor:pointer;padding:4px 0;font-family:"DM Sans",sans-serif;}
+#pb-import-list{flex:1;overflow-y:auto;padding:8px 14px;}
+.pb-import-row{display:flex;align-items:flex-start;gap:10px;padding:10px;border:1px solid #e0dbd6;border-radius:10px;margin-bottom:6px;background:#fff;cursor:pointer;}
+.pb-import-row input[type=checkbox]{margin-top:2px;width:16px;height:16px;accent-color:#2e8b8b;flex-shrink:0;}
+.pb-import-info{flex:1;min-width:0;}
+.pb-import-pair{display:inline-block;background:#e6f4f4;color:#2e8b8b;border-radius:999px;padding:1px 8px;font-size:10px;font-weight:700;margin-bottom:4px;}
+.pb-import-src{display:block;font-size:13px;color:#1a1714;font-weight:500;}
+.pb-import-tgt{display:block;font-size:12px;color:#5a5552;margin-top:1px;}
+.pb-im-footer{display:flex;gap:8px;padding:12px 14px max(12px,env(safe-area-inset-bottom));border-top:1px solid #e0dbd6;background:#fff;flex-shrink:0;}
+.pb-im-cancel{flex:1;background:#f5f1ec;color:#5a5552;border:1px solid #e0dbd6;border-radius:10px;padding:12px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-im-ok{flex:2;background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-sheet{position:fixed;left:0;right:0;bottom:-65dvh;height:65dvh;background:#fdfaf7;border-top:1px solid #e0dbd6;border-radius:14px 14px 0 0;z-index:35;transition:bottom .22s ease;display:flex;flex-direction:column;overflow:hidden;font-family:"DM Sans",sans-serif;}
+.pb-nc-sheet.open{bottom:0;}
+.pb-nc-hdr{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid #e0dbd6;flex-shrink:0;}
+.pb-nc-title{flex:1;font-size:15px;font-weight:700;color:#1a1714;}
+.pb-nc-x{background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;}
+.pb-nc-label{font-size:11px;font-weight:700;color:#9a9592;text-transform:uppercase;letter-spacing:.4px;margin-bottom:4px;display:block;}
+.pb-nc-sel{border:1.5px solid #e0dbd6;border-radius:8px;padding:6px 8px;font-size:13px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;color:#1a1714;cursor:pointer;-webkit-appearance:none;}
+.pb-nc-sel:focus{border-color:#2e8b8b;}
+.pb-nc-ta{width:100%;border:1.5px solid #e0dbd6;border-radius:10px;padding:9px 12px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;resize:none;outline:none;min-height:60px;color:#1a1714;}
+.pb-nc-ta:focus{border-color:#2e8b8b;}
+.pb-nc-trans{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:8px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;margin:8px 0;}
+.pb-nc-save{background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:15px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;}
+.phrase-mini{border:1px solid rgba(255,255,255,.12);border-radius:10px;padding:8px;margin:8px 0;background:rgba(255,255,255,.03);}
+.phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+.phrase-mini-side{border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:6px;}
+.phrase-mini-meta{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;}
+.phrase-mini-src{font-size:13px;color:var(--text-dim);}
+.phrase-mini-tgt{font-size:13px;color:var(--text);margin-top:2px;}
+.phrase-mini-actions{display:flex;gap:6px;margin-top:6px;}
+.phrase-mini-actions button{background:rgba(255,255,255,.08);color:var(--text);border:none;border-radius:8px;padding:6px 8px;font-size:11px;cursor:pointer;}
+#chat-body{padding:0;}
+.ch-entry{padding:4px 0;}
+.ch-bubble{border:1px solid rgba(255,255,255,.14);border-radius:12px;overflow:hidden;background:rgba(255,255,255,.03);}
+.ch-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:4px 10px;border-bottom:1px solid rgba(255,255,255,.08);font-size:11px;}
+.ch-who{font-weight:700;}.ch-who.mine{color:var(--teal-bright);}.ch-who.theirs{color:var(--text-dim);}
+.ch-time{font-size:10px;color:var(--text-muted);font-variant-numeric:tabular-nums;}
+.ch-body{display:grid;grid-template-columns:1fr 1px 1fr;}
+.ch-col{padding:7px 10px;font-size:13px;line-height:1.4;color:var(--text);word-break:break-word;min-width:0;}
+.ch-col.orig{color:var(--text-dim);}
+.ch-divider{background:rgba(255,255,255,.08);}
+@media(min-width:768px){.chat-compose-ta{font-size:15px;}}
+@media(max-height:500px) and (orientation:landscape){.chat-compose-strip{padding:5px 10px;}.chat-compose-ta{min-height:32px;font-size:13px;}}
+.joiner-landing{position:fixed;inset:0;z-index:30;display:none;flex-direction:column;align-items:center;justify-content:center;gap:24px;padding:32px 20px;background-image:linear-gradient(rgba(10,10,10,.82),rgba(10,10,10,.82)),url('./flags.gif'),url('./flags.png'),linear-gradient(135deg,#0a2020,#0a1020);background-size:cover,cover,cover,cover;background-position:center,center,center,center;background-repeat:no-repeat,no-repeat,no-repeat,no-repeat;}
+.joiner-landing.show{display:flex;}
+.joiner-lang-pill{font-size:28px;letter-spacing:2px;}
+.joiner-room-name{font-family:"Lora",serif;font-size:22px;font-weight:600;color:#fff;text-align:center;line-height:1.3;width:100%;word-break:break-word;}
+.joiner-flags{font-size:36px;letter-spacing:4px;}
+.joiner-join-btn{width:100%;background:var(--teal-bright);color:#fff;border:none;border-radius:16px;padding:18px;font-size:18px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.joiner-sub{font-size:13px;color:rgba(255,255,255,.6);text-align:center;}
+.thankyou-page{position:fixed;inset:0;background:var(--bg);z-index:40;display:none;flex-direction:column;align-items:center;justify-content:center;gap:20px;padding:32px 24px;}
+.thankyou-page.show{display:flex;}
+.thankyou-page-bg{position:fixed;inset:0;z-index:0;pointer-events:none;background-image:linear-gradient(rgba(10,10,10,.82),rgba(10,10,10,.82)),url('./flags.gif'),url('./flags.png'),linear-gradient(135deg,#0a2020,#0a1020);background-size:cover,cover,cover,cover;background-position:center,center,center,center;background-repeat:no-repeat,no-repeat,no-repeat,no-repeat;}.thankyou-title{font-family:"Lora",serif;font-size:22px;font-weight:600;color:#fff;text-align:center;position:relative;z-index:1;}
+.thankyou-sub{font-size:14px;color:rgba(255,255,255,.6);text-align:center;line-height:1.5;position:relative;z-index:1;}
+.thankyou-btn{background:rgba(255,255,255,.12);color:#fff;border:1px solid rgba(255,255,255,.25);border-radius:12px;padding:12px 24px;font-size:14px;font-weight:600;cursor:pointer;font-family:"DM Sans",sans-serif;position:relative;z-index:1;}
+
+
+/* ─── Call PiP overlay ─────────────────────────────────── */
+#pip-overlay{position:fixed;bottom:24px;right:16px;width:min(44vw,200px);z-index:50;display:none;flex-direction:column;border-radius:14px;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,.6);background:#000;}
+#pip-overlay.show{display:flex;}
+#pip-overlay video{width:100%;display:block;object-fit:cover;}
+#pip-remote{aspect-ratio:9/16;max-height:200px;}
+#pip-local{width:32%;aspect-ratio:9/16;position:absolute;bottom:6px;right:6px;border-radius:6px;border:1.5px solid rgba(255,255,255,.25);}
+.pip-controls{position:absolute;top:6px;right:6px;display:flex;gap:6px;}
+.pip-btn{background:rgba(0,0,0,.55);border:none;border-radius:50%;width:28px;height:28px;cursor:pointer;color:#fff;display:flex;align-items:center;justify-content:center;line-height:0;backdrop-filter:blur(4px);}
+.pip-btn:hover{background:rgba(0,0,0,.8);}
+#pip-overlay .pip-tap-target{position:absolute;inset:0;cursor:pointer;}
+
+/* ─── PB v2+ additions ───────────────────────────────── */
+/* Icon-only action buttons */
+.pb-icon-btn{background:none;border:none;cursor:pointer;color:#9a9592;padding:4px;border-radius:6px;line-height:0;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;transition:color .12s,background .12s;}
+.pb-icon-btn:hover{color:#1a1714;background:rgba(0,0,0,.06);}
+.pb-icon-btn.danger:hover{color:#c0392b;background:rgba(192,57,43,.08);}
+.pb-icon-btn.restore:hover{color:#2e7d4f;background:rgba(46,125,79,.08);}
+/* Chevron expand */
+.pb-chevron-row{display:flex;align-items:center;justify-content:flex-end;padding:0 6px 4px;gap:6px;}
+.pb-chevron-row.deleted{background:rgba(192,57,43,.05);}
+/* Soft-deleted bubble */
+.pb-bubble.deleted .pb-bbl-txt{text-decoration:line-through;opacity:.5;}
+.pb-bubble.deleted .pb-bbl-hdr{background:#f9eded;}
+/* Use button — icon only */
+.pb-use-btn{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:7px;padding:4px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;line-height:1.4;display:inline-flex;align-items:center;justify-content:center;}
+.pb-use-btn:hover{background:#2e8b8b;color:#fff;}
+/* BT TTS */
+.pb-bt-tts{background:none;border:none;cursor:pointer;color:#9a9592;padding:3px;display:inline-flex;align-items:center;vertical-align:middle;}
+.pb-bt-tts:hover{color:#2e8b8b;}
+/* URL import inline row */
+
+.pb-url-go{background:var(--teal);color:#fff;border:none;border-radius:8px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;white-space:nowrap;}
+/* Attachment modal */
+#att-modal{position:fixed;inset:0;background:rgba(0,0,0,.75);z-index:60;display:none;align-items:center;justify-content:center;padding:16px;}
+#att-modal.show{display:flex;}
+#att-modal-inner{background:var(--surface);border-radius:14px;max-width:min(96vw,640px);max-height:90dvh;width:100%;display:flex;flex-direction:column;overflow:hidden;}
+#att-modal-hdr{display:flex;align-items:center;gap:8px;padding:12px 14px;border-bottom:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+#att-modal-name{flex:1;font-size:13px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+#att-modal-body{flex:1;overflow:auto;padding:14px;}
+#att-modal-body img{max-width:100%;border-radius:8px;}
+#att-modal-body iframe{width:100%;height:60dvh;border:none;border-radius:8px;background:#fff;}
+/* tr-use icon style */
+.tr-use-ico{border:none;background:rgba(255,255,255,.08);color:#c4ccd4;border-radius:5px;padding:3px 6px;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:600;}
+.tr-use-ico:hover{background:rgba(63,193,193,.25);color:var(--teal-bright);}
+/* Chat attach SVG */
+.chat-attach-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;}
+.chat-attach-btn:hover{color:var(--text);}
+.pb-strip-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;transition:color .12s;}
+.pb-strip-btn:hover{color:var(--teal-bright);}
+.pb-strip-btn.active{color:var(--teal-bright);}
+</style>
+</head>
+<body>
+
+<div class="lobby" id="lobby">
+  <div class="lobby-card">
+    <div class="lobby-brand">TalkBridge</div>
+    <div id="lobby-setup" style="display:flex;flex-direction:column;flex:1;min-height:0;">
+      <div style="flex:1;overflow-y:auto;padding-bottom:8px;">
+        <div style="display:flex;flex-direction:column;gap:10px;padding-bottom:4px;">
+          <button class="lobby-btn" onclick="openCreateRoomModal()">＋ Create new room</button>
+          <input type="hidden" id="room-name" value="">
+          <select id="my-lang" style="display:none"></select>
+          <select id="their-lang" style="display:none"></select>
+        </div>
+        <div id="keys-panel" style="display:none;flex-direction:column;gap:10px;margin-top:14px;padding-top:14px;border-top:1px solid var(--surface2);">
+          <div><div class="lobby-label" style="margin-bottom:6px;">Deepgram API key</div>
+          <input class="lobby-input" id="dg-key" type="password" placeholder="Paste key — stored locally" oninput="onDgKeyInput()">
+          <div id="dg-key-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+          <div><div class="lobby-label" style="margin-bottom:6px;">Cloudflare TURN token ID</div>
+          <input class="lobby-input" id="cf-turn-id" type="password" placeholder="Paste token ID — stored locally" oninput="onCfTurnInput()">
+          <div class="lobby-label" style="margin-bottom:6px;margin-top:10px;">Cloudflare TURN API token</div>
+          <input class="lobby-input" id="cf-turn-tok" type="password" placeholder="Paste API token — stored locally" oninput="onCfTurnInput()">
+          <div id="cf-turn-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+        </div>
+        <div class="recent-rooms" id="recent-rooms" style="display:none;margin-top:14px;">
+          <div class="recent-title">Recent rooms</div>
+          <div class="recent-rooms-scroll" id="recent-rooms-list"></div>
+        </div>
+      </div>
+      <div class="lobby-footer" style="flex-shrink:0;border-top:1px solid var(--surface2);padding-top:6px;margin-top:4px;display:flex;align-items:center;justify-content:space-between;">
+        <button class="lobby-footer-btn" onclick="openLog()" title="Debug log">🪲</button>
+        <span id="ft-lobby-status" class="ft-status-pill"><span class="ft-status-dot loading" id="ft-dot"></span><span id="ft-label">Lang model loading…</span></span>
+        <span style="font-size:10px;color:var(--text-muted);">v2.0</span>
+        <button class="lobby-footer-btn" onclick="toggleKeysPanel()" id="keys-gear-btn" title="API keys">⚙️</button>
+      </div>
+    </div>
+    <div id="lobby-waiting" style="display:none;">
+      <div style="font-size:14px;color:var(--text-dim);text-align:center;margin-bottom:10px;" id="room-name-display"></div>
+      <div class="lobby-link-box" id="lobby-link" onclick="copyLink()">—</div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-backdrop" id="create-room-backdrop">
+  <div class="modal-card">
+    <div style="font-family:'Lora',serif;font-size:18px;font-weight:600;color:var(--text);">Create new room</div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">Room name (optional)</div>
+    <input class="lobby-input" id="modal-room-name" placeholder="e.g. Doctor visit" maxlength="60"></div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">I speak</div>
+    <select class="lobby-select" id="modal-my-lang" onchange="syncModalBtn()"></select></div>
+    <div><div class="lobby-label" style="margin-bottom:6px;">They speak</div>
+    <select class="lobby-select" id="modal-their-lang" onchange="syncModalBtn()"></select></div>
+    <div style="display:flex;gap:10px;">
+      <button class="lobby-btn secondary" style="flex:1;" onclick="closeCreateRoomModal()">Cancel</button>
+      <button class="lobby-btn" style="flex:1;" id="modal-create-btn" onclick="confirmCreateRoom()" disabled>OK</button>
+    </div>
+  </div>
+</div>
+<div class="joining-screen" id="joining-screen">
+  <div class="joining-spinner"></div>
+  <div class="joining-label">Joining call…</div>
+</div>
+
+<div class="log-overlay" id="log-overlay">
+  <div class="log-header">
+    <span class="log-title">🪲 Debug Log</span>
+    <div class="log-actions">
+      <button class="log-btn" onclick="copyLogText()">Copy</button>
+      <button class="log-btn" onclick="clearLogText()">Clear</button>
+      <button class="log-btn" onclick="closeLog()"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> Close</button>
+    </div>
+  </div>
+  <div class="log-body" id="log-body"></div>
+</div>
+
+<div class="log-overlay" id="room-tr-overlay">
+  <div class="log-header">
+    <span class="log-title" id="room-tr-title">Transcript</span>
+    <div class="log-actions">
+      <button class="log-btn" onclick="copyRoomTr()">Copy</button>
+      <button class="log-btn" onclick="closeRoomTr()"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> Close</button>
+    </div>
+  </div>
+  <div class="log-body" id="room-tr-body" style="font-family:'DM Sans',sans-serif;font-size:13px;"></div>
+</div>
+
+<div class="joiner-landing" id="joiner-landing">
+  <div class="joiner-lang-pill" id="joiner-lang-pill"></div>
+  <div class="joiner-room-name" id="joiner-room-name">You are invited to join a call</div>
+  <div class="joiner-flags" id="joiner-flags"></div>
+  <button class="joiner-join-btn" id="joiner-join-btn" onclick="joinerProceed()">Join Call</button>
+  <div class="joiner-sub" id="joiner-sub">Tap to allow camera &amp; microphone access</div>
+</div>
+<div class="thankyou-page" id="thankyou-page">
+  <div class="thankyou-page-bg"></div>
+  <div class="joiner-lang-pill" id="thankyou-lang-pill"></div>
+  <div class="thankyou-title" id="thankyou-title">Thanks for calling.</div>
+  <button class="thankyou-btn" onclick="copyLogText();toast('Log copied')">📋 Copy log</button>
+  <button class="thankyou-btn" onclick="downloadThankyouLog()">⬇ Download log</button>
+  <button class="thankyou-btn" onclick="copyTr();toast('Transcript copied')">📋 Copy transcript</button>
+  <button class="thankyou-btn" id="thankyou-dl-btn" onclick="exportTxt()">⬇ Download transcript</button>
+  <button class="thankyou-btn" id="thankyou-rejoin-btn" onclick="rejoinCall()" style="display:none">🔄 Rejoin</button>
+  <div class="thankyou-sub" id="thankyou-sub" style="margin-top:auto;padding-top:16px;">You can close this tab.</div>
+</div>
+<div class="call" id="call-screen">
+  <div class="call-videos" id="call-videos">
+    <video id="remote-video" autoplay playsinline></video>
+    <video id="local-video" autoplay muted playsinline></video>
+    <div class="no-video-placeholder" id="no-video-msg">👤</div>
+    <div class="remote-cam-off" id="remote-cam-off"><div class="remote-cam-off-icon">👤</div><div class="remote-cam-off-label" id="remote-cam-off-label">Camera off</div></div>
+    <div class="partner-disconnected-overlay" id="partner-disconnected-overlay"><div style="font-size:36px;">📵</div><div class="partner-disconnected-label" id="partner-disconnected-label">Partner has disconnected</div><div class="partner-disconnected-sub" id="partner-disconnected-sub">Waiting to reconnect…</div></div>
+    <button class="reconnect-banner" id="reconnect-banner" onclick="forceReconnect()">Tap to reconnect</button>
+    <div class="solo-banner" id="solo-banner" style="display:none;">
+      <div class="solo-banner-text">Waiting for partner to join…</div>
+    </div>
+    <div class="partner-speaking-indicator" id="partner-speaking-indicator" aria-hidden="true">…</div>
+    <div class="subtitle-area" id="subtitle-area"></div>
+  </div>
+  <div class="call-transcript" id="call-transcript">
+    <div class="call-transcript-header" style="justify-content:space-between;">
+      <div class="call-transcript-actions">
+        <button class="call-transcript-btn" id="transcript-toggle-btn" onclick="toggleTranscript()" title="Collapse" aria-label="Collapse transcript" aria-expanded="true">
+          <svg class="chevron-down" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg>
+          <svg class="chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg>
+        </button>
+        <button class="call-transcript-btn" id="transcript-tts-toggle" onclick="toggleTranscriptTts()" title="TTS" aria-pressed="false">
+          <svg class="tts-on" viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/><path d="M18 7a7 7 0 0 1 0 10"/></svg>
+          <svg class="tts-off" viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><line x1="3" y1="21" x2="21" y2="3" stroke="#e74c3c" stroke-width="2.5"/></svg>
+        </button>
+        <button class="call-transcript-btn" id="strip-share-btn" onclick="shareLink()" title="Share" style="display:none;">
+          <svg viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.8 10.8l6.4-3.6M8.8 13.2l6.4 3.6"/></svg>
+        </button>
+        <button class="call-transcript-btn" onclick="copyTr()" title="Copy">
+          <svg viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
+        </button>
+        <button class="call-transcript-btn" onclick="exportTxt()" title="Download">
+          <svg viewBox="0 0 24 24"><path d="M12 3v11"/><path d="M8 10l4 4 4-4"/><path d="M4 20h16"/></svg>
+        </button>
+      </div>
+      <div style="display:flex;gap:6px;align-items:center;">
+        <button class="vc-btn" id="top-mic-btn" onclick="toggleMic()" title="Mic">
+          <svg viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+        </button>
+        <button class="vc-btn" id="top-cam-btn" onclick="toggleCam()" title="Cam">
+          <svg viewBox="0 0 24 24"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+        </button>
+        <button class="vc-btn end" onclick="hangUp()" title="End">
+          <svg viewBox="0 0 24 24"><path d="M10.68 13.31a16 16 0 0 0 3.41 2.6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.11 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 2.59 3.4z" transform="rotate(135 12 12)"/></svg>
+        </button>
+      </div>
+    </div>
+    <div id="transcript-body"><div class="tr-empty">Speak or type to see transcript here.</div></div>
+    <div class="transcript-more-indicator" id="transcript-more-indicator" onclick="scrollToBottom()">↓</div>
+  </div>
+  <div class="chat-compose-strip" id="chat-compose-strip">
+    <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-attach-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button class="pb-strip-btn" id="pb-strip-btn" onclick="pbToggleDrawer()" title="Phrases"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></button><textarea class="chat-compose-ta" id="chat-input" placeholder="type here to chat" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)" onfocus="composeFocusMute()" onblur="_pbRestoreMic()"></textarea>
+    <button class="chat-send-btn" id="chat-send-btn" onclick="sendChat()" disabled title="Send">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+    </button>
+  </div>
+</div>
+<!-- PiP overlay -->
+<div id="pip-overlay">
+  <div class="pip-tap-target" onclick="pipExpand()"></div>
+  <video id="pip-remote" autoplay playsinline muted></video>
+  <video id="pip-local" autoplay muted playsinline style="transform:scaleX(-1);"></video>
+  <div class="pip-controls">
+    <button class="pip-btn" onclick="pipExpand()" title="Expand"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></button>
+    <button class="pip-btn" onclick="pipClose()" title="End call"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+</div>
+<!-- Attachment modal -->
+<div id="att-modal">
+  <div id="att-modal-inner">
+    <div id="att-modal-hdr">
+      <span id="att-modal-name"></span>
+      <a id="att-modal-dl" href="#" download style="color:var(--teal-bright);font-size:12px;margin-right:4px;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></a>
+      <button onclick="attModalClose()" style="background:none;border:none;cursor:pointer;color:var(--text-dim);line-height:0;padding:4px;"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+    </div>
+    <div id="att-modal-body"></div>
+  </div>
+</div>
+<!-- ══ PHRASEBOOK v2 ══ -->
+<div id="pb-drawer" class="pb-drawer"><div id="pb-drawer-content"></div></div>
+
+<div id="pb-overlay" class="pb-overlay" style="display:none;">
+  <div class="pb-ov-hdr">
+    <button class="pb-ov-back" onclick="pbCloseOverlay()" title="Back"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg></button>
+    <div class="pb-ov-title">Phrasebook</div>
+    <button class="pb-ov-act" onclick="pbOpenNewCard({})" title="New phrase"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
+    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></button>
+    <button class="pb-ov-act" onclick="pbOpenBooksModal()" title="Switch phrasebook"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 1.41 14.14"/><path d="M4.93 4.93A10 10 0 0 0 3.52 19.07"/></svg></button>
+    <button class="pb-ov-act" onclick="pbResetConfirm()" title="Reset phrasebook" style="color:#c0392b;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></button>
+    <button class="pb-ov-act" onclick="pbCloseOverlay()" title="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+  </div>
+  <div class="pb-ov-searchbar">
+    <input id="pb-ov-search" class="pb-ov-si" placeholder="Search all phrases… (-word to exclude)" oninput="pbOvSearch()">
+  </div>
+  <div class="pb-ov-filter-bar" id="pb-ov-filter"></div>
+  <div id="pb-ov-cards"></div>
+</div>
+
+<div id="pb-import-modal" class="pb-import-modal" style="display:none;">
+  <div class="pb-im-hdr">
+    <span class="pb-im-title">Import Phrases</span>
+    <button class="pb-im-x" onclick="pbCloseImportModal()">×</button>
+  </div>
+  <div class="pb-im-sel-bar">
+    <button class="pb-im-sel-btn" onclick="pbSelectAllImport(true)">Select all</button>
+    <button class="pb-im-sel-btn" onclick="pbSelectAllImport(false)">Deselect all</button>
+  </div>
+  <div id="pb-import-list"></div>
+  <div class="pb-im-footer">
+    <button class="pb-im-cancel" onclick="pbCloseImportModal()">Cancel</button>
+    <button class="pb-im-ok" id="pb-import-ok" onclick="pbConfirmImport()">Import</button>
+  </div>
+</div>
+
+<div id="pb-new-card-sheet" class="pb-nc-sheet">
+  <div class="pb-nc-hdr">
+    <span class="pb-nc-title">New phrase</span>
+    <button class="pb-nc-x" onclick="pbCloseNewCard()">×</button>
+  </div>
+  <div class="pb-nc-body" style="flex:1;overflow-y:auto;padding:12px 14px;">
+    <div style="display:flex;gap:8px;margin-bottom:10px;align-items:flex-end;">
+      <div style="flex:1;"><span class="pb-nc-label">Source lang</span><select id="pbnc-sl" class="pb-nc-sel" style="width:100%;"></select></div>
+      <div style="flex:1;"><span class="pb-nc-label">Target lang</span><select id="pbnc-tl" class="pb-nc-sel" style="width:100%;"></select></div>
+    </div>
+    <span class="pb-nc-label">Source phrase</span>
+    <textarea id="pbnc-src" class="pb-nc-ta" rows="2" placeholder="Original phrase…"></textarea>
+    <button class="pb-nc-trans" onclick="pbNcAutoTranslate()">Translate →</button>
+    <span class="pb-nc-label">Translation</span>
+    <textarea id="pbnc-tgt" class="pb-nc-ta" rows="2" placeholder="Translation…"></textarea>
+    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:12px;">Save to phrasebook</button>
+  </div>
+</div>
+
+<div id="pb-books-modal" style="position:fixed;inset:0;background:#fdfaf7;z-index:45;display:none;flex-direction:column;font-family:'DM Sans',sans-serif;overflow:hidden;">
+  <div style="display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid #e0dbd6;background:#fff;flex-shrink:0;">
+    <span style="flex:1;font-size:17px;font-weight:600;color:#1a1714;">Phrasebooks</span>
+    <button onclick="document.getElementById('pb-books-modal').style.display='none'" style="background:none;border:none;font-size:20px;cursor:pointer;color:#5a5552;">×</button>
+  </div>
+  <div id="pb-books-list" style="flex:1;overflow-y:auto;padding:10px 14px;"></div>
+  <div style="padding:12px 14px;border-top:1px solid #e0dbd6;background:#fff;color:#9a9592;font-size:11px;">Import a phrasebook to add it here. Default cannot be deleted.</div>
+</div>
+<input id="pb-file-input" type="file" accept=".json" style="display:none" onchange="pbHandleFile(event)">
+<div id="toast"></div>
+
+<script>
+'use strict';
+var RELAY_BASE='talk-signal.myacctfortracking.workers.dev/signal';
+var RELAY_WS='wss://'+RELAY_BASE;
+var RELAY_APP='talk-say-v1';
+var LANGS=[
+  {code:'en',label:'English',flag:'🇺🇸'},{code:'th',label:'Thai',flag:'🇹🇭'},
+  {code:'es',label:'Spanish',flag:'🇪🇸'},{code:'ja',label:'Japanese',flag:'🇯🇵'},
+  {code:'ko',label:'Korean',flag:'🇰🇷'},{code:'zh',label:'Chinese (Mandarin)',flag:'🇨🇳'},
+  {code:'ar',label:'Arabic',flag:'🇸🇦'},{code:'hi',label:'Hindi',flag:'🇮🇳'},
+  {code:'ru',label:'Russian',flag:'🇷🇺'},{code:'fr',label:'French',flag:'🇫🇷'},
+  {code:'de',label:'German',flag:'🇩🇪'},{code:'it',label:'Italian',flag:'🇮🇹'},
+  {code:'pt',label:'Portuguese',flag:'🇧🇷'},{code:'vi',label:'Vietnamese',flag:'🇻🇳'},
+  {code:'id',label:'Indonesian',flag:'🇮🇩'},{code:'ms',label:'Malay',flag:'🇲🇾'},
+  {code:'fil',label:'Filipino',flag:'🇵🇭'},{code:'nl',label:'Dutch',flag:'🇳🇱'},
+  {code:'sv',label:'Swedish',flag:'🇸🇪'},{code:'pl',label:'Polish',flag:'🇵🇱'},
+  {code:'tr',label:'Turkish',flag:'🇹🇷'}
+];
+var TTS_LOCALE={en:'en-US',th:'th-TH',ja:'ja-JP',ko:'ko-KR',zh:'zh-CN',ar:'ar-SA',hi:'hi-IN',ru:'ru-RU',fr:'fr-FR',de:'de-DE',es:'es-ES',it:'it-IT',pt:'pt-BR',vi:'vi-VN',id:'id-ID',ms:'ms-MY',fil:'fil-PH',nl:'nl-NL',sv:'sv-SE',pl:'pl-PL',tr:'tr-TR'};
+var DG_LANGS={en:'en-US',th:'th',ja:'ja',ko:'ko',zh:'zh-CN',ar:'ar',hi:'hi',ru:'ru',fr:'fr',de:'de',es:'es',it:'it',pt:'pt-BR',vi:'vi',id:'id',ms:'ms',fil:'fil',nl:'nl',sv:'sv',pl:'pl',tr:'tr'};
+
+
+// ─── AUDIO WORKLET — single-file Blob URL, falls back to ScriptProcessor ────
+var DG_WORKLET_CODE='class TBAudioCapture extends AudioWorkletProcessor{constructor(){super();this._b=[];this._n=4096;}process(inputs){var ch=inputs[0]&&inputs[0][0];if(ch){for(var i=0;i<ch.length;i++)this._b.push(ch[i]);}while(this._b.length>=this._n){var out=new Float32Array(this._b.splice(0,this._n));this.port.postMessage(out,[out.buffer]);}return true;}}registerProcessor(\'tb-audio-capture\',TBAudioCapture);';
+
+// ─── NORTHERN THAI → CENTRAL THAI dialect map ────────────────────────────────
+var NT_PHRASE_MAP={
+  'ไปไสมาเจ้า':'ไปไหนมาครับ','กิ๋นข้าวแล้วเจ้า':'กินข้าวแล้วครับ',
+  'สวัสดีเจ้า':'สวัสดีครับ','ลาก่อนเจ้า':'ลาก่อนครับ',
+  'ขอบใจเจ้า':'ขอบคุณครับ','สบายดีเจ้า':'สบายดีครับ',
+  'บ่เป็นหยัง':'ไม่เป็นไร','เจ้าเป็นไง':'คุณเป็นยังไง',
+  'จอยเป็นไง':'ฉันเป็นยังไง','เว้ากันก่อน':'คุยกันก่อน',
+  'ฮักเจ้า':'รักคุณ','ม่วนหลาย':'สนุกมาก',
+  'แซ่บหลาย':'อร่อยมาก','เมินแล้ว':'นานแล้ว',
+  'ก็ได้เจ้า':'ก็ได้ครับ','มื้อนี้ตอนเช้า':'เช้านี้',
+  'ม่วนใจ๋':'มีความสุข','ดีใจ๋':'ดีใจ'
+};
+var NT_WORD_MAP={
+  'ฮู้สึก':'รู้สึก','ฮ้องไห้':'ร้องไห้',
+  'บ่อยาก':'ไม่อยาก','บ่ชอบ':'ไม่ชอบ',
+  'บ่เป็น':'ไม่เป็น','บ่รู้':'ไม่รู้',
+  'บ่มี':'ไม่มี','บ่ได้':'ไม่ได้','บ่ดี':'ไม่ดี',
+  'จั๋งใด':'ยังไง','เป็นไง':'เป็นยังไง',
+  'ไปไส':'ไปไหน','ทำหยัง':'ทำอะไร',
+  'อะหยัง':'อะไร','เป๋นหยัง':'เป็นอะไร',
+  'มื้อวาน':'เมื่อวาน','มื้อนี้':'วันนี้','มื้ออื่น':'วันอื่น',
+  'ขอบใจ':'ขอบคุณ',
+  'จอย':'ฉัน','เปิ้น':'เขา','เฮา':'เรา',
+  'เน้อ':'นะ','เนาะ':'นะ','ก้อ':'ก็',
+  'กิ๋น':'กิน','ผ่อ':'ดู','แอ่ว':'เที่ยว',
+  'กึ๊ด':'คิด','เว้า':'พูด','หื้อ':'ให้',
+  'หลาย':'มาก','คัก':'มาก',
+  'ม่วน':'สนุก','แซ่บ':'อร่อย',
+  'งาม':'สวย','เมิน':'นาน',
+  'ฮู้':'รู้','ฮัก':'รัก','ฮับ':'รับ',
+  'ฮ้อน':'ร้อน','ฮอด':'ถึง','ฮ่ม':'ร่ม',
+  'หั้น':'นั้น','อั้น':'อัน','ตี้':'ที่',
+  'ใจ๋':'ใจ','มื้อ':'วัน','หยัง':'อะไร'
+};
+function applyNorthernThaiMap(text){
+  if(!text||room.myLang!=='th')return text;
+  var keys,i;
+  keys=Object.keys(NT_PHRASE_MAP).sort(function(a,b){return b.length-a.length;});
+  for(i=0;i<keys.length;i++){if(text.indexOf(keys[i])>=0)text=text.split(keys[i]).join(NT_PHRASE_MAP[keys[i]]);}
+  keys=Object.keys(NT_WORD_MAP).sort(function(a,b){return b.length-a.length;});
+  for(i=0;i<keys.length;i++){if(text.indexOf(keys[i])>=0)text=text.split(keys[i]).join(NT_WORD_MAP[keys[i]]);}
+  // บ่ prefix rule: any remaining บ่ + Thai chars = ไม่ + those chars
+  text=text.replace(/บ่([\u0E00-\u0E7F]+)/g,'ไม่$1');
+  return text;
+}
+
+var room={id:null,myLang:'',theirLang:'',role:null,name:''};
+var deviceId=localStorage.getItem('tb_dev')||(function(){var id=crypto.randomUUID();localStorage.setItem('tb_dev',id);return id})();
+
+// ─── SESSION STATE (Phase 1) ───────────────────────────────────────────────
+var sessionEpoch=0;
+// callPhase: idle|prejoin|joining_media|call_connecting|call_live|call_degraded|ending_local|ending_remote|postcall_joiner|postcall_creator
+var callPhase='idle';
+var lastSessionContext={role:null,myLang:'',theirLang:'',roomName:'',pendingJoinSnapshot:null};
+var micMutedByUser=false;
+var dgDesired=false;
+// Chat reliability (Phase 6)
+var _chatOutbox=new Map();   // chatId → relay msg object, cleared on ack
+var _chatReceived=new Set(); // chatId dedupe set
+
+function setCallPhase(next,reason){
+  log('phase',{from:callPhase,to:next,why:reason||''});
+  callPhase=next;
+}
+function bumpSessionEpoch(reason){
+  sessionEpoch++;
+  log('epoch',{n:sessionEpoch,why:reason||''});
+  return sessionEpoch;
+}
+function isActiveCallPhase(){
+  return ['call_connecting','call_live','call_degraded'].indexOf(callPhase)>=0;
+}
+// ──────────────────────────────────────────────────────────────────────────
+
+var _relayWs=null;
+var pc=null,videoStream=null,remoteStream=null;
+var micOn=true,camOn=true,makingOffer=false;
+var dgWs=null,dgAudioCtx=null,dgProc=null,dgSrc=null,dgActive=false;
+var _dgLastMsg=0,_dgWatchdogTimer=null;
+var DG_WATCHDOG_MS=20000; // restart DG if no WS messages in 20s during live call
+var recentFinals=[],DEDUP_MS=4000,DEDUP_MAX=5;
+var localSubSeq=(Date.now()&0xFFFF),_ssNonce=Date.now().toString(36).slice(-4),transcript=[],trCache=new Map(),TR_CACHE_MAX=500;
+var hbTimer=null,seq=0,wsReconnectTimer=null;
+var debugLog=[],HEARTBEAT_MS=30000,SUB_LINGER=5000,MAX_TR=300;
+var RK='tb_recent_rooms',TP='tb_transcript_',RL=12;
+var viewingRoomId=null,callHistoryPushed=false;
+var transcriptCollapsed=false,showTranscriptMore=false,partnerSpeakTimer=null,transcriptTtsOn=false;
+var dgKeyVerified=false,dgKeyVerifyTimer=null;
+var pendingCandidates=[];
+var savedOffer=null;
+var savedCandidates=[];
+var _recoveryLock=false,_recoveryStep=0,_recoveryTimer=null,_stableSince=null,_connectTimeoutTimer=null,_seenRemoteCand=new Set();
+var _remoteVideoWatchdogTimer=null,_remoteVideoLastTime=0,_remoteVideoStallCount=0;
+
+// ─── Phase 3: Canonical audio constraints ─────────────────────────────────
+function getMicConstraints(){
+  return {echoCancellation:true,noiseSuppression:true,autoGainControl:true};
+}
+
+// ─── Phase 5: Text normalization ──────────────────────────────────────────
+function normalizeText(raw,mode){
+  if(!raw)return'';
+  var s=raw.normalize?raw.normalize('NFKC'):raw;
+  s=s.trim().replace(/\s+/g,' ');
+  s=s.replace(/[\u200B-\u200D\uFEFF\u2060]/g,'');
+  if(mode==='speech'){
+    // Strip XLIFF/TMX markup tags from MyMemory translation memory output
+    // e.g. สอง<bx id="2"/> → สอง
+    s=s.replace(/<\/?[a-zA-Z][^>]*>/g,'');
+    s=s.trim().replace(/\s+/g,' ');
+  }
+  if(mode==='compare'){
+    s=s.toLowerCase();
+    s=s.replace(/[\u2018\u2019]/g,"'").replace(/[\u201C\u201D]/g,'"');
+  }
+  return s;
+}
+
+// ─── Phase 4: DG helpers ──────────────────────────────────────────────────
+var _silentAudioCtx=null;
+var _silentOsc=null;
+var _silentAudioTrack=null;
+var _micToggleInFlight=false;
+function isLiveMicTrackPresent(){
+  if(!videoStream)return false;
+  return videoStream.getAudioTracks().some(function(t){
+    return t.readyState==='live'&&t!==_silentAudioTrack;
+  });
+}
+function reconcileDeepgramState(reason){
+  var should=dgDesired&&isCallActive()&&isLiveMicTrackPresent()&&!micMutedByUser&&isActiveCallPhase();
+  log('dg_reconcile',{why:reason,desired:dgDesired,muted:micMutedByUser,phase:callPhase,active:dgActive,should:should});
+  if(should&&!dgActive)startDeepgram();
+  else if(!should&&dgActive)stopDeepgram();
+}
+
+// ─── Phase 7: Unified teardown ────────────────────────────────────────────
+function _cleanupSilentAudioHelper(){
+  if(_silentOsc){try{_silentOsc.stop();}catch(_){}try{_silentOsc.disconnect();}catch(_){} _silentOsc=null;}
+  if(_silentAudioTrack){try{_silentAudioTrack.stop();}catch(_){} _silentAudioTrack=null;}
+  if(_silentAudioCtx){try{_silentAudioCtx.close();}catch(_){} _silentAudioCtx=null;}
+}
+
+function teardownSession(mode,reason){
+  log('teardown',{mode:mode,why:reason});
+  bumpSessionEpoch('teardown_'+mode);
+  dgDesired=false;
+  stopDeepgram();
+  if(videoStream){videoStream.getTracks().forEach(function(t){t.stop();});videoStream=null;}
+  _cleanupSilentAudioHelper();
+  if(pc){try{pc.close();}catch(_){}pc=null;}
+  stopKeepalive();stopHB();
+  if(_relayWs)try{_relayWs.close();}catch(_){}
+  _relayWs=null;
+  clearTimeout(wsReconnectTimer);wsReconnectTimer=null;
+  makingOffer=false;
+  pendingCandidates=[];savedOffer=null;savedCandidates=[];
+  resetRecoveryState();
+  saveTr();
+  callHistoryPushed=false;
+}
+
+// ─── Phase 2: Role-based post-call routing ────────────────────────────────
+function routePostCallByRole(sourceReason){
+  var role=room.role||lastSessionContext.role;
+  log('post_call_route',{role:role,why:sourceReason});
+  if(role==='creator'){
+    setCallPhase('postcall_creator',sourceReason);
+    cleanUp();
+  }else{
+    setCallPhase('postcall_joiner',sourceReason);
+    showThankYou();
+  }
+}
+
+// Safe stub — returns current lang so the race fallback never throws
+function detectLang(text,src){return src||'en';}
+
+/* === FASTTEXT WASM === */
+var _ftReady=false,_ftModule=null,_ftLoadFailed=false,_ftPending=[];
+var FT_CONF=0.5;
+var FT_CONF_SPEECH=0.58;
+var FT_LOAD_TIMEOUT_MS=15000;
+var ERR={
+  LANG_RUNTIME_LOADING:'LANG_RUNTIME_LOADING',
+  LANG_RUNTIME_FAILED:'LANG_RUNTIME_LOAD_FAILED',
+  LANG_DETECT_TOO_SHORT:'LANG_DETECT_TOO_SHORT',
+  LANG_DETECT_LOW_CONF:'LANG_DETECT_LOW_CONFIDENCE',
+  LANG_DETECT_FAILED:'LANG_DETECT_PREDICT_FAILED',
+  LANG_DETECT_EMPTY:'LANG_DETECT_EMPTY_RESULT',
+  TRANS_FAILED:'TRANSLATION_REQUEST_FAILED',
+  TRANS_EMPTY:'TRANSLATION_EMPTY_OR_IDENTITY',
+  TRANS_EXHAUSTED:'TRANSLATION_EXHAUSTED',
+  NORM_FAILED:'NORMALIZATION_FAILED',
+  TTS_FAILED:'TTS_SPEAK_FAILED',
+  TTS_UNAVAILABLE:'TTS_UNAVAILABLE'
+};
+var _langRuntime={status:'idle',startedAt:0,readyAt:0,error:null,detector:null,loadPromise:null};
+var FT_WRAPPER_JS='/stuff/fastType/fasttext-wrapper.umd.js';
+var FT_CORE_JS='/stuff/fastType/core/fasttext.mjs';
+var FT_CORE_WASM='/stuff/fastType/core/fasttext.wasm';
+var FT_MODEL='/stuff/fastType/model/lid.176.ftz';
+var FT_ASSETS=[FT_WRAPPER_JS,FT_CORE_JS,FT_CORE_WASM,FT_MODEL];
+var FT_SMOKE=[['hello how are you today','en'],['hola como estas hoy','es'],['bonjour comment allez vous','fr'],['guten morgen wie geht es dir','de']];
+function _ftStartupStep(step,extra){log('ft_startup_step',{step:step,extra:extra||null,ft_status:_langRuntime.status});}
+function _ftStartupDone(ok,msg){
+  _langRuntime.status=ok?'ready':'failed';
+  if(ok){_langRuntime.readyAt=Date.now();_langRuntime.detector=_ftModule;}
+  else{_langRuntime.error=msg||null;}
+  _ftReady=ok;_ftLoadFailed=!ok;
+  log('ft_startup_'+(ok?'ready':'degraded'),{message:msg||null,elapsed:Date.now()-_langRuntime.startedAt,ft_ready:_ftReady,ft_failed:_ftLoadFailed},ok?'ok':'warn');
+  _syncFtStatus();syncBtn();syncModalBtn();
+}
+function _ftWhitelist(){return LANGS.map(function(l){return l.code;});}
+function _ftAllowed(code){return _ftWhitelist().indexOf(code)>=0;}
+function _syncFtStatus(){
+  var dot=$('ft-dot'),label=$('ft-label'),pill=$('ft-lobby-status');
+  if(!dot||!label||!pill)return;
+  if(_ftReady){pill.classList.add('ready');}
+  else if(_ftLoadFailed){dot.className='ft-status-dot err';label.textContent='Lang detect unavailable';}
+  else{dot.className='ft-status-dot loading';label.textContent='Lang model loading…';}
+}
+function _probeFtAsset(path){
+  log('ft_asset_probe',{path:path});
+  return fetch(path,{cache:'no-store'}).then(function(res){
+    if(!res.ok)throw new Error('status_'+res.status);
+    return res.arrayBuffer().then(function(buf){
+      if(!buf||!buf.byteLength)throw new Error('empty');
+      log('ft_asset_ok',{path:path,size:buf.byteLength},'ok');
+      return true;
+    });
+  }).catch(function(e){
+    log('ft_asset_err',{path:path,e:String(e)},'error');
+    throw e;
+  });
+}
+function _ftErrDetail(e,ctx){
+  var t=(e===null)?'null':typeof e;
+  var raw;
+  try{raw=(t==='object'&&e&&e.message)?String(e.message):String(e);}catch(_){raw='[unstringifiable]';}
+  return {context:ctx||null,type:t,detail:raw};
+}
+function parseFastTextPrediction(raw,conf){
+  conf=(conf!=null?conf:FT_CONF);
+  var label=null,confidence=null,item=null;
+  if(raw instanceof Map){var first=raw.entries().next();if(!first.done){label=first.value[0];confidence=first.value[1];}}
+  else if(Array.isArray(raw)&&raw.length){item=raw[0];if(Array.isArray(item)){label=item[0];confidence=item[1];}else if(item&&typeof item==='object'){label=item.label!=null?item.label:item[0];confidence=item.prob!=null?item.prob:item.score!=null?item.score:item.probability;}else if(typeof item==='string'){label=item;}}
+  else if(raw&&typeof raw==='object'){label=raw.label!=null?raw.label:raw[0];confidence=raw.prob!=null?raw.prob:raw.score!=null?raw.score:raw.probability;}
+  else if(typeof raw==='string'){label=raw;}
+  var lang=label?String(label).replace(/^(__label__|label__)/,''):null;
+  if(!lang||_ftWhitelist().indexOf(lang)<0)return{language:null,confidence:null};
+  var n=Number(confidence);if(!isFinite(n))return{language:lang,confidence:null};
+  return{language:n>=conf?lang:null,confidence:n};
+}
+function _ftPredictLabel(ft,text,conf){
+  return parseFastTextPrediction(ft.predict(text,1),conf).language;
+}
+function getFastTextDetector(){
+  if(_langRuntime.loadPromise)return _langRuntime.loadPromise;
+  if(_langRuntime.status==='ready')return _langRuntime.loadPromise=Promise.resolve(_langRuntime.detector);
+  if(_langRuntime.status==='failed')return _langRuntime.loadPromise=Promise.resolve(null);
+  _langRuntime.loadPromise=new Promise(function(resolve){var check=setInterval(function(){if(_langRuntime.status==='ready'){clearInterval(check);resolve(_langRuntime.detector);}else if(_langRuntime.status==='failed'){clearInterval(check);resolve(null);}},100);});
+  return _langRuntime.loadPromise;
+}
+function _loadFastText(){
+  if(_ftReady||_ftLoadFailed)return;
+  _langRuntime.status='loading';_langRuntime.startedAt=Date.now();_syncFtStatus();
+  _ftStartupStep('asset probes');
+  Promise.all(FT_ASSETS.map(_probeFtAsset)).then(function(){
+    _ftStartupStep('runtime bootstrap load');
+    var ftModuleConfig={locateFile:function(path){
+      var p=String(path||'');
+      if(/\.wasm$/i.test(p))return FT_CORE_WASM;
+      var base=p.split('/').pop().split('\\').pop();
+      return '/stuff/fastType/'+base;
+    }};
+    window.Module=ftModuleConfig;
+    window.FastTextModule=ftModuleConfig;
+    log('ft_load_start',{src:FT_WRAPPER_JS});
+    var s=document.createElement('script');s.src=FT_WRAPPER_JS;
+    s.onerror=function(){ log('ft_load_err',Object.assign({src:s.src,reason:'runtime wrapper script failed to load'},_ftErrDetail(null,'script.onerror')),'error'); _ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'runtime_load_err'); _ftPending.forEach(function(cb){cb(null);});_ftPending=[]; };
+    s.onload=function(){
+      if(typeof FastText==='undefined'){log('ft_no_global',{reason:'FastText global missing after wrapper load'},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'runtime_init_err: FastText global missing');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];return;}
+      try{
+        var ft=new FastText();
+        _ftStartupStep('model load');
+        log('ft_model_load',{model:FT_MODEL});
+        var timer=setTimeout(function(){log('ft_model_timeout',{ms:FT_LOAD_TIMEOUT_MS,reason:'FastText model load timeout'},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,'timeout: model load exceeded '+FT_LOAD_TIMEOUT_MS+'ms');_ftPending.forEach(function(cb){cb(null);});_ftPending=[];},FT_LOAD_TIMEOUT_MS);
+        ft.loadModel(FT_MODEL).then(function(){
+          _ftStartupStep('smoke tests');
+          return Promise.all(FT_SMOKE.map(function(pair){
+            var got=_ftPredictLabel(ft,pair[0]);
+            if(got!==pair[1])throw new Error('smoke mismatch: input="'+pair[0]+'" expected="'+pair[1]+'" got="'+got+'"');
+            return got;
+          }));
+        }).then(function(){
+          clearTimeout(timer);_ftModule=ft;_ftReady=true;_syncFtStatus();_ftStartupDone(true,'ready');log('ft_ready',{},'ok');_ftPending.forEach(function(cb){cb(ft);});_ftPending=[];
+        }).catch(function(e){
+          clearTimeout(timer);log('ft_model_err',{reason:'runtime/model init or smoke failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];
+        });
+      }catch(e){log('ft_init_err',{reason:'FastText constructor/init failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];}
+    };
+    document.head.appendChild(s);
+  }).catch(function(e){log('ft_probe_err',{reason:'asset probe failure',detail:String(e)},'error');_ftLoadFailed=true;_syncFtStatus();_ftStartupDone(false,String(e));_ftPending.forEach(function(cb){cb(null);});_ftPending=[];});
+}
+function _detectLangAsync(text,conf){
+  var t=(text||'').trim();if(!t)return Promise.resolve(null);
+  if(/[\u0E00-\u0E7F]/.test(t))return Promise.resolve('th');
+  if(/[\u3040-\u30FF\u31F0-\u31FF]/.test(t))return Promise.resolve('ja');
+  if(/[\u4E00-\u9FFF]/.test(t))return Promise.resolve('zh');
+  if(/[\uAC00-\uD7A3]/.test(t))return Promise.resolve('ko');
+  if(/[\u0600-\u06FF]/.test(t))return Promise.resolve('ar');
+  if(/[\u0900-\u097F]/.test(t))return Promise.resolve('hi');
+  if(/[\u0400-\u04FF]/.test(t))return Promise.resolve('ru');
+  if(_ftLoadFailed)return Promise.resolve(null);
+  if(_ftReady&&_ftModule){
+    return new Promise(function(resolve){
+      try{resolve(parseFastTextPrediction(_ftModule.predict(t,1),conf).language);}catch(_){resolve(null);}
+    });
+  }
+  return new Promise(function(resolve){
+    _ftPending.push(function(ft){
+      if(!ft){resolve(null);return;}
+      try{resolve(parseFastTextPrediction(ft.predict(t,1),conf).language);}catch(_){resolve(null);}
+    });
+    if(!_ftReady&&!_ftLoadFailed&&_ftPending.length===1)_loadFastText();
+  });
+}
+function _detectLangAsyncSpeech(text){return _detectLangAsync(text,FT_CONF_SPEECH);}
+async function processConversationInput(opts){
+  var text=opts.text,channel=opts.channel,src=opts.src,tgt=opts.tgt;
+  var pipelineEvent=channel==='speech'?'norm_pipeline_speech':'norm_pipeline_chat';
+  log(pipelineEvent,{stage:'start',src:src,tgt:tgt,raw:(text||'').slice(0,60)});
+  var detected=null,detectionMethod='none';
+  var wordCount=(text||'').trim().split(/\s+/).length;
+  var isNonLatin=/[\u0E00-\u0E7F\u3040-\u30FF\u4E00-\u9FFF\uAC00-\uD7A3\u0600-\u06FF\u0900-\u097F\u0400-\u04FF]/.test(text||'');
+  var tooShort=(wordCount<4&&!isNonLatin);
+  if(tooShort){detected=src;detectionMethod='stub_short';log(pipelineEvent,{stage:'detect',code:ERR.LANG_DETECT_TOO_SHORT,words:wordCount,detected:src,method:'stub_short'});}
+  else{
+    try{detected=await (channel==='speech'?_detectLangAsyncSpeech(text):_detectLangAsync(text));detectionMethod=_langRuntime.status==='ready'?'wasm':'stub';}
+    catch(e){log(pipelineEvent,{stage:'detect_err',code:ERR.LANG_DETECT_FAILED,e:String(e)},'error');detected=src;detectionMethod='error';}
+  }
+  var srcText=text,tgtText=text,translationFailed=false;
+  if(detected&&detected!==src){try{var normed=await translateWithRetry(text,detected,src,2);if(normed&&normed!==text)srcText=normalizeText(normed,'speech');}catch(_e){}}
+  tgtText=srcText;
+  if(src&&tgt&&src!==tgt){try{var tr=await translateWithRetry(srcText,src,tgt,2);tr=normalizeText(tr||'','speech');if(!tr||normalizeText(tr,'compare')===normalizeText(srcText,'compare')){translationFailed=true;tgtText=srcText;}else{tgtText=tr;}}catch(e2){translationFailed=true;tgtText=srcText;}}
+  return{srcText:srcText,tgtText:tgtText,translationFailed:translationFailed,detected:detected,method:detectionMethod};
+}
+
+/* === CHAT === */
+var _pbMutedMic=false;
+function composeFocusMute(){
+  if(!isCallActive())return;
+  if(micOn&&!micMutedByUser){_pbMutedMic=true;toggleMic();}
+  else if(!micOn){toast('Mic is muted — tap mic button to speak');}
+}
+function _pbRestoreMic(){
+  if(_pbMutedMic&&!micOn&&isCallActive()){_pbMutedMic=false;toggleMic();}else{_pbMutedMic=false;}
+}
+function chatInputEvt(){
+  var ta=$('chat-input');if(!ta)return;
+  var raw=ta.value||'';
+  ta.style.height='auto';
+  ta.style.height=Math.min(ta.scrollHeight,80)+'px';
+  $('chat-send-btn').disabled=!raw.trim();
+  // Filter search drawer live if open
+  if(_pbDrawerMode==='search')pbRunSearch();
+}
+function chatKeydown(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}}
+
+function handleChatFile(ev){
+  var file=ev&&ev.target&&ev.target.files&&ev.target.files[0];
+  if(!file)return;
+  ev.target.value='';
+  var maxMb=5;
+  if(file.size>maxMb*1024*1024){toast('File must be under '+maxMb+'MB');return;}
+  var reader=new FileReader();
+  reader.onload=function(){
+    var dataUrl=reader.result;
+    var srcText='[file:'+file.name+']';
+    var entry={id:'cf-'+uid(),type:'chat',who:'me',sourceText:srcText,translatedText:srcText,srcLang:room.myLang,tgtLang:room.theirLang,ts:Date.now(),attachment:{name:file.name,dataUrl:dataUrl,type:file.type}};
+    _attCache[entry.id]={name:file.name,dataUrl:dataUrl,type:file.type};
+    transcript.push(entry);saveTr();appendTrDom(entry);
+    var relayMsg={type:'chat-msg',chatId:entry.id,srcText:srcText,tgtText:srcText,srcLang:room.myLang,tgtLang:room.theirLang,attachment:{name:file.name,dataUrl:dataUrl,type:file.type}};
+    _chatOutbox.set(entry.id,relayMsg);
+    relaySend(relayMsg);
+    log('chat_file',{name:file.name},'ok');
+  };
+  reader.readAsDataURL(file);
+}
+
+async function sendChat(){
+  var ta=$('chat-input');
+  var text=normalizeText((ta&&ta.value||''),'chat');if(!text||!room.id)return;
+  if(!text)return;
+  ta.value='';ta.style.height='';$('chat-send-btn').disabled=true;
+  pbCloseDrawer();
+  var src=room.myLang,tgt=room.theirLang;
+  var srcText=text;
+  log('chat_norm_start',{src:src,tgt:tgt,ft_ready:_ftReady,text:text.slice(0,60)});
+  var p=await processConversationInput({text:text,channel:'chat',src:src,tgt:tgt});
+  srcText=p.srcText;var tgtText=p.tgtText;
+  var id='cm-'+uid();
+  var entry={id:id,type:'chat',who:'me',sourceText:srcText,translatedText:tgtText,srcLang:src,tgtLang:tgt,ts:Date.now()};
+  transcript.push(entry);saveTr();
+  appendTrDom(entry);
+  var relayMsg={type:'chat-msg',chatId:id,srcText:srcText,tgtText:tgtText,srcLang:src,tgtLang:tgt};
+  _chatOutbox.set(id,relayMsg);
+  relaySend(relayMsg);
+  log('chat_sent',{t:srcText.slice(0,40)},'ok');
+}
+
+function handleChatMsg(d){
+  if(!d)return;
+  // Dedupe by chatId (Phase 6)
+  if(d.chatId){
+    if(_chatReceived.has(d.chatId))return;
+    _chatReceived.add(d.chatId);
+    // Ack back so sender can clear outbox
+    relaySend({type:'chat-ack',chatId:d.chatId,transient:true});
+  }
+  // Also ignore echoes of our own sent messages
+  if(d.chatId&&transcript.some(function(e){return e.id===d.chatId&&e.who==='me';}))return;
+  var entry={
+    id:d.chatId||('ci-'+uid()),
+    type:'chat',
+    who:'partner',
+    sourceText:normalizeText(d.srcText||'','chat'),
+    translatedText:normalizeText(d.tgtText||d.srcText||'','chat'),
+    srcLang:d.srcLang||room.theirLang,
+    tgtLang:d.tgtLang||room.myLang,
+    ts:d.ts||Date.now(),
+    attachment:d.attachment||null
+  };
+  if(entry.attachment&&entry.attachment.dataUrl)_attCache[entry.id]=entry.attachment;
+  transcript.push(entry);saveTr();
+  appendTrDom(entry);
+  markPartnerTalking();
+  if(transcriptTtsOn&&entry.translatedText&&entry.who==='partner')speakText(entry.translatedText,entry.tgtLang||room.myLang);
+  log('chat_rx',{t:(d.srcText||'').slice(0,40)},'ok');
+}
+
+var LS={setup:'setup',call:'call'};
+var lobbyState=LS.setup;
+
+function $(id){return document.getElementById(id)}
+function attModalOpenById(id){var att=_attCache[id];if(att)attModalOpen(att);}
+function attModalOpen(att){
+  var m=document.getElementById('att-modal');
+  var nm=document.getElementById('att-modal-name');
+  var dl=document.getElementById('att-modal-dl');
+  var body=document.getElementById('att-modal-body');
+  if(!m||!body)return;
+  if(nm)nm.textContent=att.name||'Attachment';
+  if(dl){dl.href=att.dataUrl||'#';dl.download=att.name||'file';}
+  var isImg=/^image\//.test(att.type||'');
+  if(isImg){body.innerHTML='<img src="'+att.dataUrl+'" style="max-width:100%;border-radius:8px;">';}
+  else{body.innerHTML='<iframe src="'+att.dataUrl+'" sandbox="allow-same-origin"></iframe>';}
+  m.classList.add('show');
+}
+function attModalClose(){
+  var m=document.getElementById('att-modal');if(m)m.classList.remove('show');
+  var b=document.getElementById('att-modal-body');if(b)b.innerHTML='';
+}
+function removeTrEntry(id){
+  transcript=transcript.filter(function(e){return e.id!==id;});
+  saveTr();
+  delete _attCache[id];
+  var el=document.querySelector('[data-tr-id="'+id+'"]');
+  if(el)el.remove();
+}
+function toast(m,dur){var e=$('toast');e.textContent=m;e.classList.add('show');clearTimeout(toast._t);toast._t=setTimeout(function(){e.classList.remove('show')},dur||2800)}
+function uid(){return Date.now().toString(36)+Math.random().toString(36).slice(2,8)}
+function esc(s){var d=document.createElement('div');d.textContent=s||'';return d.innerHTML}
+function norm(s){return(s||'').replace(/\s+/g,' ').trim()}
+// ═══════════════════════════════════════════════════
+// PHRASEBOOK v2 — test.html-compatible schema
+// Storage: say_cards · say_catalogs · say_tags
+// Drawer: // = commands, / = omnisearch (call-only)
+// ═══════════════════════════════════════════════════
+'use strict';
+
+/* ── Storage keys ── */
+var PB_BASE_URL='https://github.acmeproducts.com/stuff/phrase/';
+var PB_CARDS='say_cards',PB_CATS='say_catalogs',PB_TAGS_K='say_tags',PB_SEEDED='pb_bridge_v2';
+var PB_BOOKS_KEY='pb_books_registry'; // [{id,name,createdAt,isDefault}]
+
+/* ── Embedded seed data ── */
+var PB_SEED={"type":"phrasebook","cards":[{"id":"mnhd6ozl7hxlpp","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ขอโทษ ฉันพูดไทยไม่ค่อยได้","target":"Sorry, I don't speak Thai very well.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Sorry, I don't speak Thai very well.","resultText":"","verdict":"","contentHash":"ขอโทษ ฉันพูดไทยไม่ค่อยได้||Sorry, I don't speak Thai very well.","updatedAt":1775127670421},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127676161,"updatedAt":1775127676161},{"id":"mnhd5sqhkvcmbj","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณชื่ออะไร","target":"What is your name? ","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"What is your name? ","resultText":"","verdict":"","contentHash":"คุณชื่ออะไร||What is your name?","updatedAt":1775127521508},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127634361,"updatedAt":1775127634361},{"id":"mnhd5rc2ivpbkc","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันชื่อ...","target":"My name is ...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"My name is ...","resultText":"","verdict":"","contentHash":"ฉันชื่อ...||My name is ...","updatedAt":1775127525221},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127632546,"updatedAt":1775127632546},{"id":"mnhd5pimpgxr40","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณอายุเท่าไหร่","target":"How old are you?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How old are you?","resultText":"","verdict":"","contentHash":"คุณอายุเท่าไหร่||How old are you?","updatedAt":1775127528762},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127630190,"updatedAt":1775127630190},{"id":"mnhd5nb7t16q6d","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณช่วยฉันได้ไหม","target":"Can you help me?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Can you help me?","resultText":"","verdict":"","contentHash":"คุณช่วยฉันได้ไหม||Can you help me?","updatedAt":1775127543356},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127627331,"updatedAt":1775127627331},{"id":"mnhd5heb3ge0bg","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันอายุ....ปี","target":"I am.... years old.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I am.... years old.","resultText":"","verdict":"","contentHash":"ฉันอายุ....ปี||I am.... years old.","updatedAt":1775127609337},"clarifyChain":[],"savedBy":"Pam","createdAt":1775127619667,"updatedAt":1775127619667},{"id":"mnhbaipi7n2g3o","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"อรุณสวัสดิ์","target":"Good morning","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Good morning","resultText":"","verdict":"","contentHash":"อรุณสวัสดิ์||Good morning","updatedAt":1775124430577},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124495414,"updatedAt":1775124495414},{"id":"mnhba9ggtikgc7","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ซ้าย/ขวา/ตรงไป","target":"Left/Right/Straight","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Left/Right/Straight","resultText":"","verdict":"","contentHash":"ซ้าย/ขวา/ตรงไป||Left/Right/Straight","updatedAt":1775124477253},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124483424,"updatedAt":1775124483424},{"id":"mnhba8ehouyhzp","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันอยากไป...","target":"I want to go...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I want to go...","resultText":"","verdict":"","contentHash":"ฉันอยากไป...||I want to go...","updatedAt":1775124467845},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124482057,"updatedAt":1775124482057},{"id":"mnhb9p4i5y4z0w","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ราตรีสวัสดิ์","target":"good night","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"good night","resultText":"","verdict":"","contentHash":"ราตรีสวัสดิ์||good night","updatedAt":1775124442677},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124457074,"updatedAt":1775124457074},{"id":"mnhb9nsgvvfg0y","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เจอกันใหม่","target":"See you later.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"See you later.","resultText":"","verdict":"","contentHash":"เจอกันใหม่||See you later.","updatedAt":1775124446261},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124455344,"updatedAt":1775124455344},{"id":"mnhb9mr2rznooq","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เท่าไหร่","target":"How much is it?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How much is it?","resultText":"","verdict":"","contentHash":"เท่าไหร่||How much is it?","updatedAt":1775124450852},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124453998,"updatedAt":1775124453998},{"id":"mnhb89mv3u4zo3","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ช่วยด้วย","target":"Help.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Help.","resultText":"","verdict":"","contentHash":"ช่วยด้วย||Help.","updatedAt":1775124368359},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124390343,"updatedAt":1775124390343},{"id":"mnhb88qc00qe6t","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันหลงทาง","target":"I'm lost.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I'm lost.","resultText":"","verdict":"","contentHash":"ฉันหลงทาง||I'm lost.","updatedAt":1775124371739},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124389172,"updatedAt":1775124389172},{"id":"mnhb87nl5ghaaq","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เรียกตำรวจ","target":"Call the police.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Call the police.","resultText":"","verdict":"","contentHash":"เรียกตำรวจ||Call the police.","updatedAt":1775124377835},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124387777,"updatedAt":1775124387777},{"id":"mnhb86m19cxq5u","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันต้องการหมอ","target":"I need a doctor","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I need a doctor","resultText":"","verdict":"","contentHash":"ฉันต้องการหมอ||I need a doctor","updatedAt":1775124382380},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124386425,"updatedAt":1775124386425},{"id":"mnhb7h1wzbqmpp","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"I want this","target":"ฉันเอาอันนี้","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันเอาอันนี้","resultText":"","verdict":"","contentHash":"I want this||ฉันต้องการแบบนี้","updatedAt":1775124322105},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124353300,"updatedAt":1775124353300},{"id":"mnhb6ra1x98obt","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Can you lower the price?","target":"ลดราคาหน่อยได้ไหม","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ลดราคาหน่อยได้ไหม","resultText":"","verdict":"","contentHash":"Can you lower the price?||ลดราคาหน่อยได้ไหม","updatedAt":1775124296076},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124319897,"updatedAt":1775124319897},{"id":"mnhb671p3dgige","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"How much is this?","target":"อันนี้ราคาเท่าไหร่","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"อันนี้ราคาเท่าไหร่","resultText":"","verdict":"","contentHash":"How much is this?||นี่เท่าไหร่","updatedAt":1775124257766},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124293677,"updatedAt":1775124293677},{"id":"mnhb4whppegmz4","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันเอาอันนี้","target":"I'll take this one.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I'll take this one.","resultText":"","verdict":"","contentHash":"ฉันเอาอันนี้||I'll take this one.","updatedAt":1775124208507},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124233341,"updatedAt":1775124233341},{"id":"mnhb4tqrrylp94","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"คุณมี..ไหม","target":"Do you have..?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Do you have..?","resultText":"","verdict":"","contentHash":"คุณมี..ไหม||Do you have..?","updatedAt":1775124226415},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124229779,"updatedAt":1775124229779},{"id":"mnhb3qzifksu90","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Check, please","target":"เช็คบิลด้วย","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"เช็คบิลด้วย","resultText":"","verdict":"","contentHash":"Check, please||ตรวจสอบได้โปรด","updatedAt":1775124139994},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124179550,"updatedAt":1775124179550},{"id":"mnhb2l5e2yj4jl","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Menu, please","target":"ขอเมนูหน่อย","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอเมนูหน่อย","resultText":"","verdict":"","contentHash":"Menu, please||เมนูได้โปรด","updatedAt":1775124094266},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124125330,"updatedAt":1775124125330},{"id":"mnhb1pfnvwo41g","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"อร่อย","target":"Delicious","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Delicious","resultText":"","verdict":"","contentHash":"อร่อย||Delicious","updatedAt":1775124062936},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124084227,"updatedAt":1775124084227},{"id":"mnhb1lqwob2ysb","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"น้ำอัดลม","target":"Carbonated drink","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Carbonated drink","resultText":"","verdict":"","contentHash":"น้ำอัดลม||Carbonated drink","updatedAt":1775124037951},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124079448,"updatedAt":1775124079448},{"id":"mnhb1dxdoeuxpd","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"น้ำเปล่า","target":"Water","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Water","resultText":"","verdict":"","contentHash":"น้ำเปล่า||Water","updatedAt":1775124034461},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124069313,"updatedAt":1775124069313},{"id":"mnhb1ar98mw7x3","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"เช็คบิล","target":"Check Bills","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Check Bills","resultText":"","verdict":"","contentHash":"เช็คบิล||Check Bills","updatedAt":1775124060719},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124065205,"updatedAt":1775124065205},{"id":"mnhb0i55fatnud","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ฉันกินมังสวิรัติ","target":"I am a vegetarian.","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"I am a vegetarian.","resultText":"","verdict":"","contentHash":"ฉันกินมังสวิรัติ||I am a vegetarian.","updatedAt":1775124022710},"clarifyChain":[],"savedBy":"Pam","createdAt":1775124028121,"updatedAt":1775124028121},{"id":"mnhazuhsabexw1","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"สถานีรถไฟ","target":"Train station","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Train station","resultText":"","verdict":"","contentHash":"สถานีรถไฟ||Train station","updatedAt":1775123982780},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123997472,"updatedAt":1775123997472},{"id":"mnhazsg7yh1yc4","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ป้ายรถเมล์","target":"Bus stop","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Bus stop","resultText":"","verdict":"","contentHash":"ป้ายรถเมล์||Bus stop","updatedAt":1775123976729},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123994823,"updatedAt":1775123994823},{"id":"mnhazrfvpdal4i","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ค่าโดยสารเท่าไหร่","target":"How much is the fare?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"How much is the fare?","resultText":"","verdict":"","contentHash":"ค่าโดยสารเท่าไหร่||How much is the fare?","updatedAt":1775123971900},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123993515,"updatedAt":1775123993515},{"id":"mnhazq8se0tg1f","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"แท็กซี่อยู่ไหน","target":"Where's the taxi?","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Where's the taxi?","resultText":"","verdict":"","contentHash":"แท็กซี่อยู่ไหน||Where's the taxi?","updatedAt":1775123964993},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123991964,"updatedAt":1775123991964},{"id":"mnhayzu33872p1","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ไม่ใช่","target":"NO","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"NO","resultText":"","verdict":"","contentHash":"ไม่ใช่||NO","updatedAt":1775123953876},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123957739,"updatedAt":1775123957739},{"id":"mnhayyoioghmhx","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ใช่","target":"Yes","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Yes","resultText":"","verdict":"","contentHash":"ใช่||Yes","updatedAt":1775123952083},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123956242,"updatedAt":1775123956242},{"id":"mnhay9psbcymxo","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"I'm fine, thank you","target":"ฉันสบายดี ขอบคุณ","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันสบายดี ขอบคุณ","resultText":"","verdict":"","contentHash":"I'm fine, thank you||ฉันสบายดี ขอบคุณค่ะ","updatedAt":1775123880780},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123923888,"updatedAt":1775123923888},{"id":"mnhax9ua30pb0m","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"Excuse me","target":"ขอโทษ","notes":"","tags":[],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอโทษ","resultText":"","verdict":"","contentHash":"Excuse me||ขอโทษ","updatedAt":1775123863947},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123877394,"updatedAt":1775123877394},{"id":"mnhavy4sxlyxp5","catalogIds":[],"sourceLang":"th","targetLang":"en","source":"ขอโทษ","target":"Sorry...","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"th","inputText":"Sorry...","resultText":"","verdict":"","contentHash":"ขอโทษ||Sorry...","updatedAt":1775123785278},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123815564,"updatedAt":1775123815564},{"id":"mnhatx7ik6bvn9","catalogIds":[],"sourceLang":"en","targetLang":"th","source":"How are you?","target":"สบายดีไหม","notes":"","tags":[],"backtranslate":{"sourceLang":"en","targetLang":"en","inputText":"สบายดีไหม","resultText":"","verdict":"","contentHash":"How are you?||สบายดีใช่ไหม","updatedAt":1775123661449},"clarifyChain":[],"savedBy":"Pam","createdAt":1775123721054,"updatedAt":1775123721054},{"id":"s0","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Hello","target":"สวัสดี","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"สวัสดี","resultText":"","verdict":"","contentHash":"Hello||สวัสดี","updatedAt":1774111157235},"clarifyChain":[],"savedBy":"seed","createdAt":1774111157235,"updatedAt":1774111157235},{"id":"s1","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Thank you","target":"ขอบคุณ","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ขอบคุณ","resultText":"","verdict":"","contentHash":"Thank you||ขอบคุณ","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111156237,"updatedAt":1774111157237},{"id":"s2","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"How much?","target":"เท่าไหร่?","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"เท่าไหร่?","resultText":"","verdict":"","contentHash":"How much?||เท่าไหร่?","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111155237,"updatedAt":1774111157237},{"id":"s3","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"Where is the bathroom?","target":"ห้องน้ำอยู่ที่ไหน?","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ห้องน้ำอยู่ที่ไหน?","resultText":"","verdict":"","contentHash":"Where is the bathroom?||ห้องน้ำอยู่ที่ไหน?","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111154237,"updatedAt":1774111157237},{"id":"s4","catalogIds":["cat-th"],"sourceLang":"en","targetLang":"th","source":"I don't understand","target":"ฉันไม่เข้าใจ","notes":"","tags":["essential"],"backtranslate":{"sourceLang":"th","targetLang":"en","inputText":"ฉันไม่เข้าใจ","resultText":"","verdict":"","contentHash":"I don't understand||ฉันไม่เข้าใจ","updatedAt":1774111157237},"clarifyChain":[],"savedBy":"seed","createdAt":1774111153237,"updatedAt":1774111157237}],"catalogs":[{"id":"cat-th","name":"Thailand Travel","emoji":"🇹🇭","desc":"Essential phrases","createdAt":1774111157234}],"tags":["essential"]};
+
+/* ── Helpers ── */
+var PB_ICON_TTS='<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>';
+var ICO={
+  plus:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
+  book:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>',
+  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
+  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg>',
+  warn:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  link:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+  trash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>',
+  hardtrash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#c0392b" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>',
+  tag:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>',
+  chat:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+  verify:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>',
+  chevdown:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>',
+  restore:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg>',
+  speaker:PB_ICON_TTS,
+  use:'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>',
+  clip:'<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>',
+  x:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>'
+};
+var _attCache={}; // entryId -> {name,dataUrl,type}
+var _btCache={};  // cardId -> {text,lang}
+function pbEsc(s){var d=document.createElement('div');d.textContent=String(s||'');return d.innerHTML;}
+function pbLangFlag(c){var l=LANGS.find(function(x){return x.code===c;});return l?l.flag:'🌐';}
+function pbLangLabel(c){var l=LANGS.find(function(x){return x.code===c;});return l?l.label:(c||'?');}
+function pbNow(){return Date.now();}
+
+/* ── Card normalize ── */
+function pbNorm(c){
+  var now=pbNow();c=c||{};
+  var bt=c.backtranslate||{};
+  return {
+    id:c.id||(Date.now().toString(36)+Math.random().toString(36).slice(2,6)),
+    catalogIds:Array.isArray(c.catalogIds)?c.catalogIds:[],
+    sourceLang:c.sourceLang||'en',
+    targetLang:c.targetLang||'en',
+    source:(c.source||'').trim(),
+    target:(c.target||'').trim(),
+    notes:(c.notes||'').trim(),
+    tags:Array.isArray(c.tags)?c.tags.filter(Boolean):[],
+    backtranslate:{sourceLang:bt.sourceLang||c.targetLang||'en',targetLang:bt.targetLang||c.sourceLang||'en',inputText:bt.inputText||c.target||'',resultText:bt.resultText||'',verdict:bt.verdict||'',contentHash:bt.contentHash||'',updatedAt:bt.updatedAt||now},
+    clarifyChain:Array.isArray(c.clarifyChain)?c.clarifyChain:[],
+    savedBy:c.savedBy||'',
+    deletedAt:c.deletedAt||null,
+    createdAt:c.createdAt||now,
+    updatedAt:c.updatedAt||now
+  };
+}
+
+/* ── Storage CRUD ── */
+function pbGetAllCards(){try{return JSON.parse(localStorage.getItem(PB_CARDS)||'[]').map(pbNorm);}catch(_){return[];}}
+function pbGetCards(){return pbGetAllCards().filter(function(c){return !c.deletedAt;});}
+function pbSaveCards(a){try{localStorage.setItem(PB_CARDS,JSON.stringify(a));}catch(_){toast('Storage full');}}
+function pbGetCats(){try{return JSON.parse(localStorage.getItem(PB_CATS)||'[]');}catch(_){return[];}}
+function pbSaveCats(a){try{localStorage.setItem(PB_CATS,JSON.stringify(a));}catch(_){}}
+function pbGetTags(){try{return JSON.parse(localStorage.getItem(PB_TAGS_K)||'[]');}catch(_){return[];}}
+function pbSaveTags(a){try{localStorage.setItem(PB_TAGS_K,JSON.stringify(a));}catch(_){}}
+function pbCardKey(c){return (c.sourceLang||'')+'|'+(c.source||'').trim().toLowerCase()+'|'+(c.targetLang||'')+'|'+(c.target||'').trim().toLowerCase();}
+function pbUpsert(card){
+  var cards=pbGetCards();var key=pbCardKey(card);
+  var i=cards.findIndex(function(c){return pbCardKey(c)===key;});
+  var next=pbNorm(card);if(i>=0)cards[i]=next;else cards.unshift(next);
+  pbSaveCards(cards);return next;
+}
+function pbGetCardById(id){return pbGetAllCards().find(function(c){return c.id===id;})||null;}
+function pbSaveCard(card){
+  var cards=pbGetCards();var i=cards.findIndex(function(c){return c.id===card.id;});
+  var next=pbNorm(card);next.updatedAt=pbNow();
+  if(i>=0)cards[i]=next;else cards.unshift(next);
+  pbSaveCards(cards);
+}
+function pbSoftDelete(id){
+  var card=pbGetCardById(id);if(!card)return;
+  card.deletedAt=pbNow();pbSaveCard(card);
+  var el=document.getElementById('pbb-'+id);
+  if(el){el.classList.add('deleted');pbReRenderBubbleChevron(id);}
+  toast('Moved to trash');
+}
+function pbHardDelete(id){
+  if(!confirm('Permanently delete this phrase?'))return;
+  pbSaveCards(pbGetAllCards().filter(function(c){return c.id!==id;}));
+  var el=document.getElementById('pbb-'+id);if(el)el.remove();
+  toast('Permanently deleted');
+}
+function pbRestoreCard(id){
+  var card=pbGetCardById(id);if(!card)return;
+  card.deletedAt=null;pbSaveCard(card);
+  var el=document.getElementById('pbb-'+id);
+  if(el){el.classList.remove('deleted');pbReRenderBubbleChevron(id);}
+  toast('Phrase restored');
+}
+function pbReRenderBubbleChevron(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var row=document.getElementById('pbchev-'+id);if(!row)return;
+  row.innerHTML=pbChevRowHtml(card);
+  row.className='pb-chevron-row'+(card.deletedAt?' deleted':'');
+}
+function pbChevRowHtml(card){
+  var id=card.id;
+  if(card.deletedAt){
+    return '<span style="font-size:10px;color:#c0392b;flex:1;padding-left:4px;">In trash</span>'
+      +'<button class="pb-icon-btn restore" onclick="pbRestoreCard(\'' +id+ '\')" title="Restore">'+ICO.restore+'</button>'
+      +'<button class="pb-icon-btn danger" onclick="pbHardDelete(\'' +id+ '\')" title="Delete permanently">'+ICO.hardtrash+'</button>';
+  }
+  return '<button class="pb-icon-btn danger" onclick="pbSoftDelete(\''+id+'\')" title="Move to trash">'+ICO.trash+'</button>';
+}
+function pbAddTagToReg(t){var tags=pbGetTags();if(tags.indexOf(t)<0){tags.push(t);pbSaveTags(tags);}}
+
+/* ── Auto-seed ── */
+function pbGetBooks(){try{return JSON.parse(localStorage.getItem(PB_BOOKS_KEY)||'null')||[{id:'default',name:'Default',createdAt:0,isDefault:true}];}catch(_){return [{id:'default',name:'Default',createdAt:0,isDefault:true}];}}
+function pbSaveBooks(a){try{localStorage.setItem(PB_BOOKS_KEY,JSON.stringify(a));}catch(_){}}
+function pbOpenBooksModal(){
+  var books=pbGetBooks();var m=document.getElementById('pb-books-modal');if(!m)return;
+  var list=document.getElementById('pb-books-list');
+  if(list)list.innerHTML=books.map(function(b){
+    var ts=b.createdAt?new Date(b.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+    var cnt=b.cardCount?(' · '+b.cardCount+' phrases'):'';
+    var del=b.isDefault
+      ?'<span style="font-size:10px;color:#9a9592;">default</span>'
+      :'<button onclick="pbDeleteBook(\''+b.id+'\')" style="background:none;border:none;cursor:pointer;color:#c0392b;padding:2px 6px;line-height:0;" title="Remove">'+ICO.trash+'</button>';
+    return '<div class="pb-book-row"><div style="flex:1;min-width:0;"><div style="font-size:14px;font-weight:600;color:#1a1714;">'+pbEsc(b.name)+'</div>'
+      +'<div style="font-size:11px;color:#9a9592;">'+pbEsc(ts+cnt)+'</div></div>'+del+'</div>';
+  }).join('');
+  m.style.display='flex';
+}
+function pbDeleteBook(id){
+  var books=pbGetBooks().filter(function(b){return b.id!==id;});pbSaveBooks(books);pbOpenBooksModal();toast('Removed');
+}
+function pbAutoSeed(){
+  localStorage.removeItem('tb_standard_phrasebook');
+  if(localStorage.getItem(PB_SEEDED))return;
+  pbApplyImport(PB_SEED,{silent:true});
+  localStorage.setItem(PB_SEEDED,'1');
+}
+
+/* ── Import/export ── */
+function pbApplyImport(data,opts){
+  var cards=(data.cards||[]).map(pbNorm);
+  var existing=pbGetCards();var byKey={};
+  existing.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  cards.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  pbSaveCards(Object.values(byKey));
+  var cats=pbGetCats();var catIds=cats.map(function(c){return c.id;});
+  (data.catalogs||[]).forEach(function(cat){if(cat&&cat.id&&catIds.indexOf(cat.id)<0)cats.push(cat);});
+  pbSaveCats(cats);
+  var tags=pbGetTags();(data.tags||[]).forEach(function(t){if(tags.indexOf(t)<0)tags.push(t);});
+  pbSaveTags(tags);
+  if(!opts||!opts.silent)toast('Imported '+cards.length+' phrases');
+}
+function pbExport(name){
+  var payload={type:'phrasebook',cards:pbGetCards(),catalogs:pbGetCats(),tags:pbGetTags(),exportedAt:pbNow()};
+  var fn=(name||('phrases-'+Date.now()))+'.json';
+  var a=document.createElement('a');
+  a.href=URL.createObjectURL(new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}));
+  a.download=fn;a.click();
+  setTimeout(function(){URL.revokeObjectURL(a.href);},0);
+  toast('Exported: '+fn);
+}
+function pbReset(){pbResetConfirm();}
+
+/* ── Active language pair ── */
+function pbActivePair(){
+  if(!room.id||!room.myLang||!room.theirLang)return null;
+  return{src:room.myLang,tgt:room.theirLang};
+}
+function pbCardMatchesPair(card,pair){
+  if(!pair)return true;
+  return(card.sourceLang===pair.src&&card.targetLang===pair.tgt)||
+         (card.sourceLang===pair.tgt&&card.targetLang===pair.src);
+}
+
+/* ── Search (supports - exclude) ── */
+function pbSearch(q,cards){
+  if(!q||!q.trim())return cards;
+  var tokens=q.trim().toLowerCase().split(/\s+/);
+  var inc=tokens.filter(function(t){return t[0]!=='-';});
+  var exc=tokens.filter(function(t){return t[0]==='-';}).map(function(t){return t.slice(1);});
+  return cards.filter(function(c){
+    var hay=[c.source,c.target,c.notes,(c.tags||[]).join(' '),
+             (c.clarifyChain||[]).map(function(x){return x.text||'';}).join(' '),
+             (c.backtranslate&&c.backtranslate.resultText)||'',
+             c.sourceLang,c.targetLang].join(' ').toLowerCase();
+    var verdict=(c.backtranslate&&c.backtranslate.verdict)||'';
+    if(exc.some(function(t){return t&&hay.indexOf(t)>=0;}))return false;
+    return inc.every(function(t){
+      if(!t)return true;
+      if(t.indexOf('verdict:')===0)return verdict===t.slice(8);
+      if(t.indexOf('tag:')===0)return(c.tags||[]).indexOf(t.slice(4))>=0;
+      return hay.indexOf(t)>=0;
+    });
+  });
+}
+
+/* ─────────────────────────────────────────────────
+   DRAWER
+───────────────────────────────────────────────── */
+var _pbDrawerMode=''; // 'commands'|'search'
+function pbToggleDrawer(){
+  if(_pbDrawerMode==='search'){pbCloseDrawer();return;}
+  pbOpenSearchDrawer('');
+  var btn=document.getElementById('pb-strip-btn');
+  if(btn)btn.classList.add('active');
+}
+function pbOpenCmdDrawer(){
+  _pbDrawerMode='commands';
+  var c=document.getElementById('pb-drawer-content');
+  if(c)c.innerHTML=pbCmdDrawerHtml();
+  var d=document.getElementById('pb-drawer');if(d)d.classList.add('open');
+}
+function pbOpenSearchDrawer(q){
+  _pbDrawerMode='search';
+  var c=document.getElementById('pb-drawer-content');
+  if(c)c.innerHTML=pbSearchDrawerHtml();
+  var d=document.getElementById('pb-drawer');if(d)d.classList.add('open');
+  var btn=document.getElementById('pb-strip-btn');if(btn)btn.classList.add('active');
+  setTimeout(function(){
+    var si=document.getElementById('pb-search-input');
+    if(si){si.value=q||'';pbRunSearch();si.focus();}
+  },40);
+}
+function pbCloseDrawer(){
+  var d=document.getElementById('pb-drawer');if(d)d.classList.remove('open');
+  _pbDrawerMode='';
+  var btn=document.getElementById('pb-strip-btn');
+  if(btn)btn.classList.remove('active');
+  _pbRestoreMic();
+}
+function pbCmdDrawerHtml(){
+  return '<div class="pb-drawer-hdr"><span class="pb-drawer-title" style="font-size:11px;color:var(--text-muted);">Phrasebook (//) management</span>'    +'<button class="pb-drawer-x" onclick="pbCloseDrawer();pbClearComposeSlash()">×</button></div>'    +'<div class="pb-cmd-chips" style="justify-content:flex-start;">'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenBooksModal()" title="Open / switch phrasebook">'+ICO.book+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbOpenNewCard({})" title="New phrase">'+ICO.plus+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbTriggerImport()" title="Import file">'+ICO.upload+'</button>'    +'<button class="pb-ico-chip" onclick="pbCloseDrawer();pbClearCompose();pbExportPrompt()" title="Export">'+ICO.download+'</button>'    +'<button class="pb-ico-chip danger" onclick="pbCloseDrawer();pbClearCompose();pbResetConfirm()" title="Reset phrasebook">'+ICO.warn+'</button>'    +'</div>';
+}
+function pbSearchDrawerHtml(){
+  var pair=pbActivePair();
+  var badge=pair?('<span class="pb-pair-badge">'+pbEsc(pbLangFlag(pair.src)+' → '+pbLangFlag(pair.tgt))+'</span>'):'';
+  return '<div class="pb-drawer-hdr" style="flex-shrink:0;">'    +'<input id="pb-search-input" class="pb-search-inp" placeholder="Search phrases…" oninput="pbRunSearch()" onkeydown="pbSearchKD(event)">'    +badge    +'<button class="pb-ov-act" onclick="pbOpenOverlay()" title="Manage phrasebook" style="color:var(--text-dim);padding:4px 6px;">'+ICO.book+'</button>'    +'<button class="pb-drawer-x" onclick="pbCloseDrawer()" style="line-height:0;">'+ICO.x+'</button></div>'    +'<div id="pb-search-results" class="pb-search-results"></div>';
+}
+var _PB_BASE='https://github.acmeproducts.com/stuff/phrase/';
+function pbBuildUrl(){
+  var src=(document.getElementById('pb-url-src')||{}).value||'en';
+  var tgt=(document.getElementById('pb-url-tgt')||{}).value||'th';
+  var url=_PB_BASE+'phrasebook-'+src+'-'+tgt+'-default.json';
+  var inp=document.getElementById('pb-ov-url-inp');if(inp)inp.value=url;
+  var nm=document.getElementById('pb-ov-url-name');
+  if(nm&&!nm._userEdited)nm.value='Standard '+src.toUpperCase()+'↔'+tgt.toUpperCase()+' Phrasebook';
+}
+
+
+
+
+
+function pbExportPrompt(){
+  var pair=pbActivePair();
+  var pairStr=pair?(pair.src+'-'+pair.tgt+'-'):'';
+  var def='phrases-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[\/:, ]+/g,'-');
+  var name=prompt('Export filename:',def);if(name===null)return;
+  pbExport(name);
+  document.getElementById('pb-overlay').style.display='flex';
+}
+function pbResetConfirm(){
+  var pair=pbActivePair();
+  var pairStr=pair?(pair.src+'-'+pair.tgt+'-'):'';
+  var def='phrases-backup-'+pairStr+new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(/[/:, ]+/g,'-');
+  var name=prompt('Backup filename (exported before reset):',def);if(name===null)return;
+  pbExport(name);
+  setTimeout(function(){
+    if(!confirm('Exported. Permanently reset phrasebook to default?'))return;
+    localStorage.removeItem(PB_CARDS);localStorage.removeItem(PB_CATS);
+    localStorage.removeItem(PB_TAGS_K);localStorage.removeItem(PB_SEEDED);
+    pbAutoSeed();pbRenderOverlayFilter();pbRenderOverlay();document.getElementById('pb-overlay').style.display='flex';
+    toast('Phrasebook reset to default');
+  },600);
+}
+
+function pbRunSearch(){
+  var si=document.getElementById('pb-search-input');
+  // Also pick up any text the user has typed in compose
+  var ta=document.getElementById('chat-input');
+  var q=(si?si.value:'')||(ta&&ta.value)||'';
+  var pair=pbActivePair();
+  var cards=pbGetCards().slice().sort(function(a,b){return (b.createdAt||0)-(a.createdAt||0);});
+  if(pair)cards=cards.filter(function(c){return pbCardMatchesPair(c,pair);});
+  if(q.trim())cards=pbSearch(q,cards);
+  var host=document.getElementById('pb-search-results');if(!host)return;
+  if(!cards.length){host.innerHTML='<div class="pb-empty">No matching phrases.</div>';return;}
+  host.innerHTML=cards.slice(0,40).map(function(c){return pbBubbleHtml(c,'search');}).join('');
+}
+function pbSearchKD(e){if(e.key==='Escape'){pbCloseDrawer();pbClearComposeSlash();}}
+function pbClearCompose(){
+  var ta=document.getElementById('chat-input');if(!ta)return;
+  ta.value='';ta.style.height='';
+  var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=true;
+}
+function pbClearComposeSlash(){
+  var ta=document.getElementById('chat-input');if(!ta)return;
+  if(ta.value==='/'||ta.value==='//'){ta.value='';ta.style.height='';}
+  var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!ta.value.trim();
+  ta.focus();
+}
+
+/* ── Use text ── */
+function pbUseText(id,side){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=side==='src'?card.source:card.target;
+  var ta=document.getElementById('chat-input');
+  if(ta){ta.value=text;ta.style.height='auto';ta.style.height=Math.min(ta.scrollHeight,80)+'px';
+    var sb=document.getElementById('chat-send-btn');if(sb)sb.disabled=!text.trim();ta.focus();}
+  pbCloseDrawer();
+  pbCloseOverlay();
+}
+
+/* ── Speak ── */
+function pbSpeakCard(id,side,btn){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=side==='src'?card.source:card.target;
+  var lang=side==='src'?card.sourceLang:card.targetLang;
+  speakText(text,lang);
+}
+
+/* ── Bubble HTML ── */
+var _pbCardState={}; // id→{tagsOpen,clarifyOpen,btOpen}
+function _pbCS(id){if(!_pbCardState[id])_pbCardState[id]={tagsOpen:false,clarifyOpen:false,btOpen:false};return _pbCardState[id];}
+function pbBubbleHtml(card,ctx){
+  var id=card.id;var src=card.sourceLang||'en';var tgt=card.targetLang||'en';
+  var sf=pbLangFlag(src);var tf=pbLangFlag(tgt);
+  var bt=card.backtranslate||{};var cc=(card.clarifyChain||[]).length;
+  var verdict=bt.verdict||'';var tags=card.tags||[];
+  var cs=_pbCS(id);var isDel=!!card.deletedAt;
+  var useL=L('use_word',src);var useR=L('use_word',tgt);
+  var vBadge=verdict==='good'?'<span class="pb-vbadge good">\u2713</span>':verdict==='flag'?'<span class="pb-vbadge flag">\u2691</span>':'';
+  var _hdrDate=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+  var _hdrTime=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
+  var _savedBy=card.savedBy?(' · '+card.savedBy):'';
+  return '<div class="pb-bubble'+(isDel?' deleted':'')+'" id="pbb-'+id+'">'
+    +'<div class="pb-bbl-hdr">'+vBadge+'<span class="pb-bbl-ts">'+pbEsc(_hdrDate+' '+_hdrTime+_savedBy)+'</span></div>'
+    +'<div class="pb-bbl-body">'
+    +'<div class="pb-bbl-col"><div class="pb-bbl-txt" id="pbsrc-'+id+'">'+pbEsc(card.source)+'</div>'
+    +'<div class="pb-bbl-acts"><button class="pb-use-btn" onclick="pbUseText(\''+id+'\',\'src\')" title="'+pbEsc(useL)+'">'+pbEsc(useL)+'</button>'
+    +'<button class="pb-tts-btn" onclick="pbSpeakCard(\''+id+'\',\'src\',this)" title="Play">'+PB_ICON_TTS+'</button></div></div>'
+    +'<div class="pb-bbl-div"></div>'
+    +'<div class="pb-bbl-col"><div class="pb-bbl-txt" id="pbtgt-'+id+'">'+pbEsc(card.target)+'</div>'
+    +'<div class="pb-bbl-acts"><button class="pb-use-btn" onclick="pbUseText(\''+id+'\',\'tgt\')" title="'+pbEsc(useR)+'">'+pbEsc(useR)+'</button>'
+    +'<button class="pb-tts-btn" onclick="pbSpeakCard(\''+id+'\',\'tgt\',this)" title="Play">'+PB_ICON_TTS+'</button></div></div>'
+    +'</div>'
+    +'<div class="pb-bbl-foot">'
+    +'<button class="pb-fbt'+(cs.tagsOpen?' on':'')+'" id="pbft-'+id+'" onclick="pbTogTags(\''+id+'\')" title="Tags">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.clarifyOpen?' on':'')+'" id="pbfc-'+id+'" onclick="pbTogClarify(\''+id+'\')" title="Clarify">'+ICO.chat+' Clarify'+(cc?' ('+cc+')':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ✓':'')+'</button>'
+    +'</div>'
+    +'<div class="pb-panel" id="pbtags-'+id+'" style="display:'+(cs.tagsOpen?'block':'none')+';">'+pbTagPanelHtml(card)+'</div>'
+    +'<div class="pb-panel" id="pbclarify-'+id+'" style="display:'+(cs.clarifyOpen?'block':'none')+';">'+pbClarifyPanelHtml(card)+'</div>'
+    +'<div class="pb-panel" id="pbbt-'+id+'" style="display:'+(cs.btOpen?'block':'none')+';">'+pbBtPanelHtml(card)+'</div>'
+    +'<div class="pb-chevron-row'+(isDel?' deleted':'')+'" id="pbchev-'+id+'">'+pbChevRowHtml(card)+'</div>'
+    +'</div>';
+}
+function pbTagPanelHtml(card){
+  var id=card.id;var tags=card.tags||[];
+  var pills=tags.map(function(t){return'<span class="pb-tp">#'+pbEsc(t)
+    +'<button onclick="pbRemoveTag(\''+id+'\',\''+pbEsc(t)+'\')" style="background:none;border:none;cursor:pointer;color:inherit;margin-left:2px;font-size:10px;">×</button></span>';}).join('');
+  return '<div style="padding:8px 10px;">'
+    +'<div class="pb-tpills" id="pb-atags-'+id+'">'+pills+'</div>'
+    +'<input class="pb-tag-inp" id="pb-ti-'+id+'" placeholder="Add tag…" oninput="pbTagSugg(\''+id+'\')" onkeydown="if(event.key===\'Enter\'){event.preventDefault();pbAddTagI(\''+id+'\');}">'
+    +'<div class="pb-tsugg" id="pb-ts-'+id+'"></div>'
+    +'</div>';
+}
+function pbAddTag(id,tag){
+  var t=(tag||'').toLowerCase().trim().replace(/\s+/g,'-').replace(/[^a-z0-9\-]/g,'').slice(0,24);
+  if(!t)return;
+  var card=pbGetCardById(id);if(!card)return;
+  card.tags=card.tags||[];if(card.tags.indexOf(t)<0)card.tags.push(t);
+  pbAddTagToReg(t);pbSaveCard(card);
+  pbReRenderCardPanel('tags',id);
+}
+function pbAddTagI(id){
+  var inp=document.getElementById('pb-ti-'+id);if(!inp)return;
+  pbAddTag(id,inp.value);inp.value='';
+}
+function pbRemoveTag(id,tag){
+  var card=pbGetCardById(id);if(!card)return;
+  card.tags=(card.tags||[]).filter(function(t){return t!==tag;});
+  pbSaveCard(card);pbReRenderCardPanel('tags',id);
+}
+function pbTagSugg(id){
+  var inp=document.getElementById('pb-ti-'+id);var q=(inp?inp.value:'').toLowerCase();
+  var out=document.getElementById('pb-ts-'+id);if(!out)return;
+  if(!q){out.innerHTML='';return;}
+  var tags=pbGetTags().filter(function(t){return t.indexOf(q)>=0;}).slice(0,8);
+  out.innerHTML=tags.map(function(t){return'<button class="pb-tsugg-chip" onclick="pbAddTag(\''+id+'\',\''+pbEsc(t)+'\')">'+pbEsc(t)+'</button>';}).join('');
+}
+
+/* ── Clarify panel ── */
+function pbClarifyPanelHtml(card){
+  var id=card.id;var chain=card.clarifyChain||[];
+  var thread=chain.length?chain.map(function(item,i){
+    var ts=item.timestamp?new Date(item.timestamp).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';
+    return'<div class="pb-clarify-item"><div class="pb-clarify-meta" style="display:flex;align-items:center;gap:5px;">'
+      +'<span class="pb-clarify-author">'+pbEsc(item.author||'')+'</span>'
+      +(ts?'<span style="font-size:10px;color:#b0aba8;">'+pbEsc(ts)+'</span>':'')
+      +'<button onclick="pbRemoveClarify(\''+id+'\','+i+')" style="background:none;border:none;cursor:pointer;color:#aaa;font-size:11px;margin-left:auto;">×</button>'
+      +'</div><div class="pb-clarify-body">'+pbEsc(item.text||'')+'</div></div>';
+  }).join(''):'<div style="color:#aaa;font-size:12px;padding:4px 0;">No clarifications yet.</div>';
+  return'<div style="padding:8px 10px;"><div id="pb-cthread-'+id+'">'+thread+'</div>'
+    +'<div style="display:flex;gap:6px;margin-top:8px;">'
+    +'<input class="pb-clarify-inp" id="pb-ci-'+id+'" placeholder="Add clarification…" onkeydown="if(event.key===\'Enter\'){event.preventDefault();pbAddClarify(\''+id+'\');}">'
+    +'<button class="pb-clarify-send" onclick="pbAddClarify(\''+id+'\')">Add</button>'
+    +'</div></div>';
+}
+function pbAddClarify(id){
+  var inp=document.getElementById('pb-ci-'+id);if(!inp)return;
+  var text=(inp.value||'').trim();if(!text)return;
+  var card=pbGetCardById(id);if(!card)return;
+  card.clarifyChain=card.clarifyChain||[];
+  card.clarifyChain.push({text:text,author:'Me',timestamp:pbNow()});
+  inp.value='';pbSaveCard(card);pbReRenderCardPanel('clarify',id);
+}
+function pbRemoveClarify(id,idx){
+  var card=pbGetCardById(id);if(!card)return;
+  card.clarifyChain=(card.clarifyChain||[]).filter(function(_,i){return i!==idx;});
+  pbSaveCard(card);pbReRenderCardPanel('clarify',id);
+}
+
+/* ── Back-translate panel ── */
+function pbBtPanelHtml(card){
+  var id=card.id;var bt=card.backtranslate||{};var result=bt.resultText||'';var verdict=bt.verdict||'';
+  var btLang=(card.backtranslate&&card.backtranslate.targetLang)||card.sourceLang||'en';
+  if(result)_btCache[id]={text:result,lang:btLang};
+  var resultHtml=result?('<div style="display:flex;align-items:flex-start;gap:6px;margin:6px 0;"><span style="font-style:italic;color:#555;font-size:13px;flex:1;">'+pbEsc(result)+'</span><button class="pb-bt-tts" onclick="pbPlayBT(\''+id+'\')" title="Play">'+PB_ICON_TTS+'</button></div>'):('<div style="color:#aaa;font-size:12px;">No result yet.</div>');
+  var verdictHtml='';
+  if(result){
+    if(!verdict)verdictHtml='<button class="pb-vbtn good" onclick="pbSetVerdict(\''+id+'\',\'good\')">✓ Sounds right</button> <button class="pb-vbtn flag" onclick="pbSetVerdict(\''+id+'\',\'flag\')">⚑ Flag</button>';
+    else if(verdict==='good')verdictHtml='<span class="pb-vbadge good">✓ Sounds right</span> <button class="pb-vbtn sm" onclick="pbSetVerdict(\''+id+'\',\'\')">Reset</button>';
+    else verdictHtml='<span class="pb-vbadge flag">⚑ Flagged</span> <button class="pb-vbtn sm" onclick="pbSetVerdict(\''+id+'\',\'\')">Reset</button>';
+  }
+  return'<div style="padding:8px 10px;">'
+    +'<button class="pb-bt-run" onclick="pbRunBT(\''+id+'\')"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg> Back-translate</button>'
+    +resultHtml+'<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:4px;">'+verdictHtml+'</div></div>';
+}
+function pbPlayBT(id){var e=_btCache[id];if(e&&e.text)speakText(e.text,e.lang);}
+function pbRunBT(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var text=card.target||'';var from=card.targetLang||'en';var to=card.sourceLang||'en';
+  var host=document.getElementById('pbbt-'+id);
+  if(host){var old=host.querySelector('div[style*="italic"]');if(old)old.textContent='Checking…';}
+  translateWithRetry(text,from,to,2).then(function(result){
+    card=pbGetCardById(id);if(!card)return;
+    // Strip phonetic romanization appended by MyMemory e.g. "สวัสดี (Sa-wat-dee)"
+    var clean=(result||'').replace(/\s*\([^)]*[a-zA-Z][^)]*\)\s*$/,'').trim()||result||'';
+    card.backtranslate.resultText=clean;card.backtranslate.updatedAt=pbNow();
+    pbSaveCard(card);pbReRenderCardPanel('bt',id);
+  });
+}
+function pbSetVerdict(id,val){
+  var card=pbGetCardById(id);if(!card)return;
+  card.backtranslate=card.backtranslate||{};
+  card.backtranslate.verdict=val;card.backtranslate.updatedAt=pbNow();
+  pbSaveCard(card);pbReRenderCardPanel('bt',id);
+  pbReRenderBubbleHeader(id);
+  toast(val==='good'?'Verified ✓':val==='flag'?'Flagged':'Verdict cleared');
+}
+
+/* ── Panel toggle helpers ── */
+function pbTogTags(id){var cs=_pbCS(id);cs.tagsOpen=!cs.tagsOpen;pbSyncPanel('tags',id);}
+function pbTogClarify(id){var cs=_pbCS(id);cs.clarifyOpen=!cs.clarifyOpen;pbSyncPanel('clarify',id);}
+function pbTogBt(id){var cs=_pbCS(id);cs.btOpen=!cs.btOpen;pbSyncPanel('bt',id);}
+function pbSyncPanel(type,id){
+  var cs=_pbCS(id);
+  var open=type==='tags'?cs.tagsOpen:type==='clarify'?cs.clarifyOpen:cs.btOpen;
+  var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';
+  var panel=document.getElementById(panelId+id);
+  if(panel)panel.style.display=open?'block':'none';
+  var btnId=type==='tags'?'pbft-':type==='clarify'?'pbfc-':'pbfb-';
+  var btn=document.getElementById(btnId+id);
+  if(btn)btn.classList.toggle('on',open);
+}
+function pbReRenderCardPanel(type,id){
+  var card=pbGetCardById(id);if(!card)return;
+  var panelId=type==='tags'?'pbtags-':type==='clarify'?'pbclarify-':'pbbt-';
+  var el=document.getElementById(panelId+id);if(!el)return;
+  var fn=type==='tags'?pbTagPanelHtml:type==='clarify'?pbClarifyPanelHtml:pbBtPanelHtml;
+  el.innerHTML=fn(card);
+  if(type==='tags'){
+    var btn=document.getElementById('pbft-'+id);
+    if(btn){var tags=card.tags||[];btn.innerHTML=ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'');}
+  }
+  if(type==='clarify'){
+    var btn2=document.getElementById('pbfc-'+id);
+    if(btn2){var cc=(card.clarifyChain||[]).length;btn2.innerHTML=ICO.chat+' Clarify'+(cc?' ('+cc+')':'');}
+  }
+  if(type==='bt'){
+    var btn3=document.getElementById('pbfb-'+id);
+    if(btn3){var bt=card.backtranslate||{};btn3.innerHTML=ICO.verify+' Verify'+(bt.resultText?' ✓':'');}
+  }
+}
+function pbReRenderBubbleHeader(id){
+  var card=pbGetCardById(id);if(!card)return;
+  var hdr=document.querySelector('#pbb-'+id+' .pb-bbl-hdr');if(!hdr)return;
+  var bt=card.backtranslate||{};var verdict=bt.verdict||'';
+  var vBadge=verdict==='good'?'<span class="pb-vbadge good">✓</span>':verdict==='flag'?'<span class="pb-vbadge flag">⚑</span>':'';
+  var tags=card.tags||[];var tagBadge=tags.length?'<span class="pb-tag-ct">#'+tags.length+'</span>':'';
+  var srcLang=card.sourceLang||'en';var tgtLang=card.targetLang||'en';
+  var sf=pbLangFlag(srcLang);var tf=pbLangFlag(tgtLang);
+  // preserve delete button if in overlay
+  var _hd=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
+  var _ht=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
+  var _sb=card.savedBy?(' · '+card.savedBy):'';
+  hdr.innerHTML=vBadge+'<span class="pb-bbl-ts">'+pbEsc(_hd+' '+_ht+_sb)+'</span>';
+}
+
+/* ─────────────────────────────────────────────────
+   FULL-SCREEN OVERLAY
+───────────────────────────────────────────────── */
+var _pbFilter='all';
+
+function pbOpenOverlay(){
+  var d=document.getElementById('pb-overlay');if(d)d.style.display='flex';
+  var pair=pbActivePair();
+  _pbFilter=(pair&&pair.src&&pair.tgt)?(pair.src+'|'+pair.tgt):'all';
+  pbRenderOverlayFilter();pbRenderOverlay();
+}
+function pbCloseOverlay(){
+  var d=document.getElementById('pb-overlay');if(d)d.style.display='none';
+}
+function pbSetFilter(f){_pbFilter=f;pbRenderOverlayFilter();pbRenderOverlay();}
+function pbRenderOverlayFilter(){
+  var host=document.getElementById('pb-ov-filter');if(!host)return;
+  var cards=pbGetCards();var pairs={};
+  cards.forEach(function(c){var k=(c.sourceLang||'en')+'|'+(c.targetLang||'en');pairs[k]=true;});
+  var html='<button class="pb-fc'+(_pbFilter==='all'?' act':'')+'" onclick="pbSetFilter(\'all\')">All</button>';
+  Object.keys(pairs).forEach(function(k){
+    var p=k.split('|');
+    html+='<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'
+      +pbEsc(pbLangFlag(p[0])+' '+p[0].toUpperCase())+' → '+pbEsc(pbLangFlag(p[1])+' '+p[1].toUpperCase())+'</button>';
+  });
+  host.innerHTML=html;
+}
+function pbRenderOverlay(){
+  var host=document.getElementById('pb-ov-cards');if(!host)return;
+  var q=((document.getElementById('pb-ov-search')||{}).value||'').trim();
+  var cards=pbGetCards();
+  if(_pbFilter!=='all'){var p=_pbFilter.split('|');cards=cards.filter(function(c){return (c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});}
+  if(q)cards=pbSearch(q,cards);
+  if(!cards.length){host.innerHTML='<div class="pb-empty" style="padding:24px;text-align:center;">No phrases found.</div>';return;}
+  host.innerHTML=cards.map(function(c){return pbBubbleHtml(c,'overlay');}).join('');
+}
+function pbOvSearch(){pbRenderOverlay();}
+
+/* ─────────────────────────────────────────────────
+   IMPORT MODAL
+───────────────────────────────────────────────── */
+var _pbImportData=null;
+
+function pbTriggerImport(){document.getElementById('pb-file-input').click();}
+function pbHandleFile(e){
+  var file=e&&e.target&&e.target.files&&e.target.files[0];
+  if(!file){return;}e.target.value='';
+  var def=file.name.replace(/\.json$/i,'')||new Date().toLocaleString([],{month:'short',day:'numeric',year:'2-digit',hour:'2-digit',minute:'2-digit'});
+  var name=prompt('Name for this phrasebook?',def);if(name===null)return;
+  var reader=new FileReader();
+  reader.onload=function(){
+    try{
+      var data=JSON.parse(reader.result||'{}');
+      if(!data||!Array.isArray(data.cards)){toast('Invalid phrasebook file');return;}
+      data._importName=name||def;
+      pbOpenImportModal(data);
+    }catch(_){toast('Could not read file');}
+  };
+  reader.readAsText(file);
+}
+function pbOpenImportModal(data){
+  _pbImportData=data;var cards=data.cards||[];
+  var list=document.getElementById('pb-import-list');if(!list)return;
+  list.innerHTML=cards.map(function(c,i){
+    var src=(c.sourceLang||'en');var tgt=(c.targetLang||'en');
+    return'<label class="pb-import-row">'
+      +'<input type="checkbox" checked class="pb-import-cb" data-idx="'+i+'">'
+      +'<div class="pb-import-info">'
+      +'<span class="pb-import-pair">'+pbEsc(pbLangFlag(src)+' '+src.toUpperCase())+' → '+pbEsc(pbLangFlag(tgt)+' '+tgt.toUpperCase())+'</span>'
+      +'<span class="pb-import-src">'+pbEsc((c.source||'').slice(0,50))+'</span>'
+      +'<span class="pb-import-tgt">'+pbEsc((c.target||'').slice(0,50))+'</span>'
+      +'</div></label>';
+  }).join('');
+  pbSyncImportBtn();
+  document.getElementById('pb-import-modal').style.display='flex';
+}
+function pbSelectAllImport(on){
+  document.querySelectorAll('.pb-import-cb').forEach(function(cb){cb.checked=!!on;});
+  pbSyncImportBtn();
+}
+function pbSyncImportBtn(){
+  var cbs=document.querySelectorAll('.pb-import-cb');
+  var n=Array.from(cbs).filter(function(cb){return cb.checked;}).length;
+  var btn=document.getElementById('pb-import-ok');
+  if(btn)btn.textContent='Import '+n+' phrase'+(n!==1?'s':'');
+}
+function pbConfirmImport(){
+  if(!_pbImportData)return;
+  var cbs=document.querySelectorAll('.pb-import-cb');
+  var selected=[];
+  cbs.forEach(function(cb,i){if(cb.checked&&_pbImportData.cards[i])selected.push(_pbImportData.cards[i]);});
+  var importName=(_pbImportData._importName||'').trim();
+  pbApplyImport({cards:selected,catalogs:_pbImportData.catalogs||[],tags:_pbImportData.tags||[]},{});
+  // Register named book in registry
+  if(importName){
+    var books=pbGetBooks();
+    var alreadyExists=books.some(function(b){return b.name===importName;});
+    if(!alreadyExists){
+      books.push({id:'book-'+Date.now(),name:importName,createdAt:Date.now(),isDefault:false,cardCount:selected.length});
+      pbSaveBooks(books);
+    }
+  }
+  document.getElementById('pb-import-modal').style.display='none';
+  _pbImportData=null;
+  pbRenderOverlayFilter();pbRenderOverlay();
+  document.getElementById('pb-overlay').style.display='flex';
+  if(importName)toast('Saved: '+importName+' ('+selected.length+' phrases)');
+}
+function pbCloseImportModal(){
+  document.getElementById('pb-import-modal').style.display='none';_pbImportData=null;
+  document.getElementById('pb-overlay').style.display='flex';
+  pbRenderOverlayFilter();pbRenderOverlay();
+}
+
+/* ─────────────────────────────────────────────────
+   NEW CARD SHEET
+───────────────────────────────────────────────── */
+function pbPopLangSel(id,def){
+  var s=document.getElementById(id);if(!s)return;
+  s.innerHTML=LANGS.map(function(l){return'<option value="'+l.code+'"'+(l.code===def?' selected':'')+'>'+l.flag+' '+l.label+'</option>';}).join('');
+}
+function pbOpenNewCard(opts){
+  opts=opts||{};
+  var srcLang=opts.sourceLang||(room.myLang||'en');
+  var tgtLang=opts.targetLang||(room.theirLang||'en');
+  pbPopLangSel('pbnc-sl',srcLang);pbPopLangSel('pbnc-tl',tgtLang);
+  var st=document.getElementById('pbnc-src');var tt=document.getElementById('pbnc-tgt');
+  if(st)st.value=opts.source||'';if(tt)tt.value=opts.target||'';
+  document.getElementById('pb-new-card-sheet').classList.add('open');
+  setTimeout(function(){var s=document.getElementById('pbnc-src');if(s)s.focus();},40);
+}
+function pbCloseNewCard(){document.getElementById('pb-new-card-sheet').classList.remove('open');if(document.getElementById('pb-overlay').style.display!=='flex'){document.getElementById('pb-overlay').style.display='flex';pbRenderOverlayFilter();pbRenderOverlay();}}
+function pbNcAutoTranslate(){
+  var src=(document.getElementById('pbnc-src')||{}).value||'';
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!src.trim()){toast('Enter a source phrase first');return;}
+  translateWithRetry(src,sl,tl,2).then(function(out){
+    var tt=document.getElementById('pbnc-tgt');if(tt)tt.value=out||src;
+  });
+}
+function pbSaveNewCard(){
+  var src=((document.getElementById('pbnc-src')||{}).value||'').trim();
+  var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!src){toast('Enter a source phrase');return;}
+  if(!tgt){toast('Enter a translation');return;}
+  pbUpsert(pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()}));
+  pbCloseNewCard();toast('Saved to phrasebook');
+  pbRenderOverlayFilter();pbRenderOverlay();
+  document.getElementById('pb-overlay').style.display='flex';
+}
+
+
+
+// ─── Phase 8: Structured log ──────────────────────────────────────────────
+function log(ev,d,l){
+  var meta={phase:callPhase,role:room.role||lastSessionContext.role||'?',epoch:sessionEpoch};
+  var r={ts:new Date().toISOString(),ev:ev,d:Object.assign({},meta,d||{}),l:l||'info'};
+  debugLog.push(r);if(debugLog.length>400)debugLog.shift();
+  var b=$('log-body');if(!b)return;
+  var div=document.createElement('div');div.className='log-row '+(l||'info');
+  div.innerHTML='<span class="ts">'+r.ts.slice(11,23)+'</span> <span class="ev">'+esc(ev)+'</span> '+esc(JSON.stringify(d||{}));
+  b.appendChild(div);b.scrollTop=b.scrollHeight;
+}
+
+var L_STRINGS={
+  join_call:{en:"Join Call",es:"Unirse",zh:"加入通话",fr:"Rejoindre",de:"Beitreten",ja:"通話に参加",ko:"참여하기",ar:"انضم",hi:"जुड़ें",ru:"Присоединиться",pt:"Entrar",it:"Partecipa",vi:"Tham gia",id:"Bergabung",ms:"Sertai",fil:"Sumali",nl:"Deelnemen",sv:"Gå med",pl:"Dołącz",tr:"Katıl",th:"เข้าร่วม"},
+  tap_camera:{en:"Tap to allow camera & microphone",es:"Toca para permitir cámara y micrófono",zh:"点击允许摄像头和麦克风",fr:"Appuyez pour caméra & micro",de:"Kamera & Mikro erlauben",ja:"カメラとマイクを許可",ko:"카메라와 마이크 허용",ar:"اضغط للكاميرا والميكروفون",hi:"कैमरा व माइक अनुमति दें",ru:"Разрешить камеру и микрофон",pt:"Permitir câmera e microfone",it:"Consenti fotocamera e microfono",vi:"Cho phép camera và micro",id:"Izinkan kamera & mikrofon",ms:"Benarkan kamera & mikrofon",fil:"Payagan ang camera at mikropono",nl:"Sta camera en microfoon toe",sv:"Tillåt kamera och mikrofon",pl:"Zezwól na kamerę i mikrofon",tr:"Kamera ve mikrofona izin ver",th:"อนุญาตกล้องและไมค์"},
+  joining:{en:"Joining call…",es:"Uniéndose…",zh:"加入中…",fr:"Connexion…",de:"Verbinden…",ja:"参加中…",ko:"참여 중…",ar:"جارٍ الانضمام…",hi:"जुड़ रहे हैं…",ru:"Подключение…",pt:"Entrando…",it:"Connessione…",vi:"Đang tham gia…",id:"Bergabung…",ms:"Menyertai…",fil:"Sumasali…",nl:"Deelnemen…",sv:"Ansluter…",pl:"Dołączanie…",tr:"Katılıyor…",th:"กำลังเข้าร่วม…"},
+  thanks:{en:"Thanks for calling.",es:"Gracias por llamar.",zh:"感谢通话。",fr:"Merci d'avoir appelé.",de:"Danke fürs Anrufen.",ja:"お電話ありがとう。",ko:"전화해 주셔서 감사합니다.",ar:"شكراً على الاتصال.",hi:"कॉल के लिए धन्यवाद।",ru:"Спасибо за звонок.",pt:"Obrigado pela ligação.",it:"Grazie per la chiamata.",vi:"Cảm ơn đã gọi.",id:"Terima kasih telah menelepon.",ms:"Terima kasih kerana menghubungi.",fil:"Salamat sa pagtawag.",nl:"Bedankt voor het bellen.",sv:"Tack för samtalet.",pl:"Dziękujemy za rozmowę.",tr:"Aradığınız için teşekkürler.",th:"ขอบคุณสำหรับการโทร"},
+  close_tab:{en:"You can close this tab.",es:"Puedes cerrar esta pestaña.",zh:"您可以关闭此标签页。",fr:"Vous pouvez fermer cet onglet.",de:"Sie können diesen Tab schließen.",ja:"このタブを閉じてください。",ko:"이 탭을 닫아도 됩니다.",ar:"يمكنك إغلاق هذا التبويب.",hi:"आप यह टैब बंद कर सकते हैं।",ru:"Вы можете закрыть эту вкладку.",pt:"Você pode fechar esta aba.",it:"Puoi chiudere questa scheda.",vi:"Bạn có thể đóng tab này.",id:"Anda bisa menutup tab ini.",ms:"Anda boleh tutup tab ini.",fil:"Maaari mong isara ang tab na ito.",nl:"U kunt dit tabblad sluiten.",sv:"Du kan stänga den här fliken.",pl:"Możesz zamknąć tę kartę.",tr:"Bu sekmeyi kapatabilirsiniz.",th:"คุณสามารถปิดแท็บนี้ได้"},
+  rejoin:{en:"🔄 Rejoin",es:"🔄 Volver",zh:"🔄 重新加入",fr:"🔄 Rejoindre",de:"🔄 Erneut",ja:"🔄 再参加",ko:"🔄 재참여",ar:"🔄 إعادة الانضمام",hi:"🔄 फिर जुड़ें",ru:"🔄 Переподключиться",pt:"🔄 Voltar",it:"🔄 Rientra",vi:"🔄 Tham gia lại",id:"🔄 Gabung lagi",ms:"🔄 Sertai semula",fil:"🔄 Sumali muli",nl:"🔄 Opnieuw",sv:"🔄 Gå med igen",pl:"🔄 Dołącz ponownie",tr:"🔄 Tekrar katıl",th:"🔄 เข้าร่วมอีกครั้ง"},
+  dl_transcript:{en:"⬇ Download transcript",es:"⬇ Descargar transcripción",zh:"⬇ 下载记录",fr:"⬇ Télécharger",de:"⬇ Transkript laden",ja:"⬇ 記録をダウンロード",ko:"⬇ 기록 다운로드",ar:"⬇ تنزيل النص",hi:"⬇ डाउनलोड",ru:"⬇ Скачать",pt:"⬇ Baixar",it:"⬇ Scarica",vi:"⬇ Tải xuống",id:"⬇ Unduh",ms:"⬇ Muat turun",fil:"⬇ I-download",nl:"⬇ Download",sv:"⬇ Ladda ner",pl:"⬇ Pobierz",tr:"⬇ İndir",th:"⬇ ดาวน์โหลด"},
+  camera_off:{en:"Camera off",es:"Cámara apagada",zh:"摄像头关闭",fr:"Caméra éteinte",de:"Kamera aus",ja:"カメラオフ",ko:"카메라 꺼짐",ar:"الكاميرا معطلة",hi:"कैमरा बंद",ru:"Камера выкл.",pt:"Câmera desligada",it:"Fotocamera spenta",vi:"Camera tắt",id:"Kamera mati",ms:"Kamera dimatikan",fil:"Camera naka-off",nl:"Camera uit",sv:"Kamera av",pl:"Kamera wyłączona",tr:"Kamera kapalı",th:"ปิดกล้อง"},
+  disconnected:{en:"Partner has disconnected",es:"El compañero se desconectó",zh:"对方已断开连接",fr:"Le partenaire s'est déconnecté",de:"Partner getrennt",ja:"相手が切断しました",ko:"상대방이 연결을 끊었습니다",ar:"انقطع اتصال الشريك",hi:"पार्टनर डिसकनेक्ट हो गया",ru:"Партнёр отключился",pt:"Parceiro desconectado",it:"Partner disconnesso",vi:"Đối tác đã ngắt kết nối",id:"Mitra terputus",ms:"Rakan terputus",fil:"Nadiskonekta ang kasama",nl:"Partner verbroken",sv:"Partner kopplad från",pl:"Partner rozłączony",tr:"Ortak bağlantısı kesildi",th:"คู่หูตัดการเชื่อมต่อ"},
+  waiting:{en:"Waiting to reconnect…",es:"Esperando reconexión…",zh:"等待重新连接…",fr:"En attente…",de:"Warte auf Wiederverbindung…",ja:"再接続待ち…",ko:"재연결 대기 중…",ar:"في انتظار إعادة الاتصال…",hi:"पुनः कनेक्ट होने की प्रतीक्षा…",ru:"Ожидание переподключения…",pt:"Aguardando reconexão…",it:"In attesa…",vi:"Đang chờ kết nối lại…",id:"Menunggu rekoneksi…",ms:"Menunggu sambungan semula…",fil:"Naghihintay na muling kumonekta…",nl:"Wachten op herverbinding…",sv:"Väntar på återanslutning…",pl:"Oczekiwanie…",tr:"Yeniden bağlanmayı bekliyor…",th:"รอการเชื่อมต่อใหม่…"},
+  type_msg:{en:"Type a message…",es:"Escribe un mensaje…",zh:"输入消息…",fr:"Tapez un message…",de:"Nachricht eingeben…",ja:"メッセージを入力…",ko:"메시지 입력…",ar:"اكتب رسالة…",hi:"संदेश लिखें…",ru:"Введите сообщение…",pt:"Digite uma mensagem…",it:"Scrivi un messaggio…",vi:"Nhập tin nhắn…",id:"Ketik pesan…",ms:"Taip mesej…",fil:"Mag-type ng mensahe…",nl:"Typ een bericht…",sv:"Skriv ett meddelande…",pl:"Wpisz wiadomość…",tr:"Mesaj yaz…",th:"พิมพ์ข้อความ…"},
+  use_word:{en:"Use",es:"Usar",zh:"使用",fr:"Utiliser",de:"Nutzen",ja:"使う",ko:"사용",ar:"استخدم",hi:"उपयोग",ru:"Исп.",pt:"Usar",it:"Usa",vi:"Dùng",id:"Gunakan",ms:"Guna",fil:"Gamitin",nl:"Gebruik",sv:"Använd",pl:"Użyj",tr:"Kullan",th:"ใช้"},
+  you_word:{en:"You",es:"Yo",zh:"我",fr:"Moi",de:"Ich",ja:"私",ko:"나",ar:"أنا",hi:"मैं",ru:"Я",pt:"Eu",it:"Io",vi:"Tôi",id:"Saya",ms:"Saya",fil:"Ako",nl:"Ik",sv:"Jag",pl:"Ja",tr:"Ben",th:"ฉัน"},
+  partner_word:{en:"Partner",es:"Compañero",zh:"伙伴",fr:"Partenaire",de:"Partner",ja:"パートナー",ko:"파트너",ar:"شريك",hi:"साथी",ru:"Партнёр",pt:"Parceiro",it:"Partner",vi:"Đối tác",id:"Mitra",ms:"Rakan",fil:"Kasama",nl:"Partner",sv:"Partner",pl:"Partner",tr:"Ortak",th:"คู่หู"}
+};
+function L(key,lang){var m=L_STRINGS[key];if(!m)return key;return m[lang||room.myLang||'en']||m.en||key;}
+function gL(c){c=(c||'').toLowerCase();for(var i=0;i<LANGS.length;i++)if(LANGS[i].code===c)return LANGS[i];return{code:c||'?',label:(c||'?').toUpperCase(),flag:'🌐'}}
+function updateCallChip(){
+  var n=$('room-name-chip'),f=$('lang-flags-chip');if(!n||!f)return;
+  n.textContent=room.name||'No room';
+  f.textContent=gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
+}
+function syncMic(){var btn=$('top-mic-btn');if(btn)btn.classList.toggle('muted',!micOn);}
+function syncCam(){var btn=$('top-cam-btn');if(btn)btn.classList.toggle('muted',!camOn);$('local-video').style.opacity=camOn?'1':'0.12';}
+function markPartnerTalking(){var i=$('partner-speaking-indicator');if(!i)return;i.classList.add('show');clearTimeout(partnerSpeakTimer);partnerSpeakTimer=setTimeout(function(){i.classList.remove('show')},1200)}
+function syncTranscriptToggleButton(){var b=$('transcript-toggle-btn');if(!b)return;var e=!transcriptCollapsed;b.title=e?'Collapse transcript':'Expand transcript';b.setAttribute('aria-label',b.title);b.setAttribute('aria-expanded',e?'true':'false')}
+function syncTranscriptTtsButton(){var b=$('transcript-tts-toggle');if(!b)return;b.style.color=transcriptTtsOn?'#b6bcc3':'#8f959d';b.title=transcriptTtsOn?'Transcript TTS on':'Transcript TTS off';b.setAttribute('aria-pressed',transcriptTtsOn?'true':'false');var onIcon=b.querySelector('.tts-on'),offIcon=b.querySelector('.tts-off');if(onIcon)onIcon.style.display=transcriptTtsOn?'':'none';if(offIcon)offIcon.style.display=transcriptTtsOn?'none':''}
+function toggleTranscriptTts(){transcriptTtsOn=!transcriptTtsOn;syncTranscriptTtsButton();if(!transcriptTtsOn&&window.speechSynthesis)window.speechSynthesis.cancel()}
+function speakText(text,lang){text=norm(text);if(!text||!window.speechSynthesis)return;window.speechSynthesis.cancel();var u=new SpeechSynthesisUtterance(text);u.lang=TTS_LOCALE[lang]||lang||TTS_LOCALE[room.myLang]||'en-US';window.speechSynthesis.speak(u)}
+function toggleTranscript(){transcriptCollapsed=!transcriptCollapsed;$('call-screen').classList.toggle('transcript-collapsed',transcriptCollapsed);syncTranscriptToggleButton()}
+function swapVideos(){document.querySelector('.call-videos').classList.toggle('swapped')}
+
+function cleanTranslationText(t){
+  if(!t)return'';
+  return normalizeText(String(t).replace(/<\/?[a-zA-Z][^>]*>/g,''),'speech');
+}
+
+function translateWithRetry(text,from,to,retries){
+  if(!text||!from||!to||from===to)return Promise.resolve(text);
+  var k=from+'|'+to+'|'+text;
+  if(trCache.has(k)){var v=trCache.get(k);trCache.delete(k);trCache.set(k,v);return Promise.resolve(v);}
+  var attempt=function(n){
+    return fetch('https://api.mymemory.translated.net/get?q='+encodeURIComponent(text)+'&langpair='+from+'|'+to)
+      .then(function(r){return r.json()})
+      .then(function(d){
+        if(d&&d.responseStatus===200&&d.responseData){
+          var t=d.responseData.translatedText;
+          if(t&&t.indexOf('MYMEMORY')<0){t=cleanTranslationText(t);
+            if(trCache.size>=TR_CACHE_MAX){var first=trCache.keys().next().value;trCache.delete(first);}
+            trCache.set(k,t);return t;
+          }
+        }
+        throw new Error('Invalid response');
+      })
+      .catch(function(e){
+        if(n>0){
+          log('trans_retry',{from:from,to:to,left:n},'warn');
+          return new Promise(function(res){setTimeout(res,300+((retries-n)*250));}).then(function(){return attempt(n-1);});
+        }
+        log('trans_fail',{from:from,to:to,e:String(e)},'error');
+        return text;
+      });
+  };
+  return attempt(retries||0);
+}
+function translate(text,from,to){
+  if(!text||!from||!to||from===to)return Promise.resolve(text);
+  var k=from+'|'+to+'|'+text;
+  if(trCache.has(k)){var v=trCache.get(k);trCache.delete(k);trCache.set(k,v);return Promise.resolve(v);}
+  return fetch('https://api.mymemory.translated.net/get?q='+encodeURIComponent(text)+'&langpair='+from+'|'+to)
+    .then(function(r){return r.json()}).then(function(d){
+      if(d&&d.responseStatus===200&&d.responseData){
+        var t=d.responseData.translatedText;
+        if(t&&t.indexOf('MYMEMORY')<0){
+          t=cleanTranslationText(t);
+          if(trCache.size>=TR_CACHE_MAX){var first=trCache.keys().next().value;trCache.delete(first);}
+          trCache.set(k,t);return t;
+        }
+      }
+      return text;
+    }).catch(function(){return text});
+}
+
+function openLog(){log('log_open',{dev:deviceId,dg:!!localStorage.getItem('tb_dg_key')});$('log-overlay').classList.add('show')}
+function closeLog(){$('log-overlay').classList.remove('show')}
+function clearLogText(){debugLog=[];$('log-body').innerHTML='';toast('Cleared')}
+function copyLogText(){var t=debugLog.map(function(r){return r.ts+' ['+r.ev+'] '+JSON.stringify(r.d)}).join('\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}
+
+function trKey(id){return TP+(id||room.id)}
+function saveTr(){if(room.id)try{localStorage.setItem(trKey(),JSON.stringify(transcript))}catch(_){}}
+function loadTr(id){try{var r=localStorage.getItem(trKey(id||room.id));return r?JSON.parse(r):[]}catch(_){return[]}}
+function clearTrS(id){try{localStorage.removeItem(trKey(id))}catch(_){}}
+
+function encInv(p){try{return btoa(unescape(encodeURIComponent(JSON.stringify(p)))).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}catch(_){return''}}
+function decInv(s){if(!s)return null;try{var b=s.replace(/-/g,'+').replace(/_/g,'/');while(b.length%4)b+='=';return JSON.parse(decodeURIComponent(escape(atob(b))))}catch(_){return null}}
+function invUrl(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';var tid=(($('cf-turn-id')&&$('cf-turn-id').value)||localStorage.getItem('tb_cf_tid')||'').trim();var tok=(($('cf-turn-tok')&&$('cf-turn-tok').value)||localStorage.getItem('tb_cf_tok')||'').trim();return location.href.split('?')[0].split('#')[0]+'#j='+encInv({r:room.id,ml:room.myLang,tl:room.theirLang,n:room.name||'',k:k,tid:tid,tok:tok})}
+
+function setLS(s){lobbyState=s;$('lobby-setup').style.display=s===LS.setup?'':'none';}
+function getRecent(){try{return JSON.parse(localStorage.getItem(RK)||'[]')}catch(_){return[]}}
+function setRecent(r){localStorage.setItem(RK,JSON.stringify(r.slice(0,RL)))}
+function saveRecent(){
+  if(!room.id)return;var rows=getRecent().filter(function(r){return r.id!==room.id});
+  rows.unshift({id:room.id,name:room.name||(gL(room.myLang).flag+' ↔ '+gL(room.theirLang).flag),myLang:room.myLang,theirLang:room.theirLang,ts:Date.now()});
+  setRecent(rows);renderRecent();
+}
+function delRecent(id){
+  var rooms=getRecent();
+  var r=rooms.find(function(x){return x.id===id});
+  if(r){r.deletedAt=Date.now();setRecent(rooms);}
+  renderRecent();
+}
+function hardDelRecent(id){
+  setRecent(getRecent().filter(function(r){return r.id!==id}));
+  clearTrS(id);renderRecent();
+}
+function restoreRecent(id){
+  var rooms=getRecent();
+  var r=rooms.find(function(x){return x.id===id});
+  if(r){delete r.deletedAt;setRecent(rooms);}
+  renderRecent();
+}
+
+async function reuseRoom(id){
+  var rec=getRecent().find(function(r){return r.id===id});if(!rec)return;
+  room.id=rec.id;room.myLang=rec.myLang;room.theirLang=rec.theirLang;room.role='creator';room.name=rec.name||'';
+  lastSessionContext.role='creator';lastSessionContext.myLang=rec.myLang;lastSessionContext.theirLang=rec.theirLang;lastSessionContext.roomName=rec.name||'';
+  $('my-lang').value=rec.myLang;$('their-lang').value=rec.theirLang;$('room-name').value=rec.name||'';syncBtn();
+  try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}catch(_){toast('Camera needed');return}
+  $('lobby-link').textContent=invUrl();var nd=$('room-name-display');if(nd)nd.textContent=rec.name||'';
+  saveRecent();enterCall();
+}
+function viewRoomTr(id){
+  var rec=getRecent().find(function(r){return r.id===id});var entries=loadTr(id);viewingRoomId=id;
+  $('room-tr-title').textContent=(rec&&rec.name?rec.name:'Room')+' — Transcript';
+  var b=$('room-tr-body');
+  if(!entries.length){b.innerHTML='<div style="color:var(--text-muted);padding:16px;font-style:italic;">No transcript saved.</div>'}
+  else{b.innerHTML=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});var w=e.who==='me'?'You':'Partner';var wc=e.who==='me'?'color:var(--teal-bright)':'color:var(--text-dim)';var s=e.sourceText===e.translatedText;return '<div style="padding:8px 0;border-bottom:1px solid rgba(255,255,255,.05)"><div style="font-size:10px;font-weight:700;text-transform:uppercase;'+wc+'">'+w+' · '+(e.srcLang||'').toUpperCase()+' · '+ts+'</div><div style="color:var(--text-dim);margin-top:2px">'+esc(e.sourceText)+'</div>'+(s?'':'<div style="color:var(--text);margin-top:2px">→ '+esc(e.translatedText)+'</div>')+'</div>'}).join('')}
+  $('room-tr-overlay').classList.add('show');
+}
+function closeRoomTr(){$('room-tr-overlay').classList.remove('show')}
+function copyRoomTr(){var entries=loadTr(viewingRoomId);if(!entries.length){toast('No transcript');return}var t=entries.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\n');if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')})}
+
+function renderRecent(){
+  var w=$('recent-rooms'),l=$('recent-rooms-list'),rows=getRecent();
+  var live=rows.filter(function(r){return !r.deletedAt;});
+  var dead=rows.filter(function(r){return !!r.deletedAt;});
+  w.style.display=rows.length?'':' none';
+  function liveRow(r){
+    var t=new Date(r.ts).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+    var h=!!loadTr(r.id).length;
+    var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';
+    return '<div class="recent-item"><div class="recent-item-top">'
+      +'<button class="recent-open jr" data-id="'+esc(r.id)+'">'+esc(r.name)+'<small>'+esc(t)+'</small></button>'
+      +(flags?'<span style="font-size:15px;flex-shrink:0;">'+flags+'</span>':'')+'</div><div class="recent-actions">'
+      +'<button class="recent-act jr" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"/></svg> Reopen</button>'
+      +(h?'<button class="recent-act jv" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg> Transcript</button>':'')+'<button class="recent-act danger jd" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg> Delete</button>'
+      +'</div></div>';
+  }
+  function trashRow(r){
+    var t=new Date(r.ts).toLocaleString([],{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
+    var flags=(r.myLang&&r.theirLang)?(gL(r.myLang).flag+' → '+gL(r.theirLang).flag):'';
+    return '<div class="recent-item" style="opacity:.6;">'
+      +'<div class="recent-item-top"><span class="recent-open" style="flex:1;font-size:13px;">'+esc(r.name)+'<small>'+esc(t)+'</small></span>'
+      +(flags?'<span style="font-size:15px;flex-shrink:0;">'+flags+'</span>':'')+'</div>'
+      +'<div class="recent-actions">'
+      +'<button class="recent-act jr2" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-4.2"/></svg> Restore</button>'
+      +'<button class="recent-act danger jd2" data-id="'+esc(r.id)+'"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg> Delete forever</button>'
+      +'</div></div>';
+  }
+  var html=live.map(liveRow).join('');
+  if(dead.length){
+    html+='<details class="room-trash-details"><summary><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg> Trash ('+dead.length+')</summary>'
+      +dead.map(trashRow).join('')+'</details>';
+  }
+  w.style.display=rows.length?'':' none';
+  l.innerHTML=html;
+  l.querySelectorAll('.jr').forEach(function(b){b.onclick=function(){reuseRoom(b.dataset.id)}});
+  l.querySelectorAll('.jv').forEach(function(b){b.onclick=function(){viewRoomTr(b.dataset.id)}});
+  l.querySelectorAll('.jd').forEach(function(b){b.onclick=function(){delRecent(b.dataset.id)}});
+  l.querySelectorAll('.jr2').forEach(function(b){b.onclick=function(){restoreRecent(b.dataset.id)}});
+  l.querySelectorAll('.jd2').forEach(function(b){b.onclick=function(){hardDelRecent(b.dataset.id)}});
+}
+
+function openCreateRoomModal(){
+  var bd=$("create-room-backdrop");if(!bd)return;
+  var mml=$("modal-my-lang"),mtl=$("modal-their-lang");
+  var opts=LANGS.map(function(l){return'<option value="'+l.code+'">'+l.flag+' '+l.label+'</option>';}).join('');
+  if(mml)mml.innerHTML='<option value="" disabled selected>I speak</option>'+opts;
+  if(mtl)mtl.innerHTML='<option value="" disabled selected>They speak</option>'+opts;
+  var sl=localStorage.getItem("tb_my_lang")||"",tl=localStorage.getItem("tb_their_lang")||"";
+  if(mml&&sl){try{mml.value=sl;}catch(_){}}
+  if(mtl&&tl){try{mtl.value=tl;}catch(_){}}
+  var mn=$("modal-room-name");if(mn)mn.value="";
+  syncModalBtn();
+  bd.classList.add("show");
+  setTimeout(function(){var mn=$("modal-room-name");if(mn)mn.focus();},60);
+}
+function closeCreateRoomModal(){var bd=$("create-room-backdrop");if(bd)bd.classList.remove("show");}
+function syncModalBtn(){
+  var ml=$("modal-my-lang"),tl=$("modal-their-lang"),btn=$("modal-create-btn");
+  var k=(localStorage.getItem("tb_dg_key")||"").trim();
+  var tid=(localStorage.getItem("tb_cf_tid")||"").trim();
+  var tok=(localStorage.getItem("tb_cf_tok")||"").trim();
+  if(btn)btn.disabled=!(ml&&ml.value&&tl&&tl.value&&k&&dgKeyVerified&&tid&&tok);
+}
+function confirmCreateRoom(){
+  var ml=$("modal-my-lang"),tl=$("modal-their-lang"),mn=$("modal-room-name");
+  if(!ml||!ml.value||!tl||!tl.value)return;
+  $("room-name").value=(mn&&mn.value||"").trim();
+  $("my-lang").value=ml.value;
+  $("their-lang").value=tl.value;
+  localStorage.setItem("tb_my_lang",ml.value);
+  localStorage.setItem("tb_their_lang",tl.value);
+  closeCreateRoomModal();
+  createRoom();
+}
+function populateLangs(){['my-lang','their-lang'].forEach(function(id){var s=$(id);s.innerHTML='<option value="" disabled selected>'+(id==='my-lang'?'I speak':'They speak')+'</option>'+LANGS.map(function(l){return'<option value="'+l.code+'">'+l.flag+' '+l.label+'</option>'}).join('');s.onchange=syncBtn});syncBtn()}
+function toggleKeysPanel(){
+  var p=document.getElementById('keys-panel');var btn=document.getElementById('keys-gear-btn');if(!p)return;
+  var open=p.style.display==='flex';p.style.display=open?'none':'flex';
+  if(btn)btn.style.background=open?'':'var(--teal)';if(btn)btn.style.color=open?'':'#fff';
+}
+function syncBtn(){var k=($('dg-key')&&$('dg-key').value)||localStorage.getItem('tb_dg_key')||'';var tid=(($('cf-turn-id')&&$('cf-turn-id').value)||localStorage.getItem('tb_cf_tid')||'').trim();var tok2=(($('cf-turn-tok')&&$('cf-turn-tok').value)||localStorage.getItem('tb_cf_tok')||'').trim();var cb=$('create-btn');if(cb)cb.disabled=!($('my-lang').value&&$('their-lang').value&&k&&dgKeyVerified&&tid&&tok2);syncModalBtn();}
+function setCfTurnStatus(msg,color){var el=$('cf-turn-status');if(!el)return;el.textContent=msg;el.style.color=color||'#888';}
+function onCfTurnInput(){var tid=($('cf-turn-id').value||'').trim();var tok=($('cf-turn-tok').value||'').trim();if(tid)localStorage.setItem('tb_cf_tid',tid);if(tok)localStorage.setItem('tb_cf_tok',tok);if(tid&&tok)setCfTurnStatus('✅ Saved','#2ecc71');else setCfTurnStatus('','');syncBtn();}
+function setDgKeyStatus(msg,color){var el=$('dg-key-status');if(!el)return;el.textContent=msg;el.style.color=color||'#888';}
+function onDgKeyInput(){
+  var raw=$('dg-key').value,k=raw.trim();
+  if(raw!==k)$('dg-key').value=k;
+  dgKeyVerified=false;clearTimeout(dgKeyVerifyTimer);
+  if(!k){setDgKeyStatus('','');syncBtn();return;}
+  setDgKeyStatus('Verifying…','#f39c12');syncBtn();
+  dgKeyVerifyTimer=setTimeout(function(){verifyDgKey(k)},800);
+}
+function verifyDgKey(key){
+  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language=en-US&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=true&endpointing=400';
+  var vws=new WebSocket(url,['token',key]),done=false;
+  var timer=setTimeout(function(){vws.close();if(!done){done=true;setDgKeyStatus('❌ Timed out — check key','#e74c3c');dgKeyVerified=false;syncBtn();}},8000);
+  vws.onopen=function(){if(done)return;done=true;clearTimeout(timer);vws.close();dgKeyVerified=true;localStorage.setItem('tb_dg_key',key);setDgKeyStatus('✅ Key verified','#2ecc71');syncBtn();log('dg_key_verified',{},'ok');};
+  vws.onerror=function(){};
+  vws.onclose=function(ev){clearTimeout(timer);if(!done){done=true;setDgKeyStatus('❌ Invalid key ('+ev.code+') — re-paste and try again','#e74c3c');dgKeyVerified=false;syncBtn();}};
+}
+
+async function createRoom(){
+  room.myLang=$('my-lang').value;room.theirLang=$('their-lang').value;room.name=($('room-name').value||'').trim();
+  if(!room.myLang||!room.theirLang){toast('Select both languages');return}
+  room.id=uid();room.role='creator';
+  lastSessionContext.role='creator';lastSessionContext.myLang=room.myLang;lastSessionContext.theirLang=room.theirLang;lastSessionContext.roomName=room.name;
+  try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}catch(_){toast('Camera needed');return}
+  var url=invUrl();$('lobby-link').textContent=url;var nd=$('room-name-display');if(nd)nd.textContent=room.name||'';
+  if(navigator.clipboard)navigator.clipboard.writeText(url).catch(function(){});
+  saveRecent();enterCall();
+}
+
+var _pendingJoin=null,inviteDgKey='',inviteCfTid='',inviteCfTok='';
+function handleHash(p){
+  if(!p||!p.r)return;
+  setCallPhase('prejoin','hash');
+  if(p.k){inviteDgKey=p.k;if($('dg-key'))$('dg-key').value=p.k;dgKeyVerified=true;} // invite credentials are session-only (no localStorage persistence)
+  if(p.tid){inviteCfTid=p.tid;if($('cf-turn-id'))$('cf-turn-id').value=p.tid;} // keep invite TURN credentials in-memory for this tab only
+  if(p.tok){inviteCfTok=p.tok;if($('cf-turn-tok'))$('cf-turn-tok').value=p.tok;} // keep invite TURN credentials in-memory for this tab only
+  _pendingJoin=p;
+  lastSessionContext.pendingJoinSnapshot=p;
+  var ne=$('joiner-room-name'),fe=$('joiner-flags'),lp=$('joiner-lang-pill'),sub=$('joiner-sub'),jjb=$('joiner-join-btn');
+  var jl=p.tl||'';
+  var rawName=p.n||'';
+  if(ne)ne.textContent=rawName||'You are invited to join a call';
+  if(fe)fe.textContent=(p.ml&&p.tl)?gL(p.ml).flag+' \u2192 '+gL(p.tl).flag:'';
+  if(lp)lp.textContent=jl?gL(jl).flag:'';
+  if(sub)sub.textContent=L('tap_camera',jl);
+  if(jjb)jjb.textContent=L('join_call',jl);
+  if(rawName&&p.ml&&p.tl&&p.ml!==p.tl)translate(rawName,p.ml,p.tl).then(function(tr){if(tr&&tr!==rawName&&ne)ne.textContent=tr;}).catch(function(){});
+  $('joiner-landing').classList.add('show');
+  history.replaceState({},'',location.pathname);
+}
+function joinerProceed(){
+  var p=_pendingJoin;if(!p)return;
+  var captureEpoch=bumpSessionEpoch('joiner_proceed');
+  setCallPhase('joining_media','joiner_proceed');
+  $('joiner-landing').classList.remove('show');
+  $('joining-screen').classList.add('show');
+  if(videoStream){videoStream.getTracks().forEach(function(t){t.stop();});videoStream=null;}
+  navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()}).then(function(s){
+    if(captureEpoch!==sessionEpoch){log('joiner_stale_media',{captureEpoch:captureEpoch,current:sessionEpoch},'warn');s.getTracks().forEach(function(t){t.stop();});$('joining-screen').classList.remove('show');return;}
+    videoStream=s;$('joining-screen').classList.remove('show');
+    room.id=p.r;room.myLang=p.tl;room.theirLang=p.ml;room.name=p.n||'';room.role='joiner';
+    lastSessionContext.role='joiner';lastSessionContext.myLang=p.tl;lastSessionContext.theirLang=p.ml;lastSessionContext.roomName=p.n||'';
+    saveRecent();enterCall();
+  }).catch(function(){
+    $('joining-screen').classList.remove('show');$('joiner-landing').classList.add('show');
+    setCallPhase('prejoin','media_denied');
+    toast('Camera access required');
+  });
+}
+function copyLink(){var u=room.id?invUrl():($('lobby-link').textContent||invUrl());if(navigator.clipboard)navigator.clipboard.writeText(u).then(function(){toast('Link copied')})}
+function shareLink(){var u=room.id?invUrl():($('lobby-link').textContent||invUrl());if(navigator.share)navigator.share({title:'TalkBridge',url:u}).catch(function(){});else copyLink()}
+
+// === RELAY ===
+var _relayFailCount=0;
+function showReconnectBanner(){var b=$('reconnect-banner');if(b)b.classList.add('show');}
+function hideReconnectBanner(){var b=$('reconnect-banner');if(b)b.classList.remove('show');}
+function forceReconnect(){_relayFailCount=0;hideReconnectBanner();if(_relayWs)try{_relayWs.close()}catch(_){}_relayWs=null;if(room.id&&lobbyState===LS.call)connectRelay();}
+function connectRelay(){
+  if(_relayWs)try{_relayWs.close()}catch(_){}
+  var ws=new WebSocket(RELAY_WS+'?app='+encodeURIComponent(RELAY_APP)+'&session='+encodeURIComponent(room.id)+'&client='+encodeURIComponent(deviceId));
+  _relayWs=ws;
+  ws.onopen=function(){
+    if(ws!==_relayWs)return;
+    _relayFailCount=0;hideReconnectBanner();log('relay_open',{},'ok');
+    relaySend({type:'hello',lang:room.myLang,targetLang:room.theirLang,role:room.role});
+    startHB();
+    // Resend any unacked chat messages after reconnect
+    _chatOutbox.forEach(function(msg){relaySend(msg);});
+    if(_chatOutbox.size)log('chat_resend',{n:_chatOutbox.size});
+    if(room.role==='creator'&&!pc)(async()=>{await setupPC();})();
+    // Reconcile DG after relay reconnect
+    reconcileDeepgramState('relay_reconnect');
+  };
+  ws.onmessage=function(e){try{handleRelay(JSON.parse(e.data))}catch(_){}};
+  ws.onclose=function(ev){
+    if(ws!==_relayWs)return;
+    _relayFailCount++;log('relay_close',{code:ev.code},'warn');stopHB();clearTimeout(wsReconnectTimer);
+    if(_relayFailCount>8){showReconnectBanner();return;}
+    if(room.id&&lobbyState===LS.call)wsReconnectTimer=setTimeout(function(){wsReconnectTimer=null;if(room.id)connectRelay()},2000);
+  };
+  ws.onerror=function(){log('relay_err',{},'error')};
+}
+function relaySend(m){if(!_relayWs||_relayWs.readyState!==1)return;m.session=room.id;m.from=deviceId;m.ts=Date.now();m.seq=++seq;try{_relayWs.send(JSON.stringify(m))}catch(_){}}
+function startHB(){stopHB();hbTimer=setInterval(function(){relaySend({type:'ping',transient:true})},HEARTBEAT_MS)}
+function stopHB(){if(hbTimer){clearInterval(hbTimer);hbTimer=null}}
+
+function handleRelay(d){
+  if(!d||d.from===deviceId)return;
+  if(d.type==='hello'){
+    if(room.role==='creator'){
+      $('solo-banner').style.display='none';
+      var state=pc&&pc.connectionState;
+      if(state==='connected'){log('rtc_hello_skip',{state:state});return;}
+      if(savedOffer){relaySend(savedOffer);log('rtc_offer_resent',{},'ok');savedCandidates.forEach(function(cm){relaySend(cm);});log('rtc_cands_resent',{n:savedCandidates.length});transcript.filter(function(e){return e.attachment&&e.attachment.dataUrl;}).forEach(function(e){relaySend({type:'chat-msg',chatId:e.id,srcText:e.sourceText,tgtText:e.translatedText,srcLang:e.srcLang,tgtLang:e.tgtLang,attachment:e.attachment});});}
+    }
+    return;
+  }
+  if(d.type==='ping'){relaySend({type:'pong',transient:true});return}
+  if(d.type==='pong')return;
+  // Phase 6: chat ack clears outbox
+  if(d.type==='chat-ack'){_chatOutbox.delete(d.chatId);log('chat_ack',{chatId:d.chatId});return;}
+  if(d.type==='webrtc-signal'){handleSig(d);return}
+  if(d.type==='subtitle'){
+    markPartnerTalking();
+    var normText=normalizeText(d.text, 'speech');
+    var normSrc=normalizeText(d.sourceText, 'speech')||normText;
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    addTr('partner',normSrc,normText,d.sourceLang,d.targetLang,d.subtitleSeq);return;
+  }
+  if(d.type==='subtitle-update'){
+    markPartnerTalking();
+    var normText=normalizeText(d.text, 'speech');
+    if(normText&&d.targetLang===room.myLang)showSub(normText,'partner');
+    patchTr('partner',d.subtitleSeq,normText,d.sourceLang,d.targetLang);return;
+  }
+  if(d.type==='chat-msg'){handleChatMsg(d);return;}
+  if(d.type==='mic-state'){var rmo=$('remote-mic-off');if(rmo)rmo.classList.toggle('show',d.micOn===false);return;}
+  if(d.type==='cam-state'){var rco=$('remote-cam-off');if(rco){rco.classList.toggle('show',d.camOn===false);}var rcl=$('remote-cam-off-label');if(rcl)rcl.textContent=L('camera_off');return;}
+  if(d.type==='hangup'){
+    if(room.role==='joiner'){showHostLeftCountdown();}
+    else{
+      // Joiner left — creator stays in call, resets to solo waiting state
+      hidePartnerDisconnected();
+      resetRemoteMediaState();
+      pendingCandidates=[];savedOffer=null;savedCandidates=[];
+      resetRecoveryState();
+      if(pc){try{pc.close();}catch(_){}pc=null;}
+      $('solo-banner').style.display='';
+      setCallPhase('call_connecting','partner_left');
+      armConnectTimeout();
+      log('partner_left',{},'info');
+    }
+    return;
+  }
+}
+
+async function enterCall(){
+  if(!videoStream){
+    try{videoStream=await navigator.mediaDevices.getUserMedia({video:true,audio:getMicConstraints()})}
+    catch(_){toast('Camera needed');return}
+  }
+  $('lobby-link').textContent=invUrl();
+  transcript=loadTr()||[];
+  _chatOutbox.clear();_chatReceived.clear();
+  $('lobby').classList.add('hidden');$('joiner-landing').classList.remove('show');
+  hidePartnerDisconnected();hideReconnectBanner();_relayFailCount=0;
+  var sb=$('strip-share-btn');if(sb)sb.style.display=room.role==='creator'?'':'none';
+  var ci=$('chat-input');if(ci)ci.placeholder='type here to chat \u00b7 / for phrases';
+  if(!callHistoryPushed){history.pushState({tbView:'call'},'',location.href);callHistoryPushed=true}
+  $('call-screen').classList.add('active');lobbyState=LS.call;
+  setCallPhase('call_connecting','enter_call');
+  resetRecoveryState();
+  armConnectTimeout();
+  $('local-video').srcObject=videoStream;syncMic();syncCam();updateCallChip();
+  var roomMsg='Entering'+(room.name?' '+room.name:'')+'\n'+gL(room.myLang).flag+' → '+gL(room.theirLang).flag;
+  toast(roomMsg);
+  $('solo-banner').style.display=room.role==='creator'?'':'none';
+  renderTr();
+  connectRelay();
+  dgDesired=true;
+  micMutedByUser=false;
+  reconcileDeepgramState('enter_call');
+}
+
+// === REMOTE VIDEO ===
+function refreshRemoteVideo(){
+  var rv=$('remote-video');
+  var tracks=remoteStream?remoteStream.getTracks():[];
+  var hasVideoTrack=tracks.some(function(t){return t.kind==='video'&&t.readyState==='live'});
+  var hasRemoteTrack=tracks.some(function(t){return t.readyState==='live'});
+  log('rtc_refresh',{tracks:tracks.map(function(t){return t.kind+':'+t.readyState}).join(',')});
+  if(hasRemoteTrack&&rv.srcObject!==remoteStream){rv.srcObject=remoteStream;}
+  rv.playsInline=true;rv.autoplay=true;
+  if(hasRemoteTrack){
+    rv.muted=true;
+    var tryPlay=rv.play&&rv.play();
+    if(tryPlay&&tryPlay.then){tryPlay.then(function(){rv.muted=false;log('rtc_unmuted',{},'ok');}).catch(function(e){log('rtc_play_err',{e:String(e)},'error');});}
+    $('solo-banner').style.display='none';
+  }
+  if(hasVideoTrack){$('no-video-msg').style.display='none';}
+  else{$('no-video-msg').style.display='';if(!hasRemoteTrack&&rv.srcObject)rv.srcObject=null;}
+}
+function bindRemoteTrackState(track){
+  if(!track||track._tbBound)return;track._tbBound=true;
+  track.onunmute=refreshRemoteVideo;track.onmute=refreshRemoteVideo;track.onended=refreshRemoteVideo;
+}
+function resetRemoteMediaState(){
+  var rv=$('remote-video');
+  if(remoteStream)remoteStream.getTracks().forEach(function(t){t.onunmute=null;t.onmute=null;t.onended=null;});
+  remoteStream=null;rv.srcObject=null;$('no-video-msg').style.display='';
+}
+function resetRecoveryState(){
+  _recoveryLock=false;_recoveryStep=0;_stableSince=null;_seenRemoteCand.clear();
+  clearTimeout(_recoveryTimer);_recoveryTimer=null;
+  clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+  clearInterval(_remoteVideoWatchdogTimer);_remoteVideoWatchdogTimer=null;
+  _remoteVideoLastTime=0;_remoteVideoStallCount=0;
+}
+function armConnectTimeout(){
+  clearTimeout(_connectTimeoutTimer);
+  _connectTimeoutTimer=setTimeout(function(){
+    if(callPhase==='call_connecting')runRecovery('connect_timeout');
+  },12000);
+}
+function startRemoteVideoWatchdog(){
+  clearInterval(_remoteVideoWatchdogTimer);
+  _remoteVideoWatchdogTimer=setInterval(function(){
+    if(callPhase!=='call_live')return;
+    var rv=$('remote-video');
+    if(!rv||!rv.srcObject)return;
+    var now=rv.currentTime||0;
+    if(now<=_remoteVideoLastTime+0.01)_remoteVideoStallCount++;
+    else _remoteVideoStallCount=0;
+    _remoteVideoLastTime=now;
+    if(_remoteVideoStallCount>=4){log('rtc_watchdog_stall',{t:now},'warn');runRecovery('video_stall');}
+  },1000);
+}
+async function runRecovery(reason){
+  if(_recoveryLock||!room.id||lobbyState!==LS.call)return;
+  _recoveryLock=true;
+  _recoveryStep=Math.min(_recoveryStep+1,3);
+  var step=_recoveryStep;
+  log('rtc_recovery_step',{step:step,why:reason},'warn');
+  try{
+    if(step===1){
+      refreshRemoteVideo();
+      startRemoteVideoWatchdog();
+      log('rtc_recovery_done',{step:step},'ok');
+    }else if(step===2){
+      if(pc&&pc.connectionState!=='closed'){
+        await pc.setLocalDescription(await pc.createOffer({iceRestart:true}));
+        var msg={type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}};
+        savedOffer=msg;relaySend(msg);log('rtc_recovery_ice_restart',{},'ok');
+      }
+    }else{
+      if(pc){try{pc.close();}catch(_){}pc=null;}
+      resetRemoteMediaState();
+      pendingCandidates=[];savedCandidates=[];savedOffer=null;
+      _seenRemoteCand.clear();
+      await setupPC();
+      connectRelay();
+      armConnectTimeout();
+      log('rtc_recovery_rebuild',{},'ok');
+    }
+  }catch(e){log('rtc_recovery_err',{step:step,e:String(e)},'error');}
+  finally{
+    clearTimeout(_recoveryTimer);
+    _recoveryTimer=setTimeout(function(){_recoveryLock=false;},800);
+  }
+}
+
+// === WEBRTC ===
+var _keepaliveChannel=null;var _keepaliveTimer=null;
+function startKeepalive(){stopKeepalive();_keepaliveTimer=setInterval(function(){if(_keepaliveChannel&&_keepaliveChannel.readyState==='open'){try{_keepaliveChannel.send('k')}catch(_){}}},4000);}
+function stopKeepalive(){clearInterval(_keepaliveTimer);_keepaliveTimer=null;}
+async function setupPC(){
+  if(pc)return;
+  var iceServers=[{urls:'stun:stun.l.google.com:19302'},{urls:'stun:stun1.l.google.com:19302'}];
+  var tid=((inviteCfTid||'')||(localStorage.getItem('tb_cf_tid')||'')).trim();
+  var tok=((inviteCfTok||'')||(localStorage.getItem('tb_cf_tok')||'')).trim();
+  if(tid&&tok){
+    try{
+      var r=await fetch('https://rtc.live.cloudflare.com/v1/turn/keys/'+tid+'/credentials/generate',{method:'POST',headers:{'Authorization':'Bearer '+tok,'Content-Type':'application/json'},body:JSON.stringify({ttl:86400})});
+      if(r.ok){var d=await r.json();if(d.iceServers)iceServers=Array.isArray(d.iceServers)?d.iceServers:[d.iceServers];log('turn_ok',{n:iceServers.length},'ok');}
+      else{log('turn_err',{s:r.status},'warn');}
+    }catch(e){log('turn_fetch_err',{e:String(e)},'warn');}
+  }
+  pc=new RTCPeerConnection({iceServers:iceServers});
+  pc.ondatachannel=function(e){if(e.channel&&e.channel.label==='ka'){e.channel.onmessage=function(){};try{_keepaliveChannel=e.channel;startKeepalive();}catch(_){}}};
+  if(room.role==='creator'){
+    pc.onnegotiationneeded=async function(){
+      try{makingOffer=true;savedCandidates=[];await pc.setLocalDescription(await pc.createOffer());var _offer={type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}};relaySend(_offer);savedOffer=_offer;log('rtc_offer_saved',{},'ok');}
+      catch(_){}finally{makingOffer=false}
+    };
+  }else{
+    pc.onnegotiationneeded=function(){};
+  }
+  var localTracks=videoStream?videoStream.getTracks():[];
+  localTracks.forEach(function(t){pc.addTrack(t,videoStream)});
+  try{_keepaliveChannel=pc.createDataChannel('ka',{ordered:false,maxRetransmits:0});startKeepalive();}catch(_){}
+  pc.onicecandidate=function(e){if(e.candidate){log('rtc_ice_emit',{type:e.candidate.type||'?'});var cm={type:'webrtc-signal',transient:true,signal:{candidate:e.candidate}};savedCandidates.push(cm);relaySend(cm);}};
+  pc.oniceconnectionstatechange=function(){log('rtc_ice',{s:pc.iceConnectionState},pc.iceConnectionState==='connected'?'ok':'info')};
+  pc.onconnectionstatechange=function(){
+    var s=pc.connectionState;
+    log('rtc_conn',{s:s},s==='connected'?'ok':s==='failed'?'error':'info');
+    if(s==='connected'){
+      hidePartnerDisconnected();
+      clearTimeout(_connectTimeoutTimer);_connectTimeoutTimer=null;
+      _stableSince=Date.now();
+      clearTimeout(_recoveryTimer);
+      _recoveryTimer=setTimeout(function(){
+        if(!pc||pc.connectionState!=='connected')return;
+        if(_stableSince&&Date.now()-_stableSince>=2000){
+          setCallPhase('call_live','pc_connected_stable');
+          _recoveryStep=0;
+          reconcileDeepgramState('pc_connected_stable');
+          startRemoteVideoWatchdog();
+        }
+      },2000);
+    }
+    if(s==='disconnected'){
+      _stableSince=null;clearTimeout(_recoveryTimer);
+      setCallPhase('call_degraded','pc_disconnected');
+      showPartnerDisconnected(L('disconnected'));
+      runRecovery('pc_disconnected');
+    }
+    if(s==='failed'&&room.id&&lobbyState===LS.call){
+      _stableSince=null;clearTimeout(_recoveryTimer);
+      log('rtc_restart',{},'warn');
+      setCallPhase('call_degraded','pc_failed');
+      runRecovery('pc_failed');
+    }
+  };
+  pc.ontrack=function(e){
+    log('rtc_track',{kind:e.track.kind,state:e.track.readyState},'ok');
+    if(!remoteStream)remoteStream=new MediaStream();
+    if(e.streams&&e.streams[0]){
+      e.streams[0].getTracks().forEach(function(track){
+        if(!remoteStream.getTracks().some(function(x){return x.id===track.id}))remoteStream.addTrack(track);
+        bindRemoteTrackState(track);
+      });
+    }else if(e.track){
+      if(!remoteStream.getTracks().some(function(x){return x.id===e.track.id}))remoteStream.addTrack(e.track);
+      bindRemoteTrackState(e.track);
+    }
+    refreshRemoteVideo();
+  };
+}
+
+async function flushPendingCandidates(){
+  while(pendingCandidates.length){
+    var c=pendingCandidates.shift();
+    try{await pc.addIceCandidate(c);log('rtc_ice_flushed',{},'ok')}catch(_){}
+  }
+}
+
+async function handleSig(d){
+  if(!d.signal)return;
+  try{
+    if(d.signal.description){
+      var desc=d.signal.description;
+      if(desc.type==='offer'){
+        if(pc&&pc.connectionState==='connected'){log('rtc_offer_skip',{state:pc.connectionState});return;}
+        if(pc&&pc.connectionState!=='closed'&&pc.connectionState!=='failed'){try{pc.close()}catch(_){}pc=null;remoteStream=null;pendingCandidates=[];savedCandidates=[];}
+        if(!pc)await setupPC();
+        await pc.setRemoteDescription(desc);
+        await flushPendingCandidates();
+        await pc.setLocalDescription(await pc.createAnswer());
+        relaySend({type:'webrtc-signal',transient:true,signal:{description:pc.localDescription}});
+        $('solo-banner').style.display='none';
+        log('rtc_answered',{},'ok');
+      }else if(desc.type==='answer'){
+        await pc.setRemoteDescription(desc);
+        await flushPendingCandidates();
+        savedOffer=null;
+        log('rtc_got_answer',{},'ok');
+      }
+    }else if(d.signal.candidate){
+      var c=d.signal.candidate||{};
+      var cKey=[c.sdpMid||'',c.sdpMLineIndex==null?'':c.sdpMLineIndex,String(c.candidate||'')].join('|');
+      if(_seenRemoteCand.has(cKey)){log('rtc_ice_dupe_drop',{},'warn');return;}
+      _seenRemoteCand.add(cKey);
+      if(!pc||!pc.remoteDescription){
+        pendingCandidates.push(c);
+        log('rtc_ice_queued',{n:pendingCandidates.length});
+      }else{
+        try{await pc.addIceCandidate(c);log('rtc_ice_added',{type:c.type||'?'});}catch(e){log('rtc_ice_add_err',{e:String(e)},'error');}
+      }
+    }
+  }catch(e){log('rtc_sig_err',{e:String(e)},'error')}
+}
+
+// === DEEPGRAM STT ===
+function isCallActive(){return !!(room.id&&$('call-screen').classList.contains('active'))}
+function isDupe(text){
+  var now=Date.now();recentFinals=recentFinals.filter(function(f){return now-f.t<DEDUP_MS});
+  var lo=normalizeText(text,'compare');
+  for(var i=0;i<recentFinals.length;i++){var p=recentFinals[i].s;if(p===lo)return true;if(p.length>5&&lo.length>5&&(p.indexOf(lo)>=0||lo.indexOf(p)>=0))return true}
+  return false;
+}
+function recFinal(t){recentFinals.push({s:normalizeText(t,'compare'),t:Date.now()});if(recentFinals.length>DEDUP_MAX)recentFinals.shift()}
+function stripDGTags(t){return(t||'').replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim()}
+
+function onDGFinal(text){
+  text=normalizeText(stripDGTags(text),'speech');if(!text)return;
+  text=text.replace(/([\u0E34-\u0E37\u0E40-\u0E44]) ([\u0E00-\u0E7F])/g,'$1$2').replace(/([\u0E00-\u0E7F]) ([\u0E30-\u0E37\u0E47-\u0E4E])/g,'$1$2');
+  text=applyNorthernThaiMap(text);if(!text)return;
+  if(isDupe(text)){log('dg_dedup',{t:text.slice(0,40)},'warn');return}
+  recFinal(text);log('dg_final',{t:text.slice(0,60)},'ok');
+  var src=room.myLang,tgt=room.theirLang,ss=++localSubSeq;
+  showSub(text,'mine');
+  log('norm_start',{ss:ss,src:src,tgt:tgt,ft_ready:_ftReady,text:text.slice(0,60)});
+  var _ftWon=false;
+  Promise.race([
+    _detectLangAsyncSpeech(text).then(function(d){_ftWon=true;return d;}),
+    new Promise(function(res){setTimeout(function(){
+      if(!_ftWon)log('norm_timeout',{ft_ready:_ftReady,ft_failed:_ftLoadFailed,fallback:src},'warn');
+      res(detectLang(text,src));
+    },150);})
+  ]).then(function(detected){
+    log('norm_detect',{detected:detected||'(none)',src:src,needs_norm:!!(detected&&detected!==src),via:_ftWon?'wasm':'stub'});
+    if(detected&&detected!==src){
+      log('norm_step',{from:detected,to:src,text:text.slice(0,60)});
+      return translateWithRetry(text,detected,src,2);
+    }
+    return Promise.resolve(text);
+  }).then(function(srcText){
+    srcText=normalizeText(srcText,'speech')||text;
+    log('norm_result',{srcText:srcText.slice(0,60),ss:ss});
+    relaySend({type:'subtitle',subtitleSeq:ss,text:srcText,sourceText:srcText,sourceLang:src,targetLang:tgt,provisional:true});
+    addTr('me',srcText,srcText,src,tgt,ss);
+    return translateWithRetry(srcText,src,tgt,2).then(function(tr){
+      tr=normalizeText(tr,'speech')||srcText;
+      log('trans_result',{from:src,to:tgt,tr:tr.slice(0,60),ss:ss},'ok');
+      relaySend({type:'subtitle-update',subtitleSeq:ss,text:tr,sourceText:srcText,sourceLang:src,targetLang:tgt});
+      patchTr('me',ss,tr,src,tgt);
+    });
+  }).catch(function(e){log('dg_trans_err',{e:String(e),ss:ss},'error');});
+}
+
+function stopDGAudio(){
+  if(dgProc)try{dgProc.disconnect();}catch(_){}dgProc=null;
+  if(dgSrc)try{dgSrc.disconnect();}catch(_){}dgSrc=null;
+  if(dgAudioCtx)try{dgAudioCtx.close();}catch(_){}dgAudioCtx=null;
+}
+function stopDeepgram(){
+  _stopDgWatchdog();
+  dgActive=false;if(dgWs){try{dgWs.close()}catch(_){}dgWs=null;}stopDGAudio();log('dg_stopped',{});
+}
+function startDeepgram(){
+  var key=(($('dg-key')&&$('dg-key').value)||inviteDgKey||localStorage.getItem('tb_dg_key')||'').trim();
+  if(!key){toast('Deepgram key missing');return}
+  if(!inviteDgKey&&key)localStorage.setItem('tb_dg_key',key);
+  if(dgActive){log('dg_skip_active',{},'warn');return;}
+  if(dgWs&&dgWs.readyState<2){log('dg_skip_open',{},'warn');return;}
+  if(!videoStream){log('dg_no_stream',{},'error');return}
+  if(micMutedByUser){log('dg_skip_muted',{},'warn');return;}
+  var langCode=DG_LANGS[room.myLang]||room.myLang||'en-US';
+  log('dg_lang_select',{role:role,myLang:room.myLang,theirLang:room.theirLang,dgLang:langCode});
+  var url='wss://api.deepgram.com/v1/listen?model=nova-3&language='+encodeURIComponent(langCode)+'&encoding=linear16&sample_rate=16000&channels=1&interim_results=false&punctuate=false&endpointing=400';
+  var captureEpoch=sessionEpoch;
+  dgWs=new WebSocket(url,['token',key]);
+  dgWs.onopen=function(){
+    if(captureEpoch!==sessionEpoch||!dgDesired||micMutedByUser){log('dg_open_stale',{captureEpoch:captureEpoch,current:sessionEpoch},'warn');try{dgWs.close();}catch(_){}return;}
+    log('dg_open',{lang:langCode},'ok');
+    try{
+      var audioTracks=(videoStream?videoStream.getAudioTracks():[]).filter(function(t){return t.readyState==='live'&&t!==_silentAudioTrack;});
+      if(!audioTracks.length){log('dg_no_audio',{},'error');dgWs.close();return;}
+      var dgStream=new MediaStream(audioTracks);
+      dgAudioCtx=new(window.AudioContext||window.webkitAudioContext)({sampleRate:16000});
+      dgSrc=dgAudioCtx.createMediaStreamSource(dgStream);
+      var silentGain=dgAudioCtx.createGain();silentGain.gain.value=0;silentGain.connect(dgAudioCtx.destination);
+      function _setupScriptProc(){
+        dgProc=dgAudioCtx.createScriptProcessor(4096,1,1);
+        dgProc.onaudioprocess=function(e){
+          if(!dgWs||dgWs.readyState!==1)return;
+          var f=e.inputBuffer.getChannelData(0);
+          var b=new Int16Array(f.length);
+          for(var i=0;i<f.length;i++){var s=Math.max(-1,Math.min(1,f[i]));b[i]=s<0?s*0x8000:s*0x7FFF;}
+          dgWs.send(b.buffer);
+        };
+        dgSrc.connect(dgProc);dgProc.connect(silentGain);
+        dgActive=true;log('dg_scriptproc_active',{},'warn');
+      }
+      if(dgAudioCtx.audioWorklet&&typeof AudioWorkletNode!=='undefined'){
+        var _wblob=new Blob([DG_WORKLET_CODE],{type:'application/javascript'});
+        var _wurl=URL.createObjectURL(_wblob);
+        dgAudioCtx.audioWorklet.addModule(_wurl).then(function(){
+          URL.revokeObjectURL(_wurl);
+          if(!dgWs||dgWs.readyState!==1)return;
+          var _wnode=new AudioWorkletNode(dgAudioCtx,'tb-audio-capture');
+          _wnode.port.onmessage=function(ev){
+            if(!dgWs||dgWs.readyState!==1)return;
+            var f=ev.data;var b=new Int16Array(f.length);
+            for(var i=0;i<f.length;i++){var s=Math.max(-1,Math.min(1,f[i]));b[i]=s<0?s*0x8000:s*0x7FFF;}
+            dgWs.send(b.buffer);
+          };
+          dgSrc.connect(_wnode);_wnode.connect(silentGain);
+          dgProc=_wnode;dgActive=true;log('dg_worklet_active',{},'ok');
+        }).catch(function(e){
+          URL.revokeObjectURL(_wurl);
+          log('worklet_fallback',{e:String(e)},'warn');
+          toast('Audio: legacy processor active');
+          _setupScriptProc();
+        });
+      }else{
+        _setupScriptProc();
+      }
+    }catch(e){log('dg_audio_err',{e:String(e)},'error');dgActive=false;}
+  };
+  dgWs.onmessage=function(e){
+    _dgLastMsg=Date.now();
+    try{
+      var d=JSON.parse(e.data);
+      var alt=d.channel&&d.channel.alternatives&&d.channel.alternatives[0];
+      if(alt&&alt.transcript&&d.is_final)onDGFinal(alt.transcript);
+    }catch(_){}
+  };
+  dgWs.onerror=function(){log('dg_error',{},'error')};
+  dgWs.onclose=function(ev){
+    log('dg_close',{code:ev.code,captureEpoch:captureEpoch,current:sessionEpoch},'warn');
+    dgActive=false;stopDGAudio();_stopDgWatchdog();
+    if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+      setTimeout(function(){
+        if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+          reconcileDeepgramState('dg_onclose_retry');
+        }
+      },2000);
+    }
+  };
+  // Watchdog: if DG goes silent (no WS messages) during a live call, restart it
+  _dgLastMsg=Date.now();
+  _stopDgWatchdog();
+  _dgWatchdogTimer=setInterval(function(){
+    if(!dgActive||!dgDesired||micMutedByUser||captureEpoch!==sessionEpoch){_stopDgWatchdog();return;}
+    if(Date.now()-_dgLastMsg>DG_WATCHDOG_MS){
+      log('dg_watchdog_restart',{silent_ms:Date.now()-_dgLastMsg},'warn');
+      stopDeepgram();
+      setTimeout(function(){
+        if(isCallActive()&&dgDesired&&!micMutedByUser&&captureEpoch===sessionEpoch){
+          reconcileDeepgramState('dg_watchdog');
+        }
+      },1000);
+    }
+  },5000);
+}
+function _stopDgWatchdog(){clearInterval(_dgWatchdogTimer);_dgWatchdogTimer=null;}
+
+function showSub(text,cls){
+  var a=$('subtitle-area'),el=document.createElement('div');
+  el.className='subtitle-line '+cls;el.textContent=text;a.appendChild(el);
+  while(a.children.length>2)a.children[0].remove();
+  setTimeout(function(){if(el.parentNode)el.remove()},SUB_LINGER);
+}
+
+function addTr(who,src,tr,sL,tL,ss){
+  src=normalizeText(src,'speech');tr=normalizeText(tr,'speech');if(!src&&!tr)return;if(!tr)tr=src;
+  if(ss){for(var j=transcript.length-1;j>=0;j--){if(transcript[j].who===who&&transcript[j].subtitleSeq===ss){transcript[j].sourceText=src;transcript[j].translatedText=tr;transcript[j].ts=Date.now();saveTr();renderTr();return;}}}
+  var prev=transcript.length?transcript[transcript.length-1]:null;
+  if(!ss&&prev&&prev.who===who&&normalizeText(prev.sourceText,'compare')===normalizeText(src,'compare')&&Date.now()-prev.ts<5000)return;
+  var entry={id:(ss?('sp-'+(who==='me'?'m'+_ssNonce:'p')+'-'+ss):('sp-'+uid())),type:'speech',who:who,sourceText:src,translatedText:tr,srcLang:sL,tgtLang:tL,subtitleSeq:ss||null,ts:Date.now()};
+  transcript.push(entry);if(transcript.length>MAX_TR)transcript.splice(0,transcript.length-MAX_TR);
+  saveTr();appendTrDom(entry);
+  if(transcriptTtsOn&&who==='partner'&&tr&&!ss)speakText(tr,tL||room.myLang);
+}
+function patchTr(who,ss,newTr,sL,tL){
+  newTr=normalizeText(newTr,'speech');if(!newTr)return;
+  for(var i=transcript.length-1;i>=0;i--){
+    if(transcript[i].who===who&&transcript[i].subtitleSeq===ss){
+      if(normalizeText(transcript[i].translatedText,'compare')===normalizeText(newTr,'compare'))return;
+      transcript[i].translatedText=newTr;transcript[i].ts=Date.now();saveTr();
+      replaceTrDomById(transcript[i].id,transcript[i]);
+      if(transcriptTtsOn&&who==='partner'&&newTr)speakText(newTr,tL||room.myLang);
+      return;
+    }
+  }
+  addTr(who,newTr,newTr,sL,tL,ss);
+}
+function renderMd(txt){
+  if(!txt)return'';
+  var s=txt.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  s=s.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
+  s=s.replace(/\*(.+?)\*/g,'<em>$1</em>');
+  s=s.replace(/--([^|]+)\|([^-]+)--/g,'<a href="$2" target="_blank" rel="noopener" style="color:var(--teal-bright)">$1</a>');
+  s=s.replace(/(https?:\/\/[^\s<]+)/g,'<a href="$1" target="_blank" rel="noopener" style="color:var(--teal-bright)">$1</a>');
+  s=s.replace(/\n/g,'<br>');
+  return s;
+}
+function trHtml(e){
+  var srcLang=e.srcLang||(e.who==='me'?room.myLang:room.theirLang)||'en';
+  var tgtLang=e.tgtLang||(e.who==='me'?room.theirLang:room.myLang)||'en';
+  var locale=TTS_LOCALE[srcLang]||'en-US';
+  var ts=new Date(e.ts).toLocaleTimeString(locale,{hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  var speaker=e.who==='me'?L('you_word'):L('partner_word');
+  var srcText=e.sourceText||'';var tgtText=e.translatedText||srcText;
+  var isMine=e.who==='me';
+  var leftText,rightText,leftLang,rightLang;
+  if(isMine){leftText=srcText;rightText=tgtText;leftLang=srcLang;rightLang=tgtLang;}
+  else{leftText=tgtText;rightText=srcText;leftLang=tgtLang;rightLang=srcLang;}
+  var attachHtml='';
+  if(e.attachment&&e.attachment.dataUrl){
+    var att=e.attachment;var eid=e.id||'';var isImg=/^image\//.test(att.type||'');
+    if(!_attCache[eid])_attCache[eid]=att;
+    var imgPreview=isImg?'<img src="'+att.dataUrl+'" style="max-width:100%;max-height:120px;border-radius:6px;margin-top:4px;display:block;cursor:pointer;" onclick="attModalOpenById(\''+eid+'\')">':'';
+    attachHtml='<div style="margin-top:6px;">'
+      +'<div style="display:flex;align-items:center;gap:6px;">'
+      +'<a href="#" onclick="attModalOpenById(\''+eid+'\');return false;" style="color:var(--teal-bright);font-size:12px;display:inline-flex;align-items:center;gap:4px;text-decoration:underline;">'+ICO.clip+' '+esc(att.name||'file')+'</a>'
+      +(isMine?'<button onclick="removeTrEntry(\''+eid+'\');" style="background:none;border:none;cursor:pointer;color:#c4ccd4;padding:0;line-height:0;opacity:.7;" title="Remove"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\"><line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/><line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg></button>':'')
+      +'</div>'+imgPreview+'</div>';
+  }
+  var chatClass=e.type==='chat'?' is-chat':'';
+  return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
+    +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
+    +'<div class="tr-body">'
+    +'<div class="tr-col"><div class="tr-text">'+(e.type==='chat'?renderMd(leftText):esc(leftText))+attachHtml+'</div>'
+    +'<div style="display:flex;gap:5px;align-items:center;">'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
+    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(leftText)+'" title="'+esc(L('use_word',leftLang))+'">'+esc(L('use_word',leftLang))+'</button>'
+    +'</div></div>'
+    +'<div class="tr-divider"></div>'
+    +'<div class="tr-col source"><div class="tr-text">'+(e.type==='chat'?renderMd(rightText):esc(rightText))+'</div>'
+    +'<div style="display:flex;gap:5px;align-items:center;">'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
+    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(rightText)+'" title="'+esc(L('use_word',rightLang))+'">'+esc(L('use_word',rightLang))+'</button>'
+    +'</div></div>'
+    +'</div></div></div>';
+}
+function appendTrDom(entry){
+  var b=$('transcript-body');if(!b)return;
+  var em=b.querySelector('.tr-empty');if(em)em.remove();
+  var wrap=document.createElement('div');
+  wrap.innerHTML=trHtml(entry);
+  var eid=entry.id||(entry.ts+'_'+entry.who);
+  wrap.firstChild.dataset.trId=eid;
+  b.insertBefore(wrap.firstChild,b.firstChild);
+  checkAutoScroll();
+}
+function replaceTrDomById(id,entry){
+  var b=$('transcript-body');if(!b||!id)return;
+  var old=b.querySelector('[data-tr-id="'+id+'"]');
+  if(!old){appendTrDom(entry);return;}
+  var wrap=document.createElement('div');
+  wrap.innerHTML=trHtml(entry);
+  var fresh=wrap.firstChild;
+  fresh.dataset.trId=id;
+  old.replaceWith(fresh);
+}
+function renderTr(){
+  var b=$('transcript-body');if(!b)return;
+  if(!transcript.length){b.innerHTML='<div class="tr-empty">Speak or type to see transcript here.</div>';setTranscriptMore(false);return}
+  var existing=Array.from(b.querySelectorAll('.tr-entry'));
+  var existingIds=new Set(existing.map(function(el){return el.dataset.trId;}));
+  var toRender=transcript.slice(-120).slice().reverse();
+  var newHtml='';
+  for(var i=0;i<toRender.length;i++){
+    var e=toRender[i];var eid=e.id||(e.ts+'_'+e.who);
+    if(!existingIds.has(eid)){var wrap=document.createElement('div');wrap.innerHTML=trHtml(e);wrap.firstChild.dataset.trId=eid;newHtml+=wrap.innerHTML;}
+  }
+  if(newHtml){var em=b.querySelector('.tr-empty');if(em)em.remove();b.insertAdjacentHTML('afterbegin',newHtml);}
+  while(b.children.length>120){b.lastChild.remove();}
+  setTranscriptMore(false);
+}
+
+function checkAutoScroll(){
+  var c=$('call-transcript');
+  if(transcriptNearBottom()){c.scrollTop=0;setTranscriptMore(false)}else{setTranscriptMore(true)}
+}
+function transcriptNearBottom(){var c=$('call-transcript');if(!c)return true;return c.scrollTop<100;}
+function setTranscriptMore(show){var ind=$('transcript-more-indicator');if(!ind)return;if(show)ind.classList.add('show');else ind.classList.remove('show');}
+function scrollToBottom(){var c=$('call-transcript');if(c){c.scrollTop=0;setTranscriptMore(false)}}
+
+function copyTr(){
+  if(!transcript.length){toast('No transcript');return}
+  var t=transcript.map(function(e){var ts=new Date(e.ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'});return '['+ts+'] '+(e.who==='me'?'You':'Partner')+': '+e.sourceText+(e.translatedText&&e.translatedText!==e.sourceText?' → '+e.translatedText:'')}).join('\n');
+  if(navigator.clipboard)navigator.clipboard.writeText(t).then(function(){toast('Copied')});
+}
+function exportTxt(){
+  if(!transcript.length){toast('No transcript');return}
+  var _uid=function(){return Date.now().toString(36)+Math.random().toString(36).slice(2,8);};
+  var catId='tb-'+Date.now().toString(36);
+  var sessionName=(room.name||'TalkBridge')+' '+new Date().toLocaleDateString();
+  var cards=transcript.filter(function(e){return e.sourceText&&e.translatedText&&e.sourceText!==e.translatedText;}).map(function(e){
+    return {id:'c-'+_uid(),catalogIds:[catId],sourceLang:e.srcLang||'en',targetLang:e.tgtLang||'en',source:e.sourceText,target:e.translatedText,notes:'',tags:e.type==='chat'?['chat']:['speech'],backtranslate:{sourceLang:e.tgtLang||'en',targetLang:e.srcLang||'en',inputText:e.translatedText,resultText:'',verdict:'',contentHash:'',updatedAt:e.ts},clarifyChain:[],savedBy:e.who==='me'?'You':'Partner',createdAt:e.ts,updatedAt:e.ts};
+  });
+  if(!cards.length){toast('No translated content to export');return}
+  var payload={type:'phrasebook',cards:cards,catalogs:[{id:catId,name:sessionName,emoji:'\uD83C\uDFA4',desc:'Exported from TalkBridge',lang:room.myLang||'en',createdAt:Date.now()}],tags:['speech','chat'],exportedAt:Date.now()};
+  var blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'});
+  var u=URL.createObjectURL(blob);var a=document.createElement('a');a.href=u;a.download='talkbridge-'+new Date().toISOString().slice(0,10)+'.json';a.click();setTimeout(function(){URL.revokeObjectURL(u)},0);
+  toast('Exported '+cards.length+' phrases');
+}
+
+function _makeSilentTrack(){
+  try{
+    _cleanupSilentAudioHelper();
+    var ctx=new AudioContext();
+    var dst=ctx.createMediaStreamDestination();
+    var osc=ctx.createOscillator();
+    osc.frequency.value=0;
+    osc.connect(dst);
+    osc.start();
+    var t=dst.stream.getAudioTracks()[0]||null;
+    _silentAudioCtx=ctx;_silentOsc=osc;_silentAudioTrack=t;
+    return t;
+  }catch(_){
+    _cleanupSilentAudioHelper();
+    return null;
+  }
+}
+
+// Phase 4: toggleMic with intent tracking
+async function toggleMic(){
+  if(_micToggleInFlight)return;
+  _micToggleInFlight=true;
+  try{
+    micOn=!micOn;
+    if(!videoStream)return;
+    if(!micOn){
+      micMutedByUser=true;dgDesired=false;
+      relaySend({type:'mic-state',micOn:false});
+      stopDeepgram();
+      videoStream.getAudioTracks().forEach(function(t){try{videoStream.removeTrack(t);}catch(_){} if(t!==_silentAudioTrack)try{t.stop();}catch(_){};});
+      if(!_silentAudioTrack||_silentAudioTrack.readyState==='ended')_silentAudioTrack=_makeSilentTrack();
+      if(_silentAudioTrack){
+        videoStream.addTrack(_silentAudioTrack);
+        if(pc){
+          var sndMute=pc.getSenders().find(function(s){return s.track&&s.track.kind==='audio';});
+          if(sndMute){
+            log('replaceTrack_start',{phase:'mute'});
+            try{await sndMute.replaceTrack(_silentAudioTrack);log('replaceTrack_ok',{phase:'mute'});}catch(err){log('replaceTrack_fail',{phase:'mute',err:String(err)});}
+          }
+        }
+      }else{log('silent_track_unavailable',{});}
+      log('mic_muted',{});
+    }else{
+      var ms=null;var newTrack=null;
+      try{
+        ms=await navigator.mediaDevices.getUserMedia({audio:getMicConstraints()});
+        newTrack=ms.getAudioTracks()[0];
+        if(!newTrack)throw new Error('missing_audio_track');
+        if(pc){
+          var sndUnmute=pc.getSenders().find(function(s){return s.track&&(s.track.kind==='audio'||s.track.readyState==='ended');});
+          if(sndUnmute){
+            log('replaceTrack_start',{phase:'unmute'});
+            await sndUnmute.replaceTrack(newTrack);
+            log('replaceTrack_ok',{phase:'unmute'});
+          }
+        }
+        if(_silentAudioTrack){try{videoStream.removeTrack(_silentAudioTrack);}catch(_){}}
+        _cleanupSilentAudioHelper();
+        videoStream.getAudioTracks().forEach(function(t){ if(t!==newTrack){try{videoStream.removeTrack(t);}catch(_){} try{t.stop();}catch(_){}} });
+        videoStream.addTrack(newTrack);
+        micMutedByUser=false;dgDesired=true;
+        relaySend({type:'mic-state',micOn:true});
+        log('mic_unmuted',{});
+        log('dg_reactivate_intent',{why:'unmute'});
+        reconcileDeepgramState('unmute');
+      }catch(err){
+        if(newTrack)try{newTrack.stop();}catch(_){}
+        if(ms)ms.getTracks().forEach(function(t){if(t!==newTrack)try{t.stop();}catch(_){};});
+        micOn=false;micMutedByUser=true;dgDesired=false;
+        stopDeepgram();
+        log('replaceTrack_fail',{phase:'unmute',err:String(err)});
+        toast('Mic unavailable');
+      }
+    }
+  }finally{
+    syncMic();
+    _micToggleInFlight=false;
+  }
+}
+
+function toggleCam(){
+  if(!videoStream)return;camOn=!camOn;
+  videoStream.getVideoTracks().forEach(function(t){t.enabled=camOn});
+  syncCam();relaySend({type:'cam-state',camOn:camOn});
+}
+
+// Phase 2: rejoinCall — role-aware routing
+function rejoinCall(){
+  $('thankyou-page').classList.remove('show');
+  var role=lastSessionContext.role||(_pendingJoin?'joiner':'creator');
+  if(role==='joiner'&&_pendingJoin){
+    setCallPhase('prejoin','rejoin_joiner');
+    $('joiner-landing').classList.add('show');
+  }else{
+    setCallPhase('idle','rejoin_creator');
+    $('lobby').classList.remove('hidden');
+    setLS(LS.setup);
+  }
+}
+
+// Phase 7: showThankYou uses teardownSession
+function showThankYou(msg){
+  var savedRole=room.role;
+  var ty_lang=((_pendingJoin&&_pendingJoin.tl)||room.myLang||'en');
+  teardownSession('to_thankyou',msg||'local_end');
+  room.id=null;room.role=null;
+  setCallPhase('postcall_joiner','show_thankyou');
+  $('call-screen').classList.remove('active');
+  var t=$('thankyou-title'),s=$('thankyou-sub'),lp=$('thankyou-lang-pill');
+  if(t)t.textContent=msg||L('thanks',ty_lang);
+  if(s)s.textContent=L('close_tab',ty_lang);
+  if(lp)lp.textContent=_pendingJoin&&_pendingJoin.tl?gL(_pendingJoin.tl).flag:(ty_lang?gL(ty_lang).flag:'');
+  $('thankyou-page').classList.add('show');
+  history.replaceState({tbView:'thankyou'},'',location.pathname);
+  var rb=$('thankyou-rejoin-btn');if(rb&&_pendingJoin){rb.style.display='';rb.textContent=L('rejoin',ty_lang);}
+  var dl=$('thankyou-dl-btn');if(dl)dl.textContent=L('dl_transcript',ty_lang);
+  try{window.close();}catch(_){}
+}
+
+// Phase 7: showHostLeftCountdown uses teardownSession
+function showHostLeftCountdown(){
+  var ty_lang=((_pendingJoin&&_pendingJoin.tl)||room.myLang||'en');
+  teardownSession('to_host_left_countdown','host_ended');
+  room.id=null;room.role=null;
+  setCallPhase('postcall_joiner','host_left');
+  $('call-screen').classList.remove('active');
+  var n=5,t=$('thankyou-title'),s=$('thankyou-sub'),lp=$('thankyou-lang-pill');
+  if(t)t.textContent='Host ended the call.';
+  if(s)s.textContent=L('close_tab',ty_lang);
+  if(lp)lp.textContent=_pendingJoin&&_pendingJoin.tl?gL(_pendingJoin.tl).flag:(ty_lang?gL(ty_lang).flag:'');
+  var rb=$('thankyou-rejoin-btn');if(rb&&_pendingJoin){rb.style.display='';rb.textContent=L('rejoin',ty_lang);}
+  var dl=$('thankyou-dl-btn');if(dl)dl.textContent=L('dl_transcript',ty_lang);
+  if(s)s.textContent=L('close_tab',ty_lang);
+  $('thankyou-page').classList.add('show');
+  history.replaceState({tbView:'thankyou'},'',location.pathname);
+  var iv=setInterval(function(){n--;if(t)t.textContent=n>0?'Host ended the call. Closing in '+n+'s…':'Host ended the call.';if(n<=0){clearInterval(iv);try{window.close();}catch(_){}}},1000);
+}
+
+function downloadThankyouLog(){
+  var t=debugLog.map(function(r){return r.ts+' ['+r.ev+'] '+JSON.stringify(r.d)}).join('\n');
+  var blob=new Blob([t],{type:'text/plain'});var u=URL.createObjectURL(blob);var a=document.createElement('a');
+  a.href=u;a.download='talkbridge-log-'+new Date().toISOString().slice(0,10)+'.txt';a.click();setTimeout(function(){URL.revokeObjectURL(u)},0);
+}
+function showPartnerDisconnected(msg){
+  var ov=$('partner-disconnected-overlay'),lbl=$('partner-disconnected-label'),sub=$('partner-disconnected-sub');
+  if(!ov)return;
+  if(lbl)lbl.textContent=msg||L('disconnected');
+  if(sub)sub.textContent=L('waiting');
+  ov.classList.add('show');
+}
+function hidePartnerDisconnected(){
+  var ov=$('partner-disconnected-overlay');if(ov)ov.classList.remove('show');
+  var rco=$('remote-cam-off');if(rco)rco.classList.remove('show');
+}
+
+// Phase 2: hangUp — role-split enforced
+function hangUp(){
+  relaySend({type:'hangup'});
+  if(room.role==='creator'){
+    cleanUp();
+  }else{
+    showThankYou('You ended the call.');
+  }
+}
+
+// Phase 7: cleanUp uses teardownSession
+function cleanUp(){
+  var _ci=$('chat-input');if(_ci){_ci.value='';_ci.style.height='';}
+  teardownSession('to_lobby','cleanup');
+  recentFinals=[];
+  _chatOutbox.clear();_chatReceived.clear();
+  room.id=null;room.role=null;
+  setCallPhase('idle','cleanup_done');
+  $('call-screen').classList.remove('active');
+  $('lobby').classList.remove('hidden');setLS(LS.setup);
+  $('subtitle-area').innerHTML='';$('no-video-msg').style.display='';hidePartnerDisconnected();hideReconnectBanner();_relayFailCount=0;
+  $('partner-speaking-indicator').classList.remove('show');clearTimeout(partnerSpeakTimer);
+  $('call-screen').classList.remove('transcript-collapsed');transcriptCollapsed=false;setTranscriptMore(false);syncTranscriptToggleButton();
+  transcriptTtsOn=false;syncTranscriptTtsButton();if(window.speechSynthesis)window.speechSynthesis.cancel();
+  document.querySelector('.call-videos').classList.remove('swapped');
+  resetRemoteMediaState();
+  transcript=[];micOn=true;camOn=true;micMutedByUser=false;dgDesired=false;_pbMutedMic=false;syncMic();syncCam();renderRecent();
+}
+
+// === INIT ===
+if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem('tb_dg_key').trim();$('dg-key').value=_sk;setDgKeyStatus('Verifying saved key…','#f39c12');verifyDgKey(_sk);}
+if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
+if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
+if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
+log('startup',{v:'2.0',ua:navigator.userAgent.slice(0,80)});
+pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();_syncFtStatus();
+$('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
+$('call-transcript').addEventListener('click',function(ev){
+  var tts=ev.target.closest('.tr-tts');
+  if(tts){speakText(tts.getAttribute('data-tts-text')||'',tts.getAttribute('data-tts-lang')||room.myLang||'en');return;}
+  var use=ev.target.closest('.tr-use-ico');
+  if(use){var ci=$('chat-input');if(ci){ci.value=use.getAttribute('data-use-text')||'';ci.dispatchEvent(new Event('input'));}}
+});
+$('local-video').addEventListener('click',swapVideos);
+$('remote-video').addEventListener('click',swapVideos);
+$('remote-video').addEventListener('loadedmetadata',refreshRemoteVideo);
+var hp=new URLSearchParams((location.hash||'').replace(/^#/,''));var inv=hp.get('j');if(inv){var p=decInv(inv);if(p&&p.r)handleHash(p)}
+var _pipActive=false;
+function _pipOverlayFallback(){
+  if(_pipActive)return;_pipActive=true;
+  var po=$('pip-overlay');
+  var rv=$('remote-video');var lv=$('local-video');
+  var pr=$('pip-remote');var pl=$('pip-local');
+  if(rv&&rv.srcObject&&pr){pr.srcObject=rv.srcObject;pr.play().catch(function(){});}
+  if(lv&&lv.srcObject&&pl){pl.srcObject=lv.srcObject;pl.play().catch(function(){});}
+  if(po)po.classList.add('show');
+  $('call-screen').style.display='none';
+}
+function pipEnter(){
+  if(_pipActive)return;
+  var rv=$('remote-video');
+  if(rv&&document.pictureInPictureEnabled&&!document.pictureInPictureElement){
+    rv.requestPictureInPicture().then(function(){
+      _pipActive=true;
+      $('call-screen').style.display='none';
+    }).catch(function(){_pipOverlayFallback();});
+  } else {
+    _pipOverlayFallback();
+  }
+}
+function pipExpand(){
+  if(document.pictureInPictureElement){
+    document.exitPictureInPicture().catch(function(){});
+    return; // leavepictureinpicture listener restores screen
+  }
+  if(!_pipActive)return;_pipActive=false;
+  var po=$('pip-overlay');if(po)po.classList.remove('show');
+  $('call-screen').style.display='';
+}
+function pipClose(){
+  if(document.pictureInPictureElement){
+    document.exitPictureInPicture().catch(function(){});
+  }
+  _pipActive=false;
+  var po=$('pip-overlay');if(po)po.classList.remove('show');
+  $('call-screen').style.display='';
+  hangUp();
+}
+document.getElementById('remote-video').addEventListener('leavepictureinpicture',function(){
+  if(!_pipActive)return;
+  _pipActive=false;
+  $('call-screen').style.display='';
+  // Re-push so back button still works next time
+  if(lobbyState===LS.call)history.pushState({tbView:'call'},'',location.href);
+});
+window.addEventListener('popstate',function(){
+  var tyShowing=$('thankyou-page')&&$('thankyou-page').classList.contains('show');
+  var jlShowing=$('joiner-landing')&&$('joiner-landing').classList.contains('show');
+  if(tyShowing||jlShowing){history.pushState({},'',location.pathname);return;}
+  if(lobbyState===LS.call){
+    // Back during call → PiP mode, re-push so back again works
+    pipEnter();
+    history.pushState({tbView:'call'},'',location.href);
+    return;
+  }
+});
+window.addEventListener('visibilitychange',function(){
+  if(!document.hidden&&isCallActive())reconcileDeepgramState('visibility_restore');
+});
+window.addEventListener('pagehide',function(){stopDeepgram();if(room.id){saveTr();relaySend({type:'hangup',reason:'pagehide'})}});
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide standalone, single-file TalkBridge web clients (two variants) that implement peer-to-peer calls, live STT, translation, chat and a phrasebook for multilingual conversations.
- Support resilient call flows with WebRTC signaling, TURN support, and Deepgram-based speech-to-text for live subtitle and transcript capture.

### Description

- Adds two new HTML single-file clients: `bridge-codex-v2.html` (v2.0) and `bridge-codex-omega.html` (vOmega), each containing UI, CSS and a full JavaScript client implementation.
- Implements WebRTC with a relay (`RELAY_WS`), Cloudflare TURN integration, datachannel keepalive, offer/answer/candidate handling, and recovery/watchdog logic for connection issues.
- Integrates Deepgram STT streaming (start/stop, audio worklet fallback, watchdog), language detection via FastText WASM, and translation via MyMemory with retry and caching. Includes TTS playback using `speechSynthesis` and transcript/chat TTS toggles.
- Ships a Phrasebook v2 feature with local storage CRUD, import/export, back-translate tooling, tags/clarify UI, and phrase usage/tts hooks; plus UI features like PiP overlay, attachments modal, recent rooms, and detailed structured logging via `log()`.

### Testing

- No automated tests were added or executed for these new static HTML clients as part of this change.
- Basic runtime checks were included in the code (runtime asset probes, smoke tests for FastText model) and the client contains extensive runtime logging (`log()`), which can be used to validate behavior during manual or CI browser-based tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a042915884c832d92075454ab46a96b)