### PR TITLE
Improve mobile portrait responsiveness for repo-live-lineage-v3.html

### DIFF
--- a/repo-live-lineage-v3.html
+++ b/repo-live-lineage-v3.html
@@ -397,16 +397,32 @@
     .drawer-toggle-floating { display: none; }
 
     @media (max-width: 980px) {
-      .app { grid-template-columns: 1fr; }
+      html, body { overflow: auto; height: auto; }
+      .app { grid-template-columns: 1fr; height: auto; min-height: 100vh; }
+      .sidebar-toggle-global { top: 8px; left: 8px; }
       .sidebar { position: fixed; top: 0; bottom: 0; left: 0; width: min(92vw, 390px); z-index: 9; box-shadow: var(--shadow); }
       .sidebar.collapsed { transform: translateX(-102%); width: min(92vw, 390px); border-right: 1px solid var(--border); }
       .drawer-toggle-floating { display: none; }
+      .main { min-height: 100vh; }
+      .topbar { padding: 10px 12px; }
       .preview-layout, .preview-layout.actions-closed { grid-template-columns: 1fr; }
       .preview-area { border-right: 0; border-bottom: 1px solid var(--border); min-height: 52vh; }
       .side-column { max-height: 42vh; }
       .preview-layout.actions-closed .actions-details > summary { writing-mode: horizontal-tb; height: auto; border-left: 0; border-bottom: 1px solid var(--border); }
       .compare-grid { grid-template-columns: 1fr; overflow: auto; }
       .compare-cell { min-height: 58vh; border-right: 0; border-bottom: 1px solid var(--border); }
+    }
+
+    @media (max-width: 600px) {
+      .field.inline { grid-template-columns: 1fr; }
+      .brand-row[style], .topbar .brand-row { padding-left: 0 !important; }
+      .topbar { flex-direction: column; align-items: stretch; }
+      .topbar h2 { white-space: normal; }
+      .toolbar { justify-content: flex-start; }
+      .tabs { padding: 8px 10px 0; }
+      .workspace { padding: 0 10px 10px; }
+      .panel { border-radius: 0 12px 12px 12px; }
+      .btn, .icon-btn, input, select, textarea { font-size: 16px; }
     }
   </style>
 </head>


### PR DESCRIPTION
### Motivation
- Make the Live Lineage UI usable on narrow portrait devices by allowing natural page scrolling and preventing the app layout from being height-locked.
- Reduce cramped spacing on small screens by adjusting the floating sidebar toggle and topbar padding.
- Improve legibility and touch usability on small phones by stacking controls and increasing control font sizing.

### Description
- Updated the `@media (max-width: 980px)` rules to allow `html, body` to scroll, set `.app` to `height: auto; min-height: 100vh`, and nudge the `.sidebar-toggle-global` position and `.topbar` padding.
- Ensured `.main` can expand on small screens by adding `min-height: 100vh` under the 980px breakpoint.
- Added a new `@media (max-width: 600px)` breakpoint that stacks `.field.inline`, removes forced left padding from the title row, stacks `.topbar` content, adjusts `.tabs`/`.workspace` padding, rounds panels for small screens, and increases control font sizes for touch readability.
- Changes were made only in `repo-live-lineage-v3.html` within the embedded `<style>` block.

### Testing
- Ran an automated diff/apply check to confirm the HTML file was modified and the CSS blocks were replaced as intended, and the patch applied successfully.
- No automated UI test suite is configured for this standalone HTML file, so visual/manual verification on mobile breakpoints is recommended as next steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0514233134832da664630fa940dbd6)