### PR TITLE
Optimize lineage scan for root-level HTML wildcards

### DIFF
--- a/repo-live-lineage.html
+++ b/repo-live-lineage.html
@@ -874,16 +874,34 @@
         const concurrency = Math.max(1, Math.min(Number.isFinite(concurrencyRaw) ? concurrencyRaw : 6, 12));
         const patternRegex = wildcardToRegExp(state.pattern);
         const commitSummaries = [];
-        let page = 1;
+        const scopedPaths = await resolveScopedPaths(state.pattern, patternRegex);
 
-        while (!state.cancelScan && page <= maxPages) {
-          setStatus(els.scanStatus, `Loading commit page ${page}…`, 'info', true);
-          const query = new URLSearchParams({ per_page: '100', page: String(page), sha: state.branch });
-          const pageData = await apiFetch(`/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/commits?${query.toString()}`);
-          if (!Array.isArray(pageData) || pageData.length === 0) break;
-          commitSummaries.push(...pageData);
-          if (pageData.length < 100) break;
-          page += 1;
+        if (scopedPaths.length) {
+          setStatus(els.scanStatus, `Found ${scopedPaths.length} matching files. Loading commit history…`, 'info', true);
+          for (let pathIndex = 0; pathIndex < scopedPaths.length && !state.cancelScan; pathIndex += 1) {
+            const path = scopedPaths[pathIndex];
+            let page = 1;
+            while (!state.cancelScan && page <= maxPages) {
+              setStatus(els.scanStatus, `Loading commits for ${path} (${pathIndex + 1}/${scopedPaths.length}) page ${page}…`, 'info', true);
+              const query = new URLSearchParams({ per_page: '100', page: String(page), sha: state.branch, path });
+              const pageData = await apiFetch(`/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/commits?${query.toString()}`);
+              if (!Array.isArray(pageData) || pageData.length === 0) break;
+              commitSummaries.push(...pageData);
+              if (pageData.length < 100) break;
+              page += 1;
+            }
+          }
+        } else {
+          let page = 1;
+          while (!state.cancelScan && page <= maxPages) {
+            setStatus(els.scanStatus, `Loading commit page ${page}…`, 'info', true);
+            const query = new URLSearchParams({ per_page: '100', page: String(page), sha: state.branch });
+            const pageData = await apiFetch(`/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/commits?${query.toString()}`);
+            if (!Array.isArray(pageData) || pageData.length === 0) break;
+            commitSummaries.push(...pageData);
+            if (pageData.length < 100) break;
+            page += 1;
+          }
         }
 
         if (state.cancelScan) {
@@ -892,14 +910,15 @@
           return;
         }
 
+        const uniqueCommitSummaries = Array.from(new Map(commitSummaries.map((summary) => [summary.sha, summary])).values());
         const variants = [];
         let processed = 0;
-        await runPool(commitSummaries, concurrency, async (summary) => {
+        await runPool(uniqueCommitSummaries, concurrency, async (summary) => {
           if (state.cancelScan) return;
           const detail = await apiFetch(`/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/commits/${summary.sha}`);
           processed += 1;
-          if (processed % 5 === 0 || processed === commitSummaries.length) {
-            setStatus(els.scanStatus, `Scanning changed files ${processed}/${commitSummaries.length}…`, 'info', true);
+          if (processed % 5 === 0 || processed === uniqueCommitSummaries.length) {
+            setStatus(els.scanStatus, `Scanning changed files ${processed}/${uniqueCommitSummaries.length}…`, 'info', true);
           }
           const files = Array.isArray(detail.files) ? detail.files : [];
           for (const file of files) {
@@ -950,7 +969,7 @@
         if (state.allVariants.length) {
           await selectVariant(state.allVariants[0].id, { quiet: true });
           if (els.setupDetails) els.setupDetails.open = false;
-          setStatus(els.scanStatus, `Loaded ${state.allVariants.length} variants from ${commitSummaries.length} commits.`, 'success');
+          setStatus(els.scanStatus, `Loaded ${state.allVariants.length} variants from ${uniqueCommitSummaries.length} commits.`, 'success');
         } else {
           resetSelection();
           setStatus(els.scanStatus, `No changed files matched ${state.pattern}.`, 'warn');
@@ -963,6 +982,23 @@
       }
     }
 
+
+    async function resolveScopedPaths(pattern, patternRegex) {
+      const scoped = isRootHtmlWildcard(pattern);
+      if (!scoped) return [];
+      const tree = await apiFetch(`/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/git/trees/${encodeURIComponent(state.branch)}?recursive=1`);
+      const nodes = Array.isArray(tree.tree) ? tree.tree : [];
+      return nodes
+        .filter((node) => node && node.type === 'blob' && typeof node.path === 'string' && !node.path.includes('/'))
+        .map((node) => node.path)
+        .filter((filePath) => matchesPattern(filePath, patternRegex));
+    }
+
+    function isRootHtmlWildcard(pattern) {
+      const value = (pattern || '').trim().toLowerCase();
+      if (!value || value.includes('/')) return false;
+      return value.endsWith('*.html') || value === '*.html';
+    }
     async function runPool(items, limit, worker) {
       let index = 0;
       const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {


### PR DESCRIPTION
### Motivation
- Reduce GitHub API usage and avoid scanning full repository history for patterns that target root HTML files (e.g. `bridge*.html`).
- Prevent duplicate work when a single commit touches multiple matched files by avoiding repeated detail fetches per-commit.
- Preserve existing full-history behavior for non-root or multi-directory wildcard patterns to keep backwards compatibility.

### Description
- Added `resolveScopedPaths(pattern, patternRegex)` to list root-level files via the repository tree and filter by the wildcard when the pattern is a root HTML wildcard.
- Added `isRootHtmlWildcard(pattern)` helper to detect patterns like `*.html` or `bridge*.html` that target files at the repo root.
- Modified `buildWildcardTimeline()` to use scoped per-file commit queries (`commits?path=`) when `resolveScopedPaths()` returns matches, and fall back to the full-commit pagination otherwise.
- Deduplicated collected commit summaries into `uniqueCommitSummaries` by SHA before fetching commit details, and updated progress/status messages to use the deduplicated count.

### Testing
- Located and verified modified symbols with `rg --files | rg 'repo-live-lineage\.html|lineage'` and `rg -n "uniqueCommitSummaries|resolveScopedPaths|isRootHtmlWildcard|Loading commits for" repo-live-lineage.html`, which succeeded.
- Inspected the updated code region with `nl -ba repo-live-lineage.html | sed -n '860,1020p'` to confirm the new scoped-path flow and helper functions were inserted, which matched expected output.
- Applied the patch via local scripting (the Python replacement used in the rollout) and validated the file was patched as intended, with no automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0477fec0d8832d8406cd34161787a0)