### PR TITLE
Rewrite prompt for evidence-first baseline lineage planning

### DIFF
--- a/update_test_html_patch_prompt.txt
+++ b/update_test_html_patch_prompt.txt
@@ -1,57 +1,47 @@
-You are patching `test.html` in this repository.
+You are working in a fresh session on this repository.
 
 ## Target
-- `test.html`
+- `repo-scan-lineage.json`
+- `repo-scan.json`
+- Analysis scope: lineage tracks/versions and capability coverage across bridge variants referenced by the two scan files.
 
 ## Actions
-1. Compare current `test.html` behavior against this intended spec baseline and implement only the obvious/high-signal fixes (do not attempt speculative redesign):
+1. Suspend all prior assumptions about:
+   - whether WASM is required,
+   - whether 2-asset WASM vs 4-asset WASM is preferred,
+   - what the correct development entry point/baseline is.
+2. Use only empirical code-level evidence derived from `repo-scan-lineage.json` and `repo-scan.json` to identify capability presence/absence by track and version.
+3. Apply the prior convention of **track** and **version introduced** when reporting findings.
+4. Classify capabilities into:
+   - **Core capability** (weight 99%),
+   - **Non-core capability**,
+   - **Required add-ons**.
+5. Treat only the following as non-core:
+   - Thai overlay,
+   - Phrasebook integration,
+   - PIP changes,
+   - Auto-mute.
+6. Treat all other listed functionality as required baseline/core unless explicitly proven otherwise by evidence, including required add-ons:
+   - soft delete of room,
+   - joiner room closing when joiner hangs up,
+   - joiner goodbye page when initiator hangs up,
+   - bilingual download/copy of log/transcript on goodbye page,
+   - rejoin button on goodbye page,
+   - bilingual behavior for all user-facing flows.
+7. Explicitly verify and report whether evidence shows:
+   - non-Latin normalization is working,
+   - Latin↔Latin conversion gap is the remaining issue,
+   - or the evidence does not support that conclusion.
+8. Produce a **numbered outline plan** (editable before execution) that includes:
+   - evidence summary by track/version,
+   - baseline candidate ranking with rationale weighted by core capability,
+   - gaps/remediation sequence,
+   - validation checkpoints and pass/fail criteria,
+   - risks/unknowns requiring further code inspection.
+9. Do not implement code changes. Do not assume a baseline without evidence.
 
-### A) Backtranslate (phrasebook card module)
-- Keep module inline under each phrase card (no route/screen change).
-- Ensure the `Backtranslate` button translates **target -> source**.
-- On tap, immediately show loading state (`Checking…` or equivalent), then replace with returned text.
-- If no target text, block the run and show guardrail feedback.
-- If translation fails/empty, show explicit failure text and keep retry path.
-- Keep TTS control in the module and ensure it plays the backtranslated text using source language voice.
-- Keep verdict chips `Sounds good` and `Flag` mutually exclusive and persisted at card level.
-- Preserve persisted status text (`Persisted: Sounds good` / `Persisted: Flagged` / `Persisted: Pending verdict`).
-- On re-run, reset prior verdict to pending.
-
-### B) Clarify (phrasebook card module)
-- Keep clarify inline under card.
-- Replace prompt-based `Add clarify` flow with in-UI inputs in the module (request + answer) and a save action.
-- Enforce non-empty validation for both fields with inline feedback.
-- Append saved entries chronologically to `clarifyChain` (do not overwrite prior entries).
-- Render clarify history with request, answer, timestamp; include more than the last 3 entries (show full chain or an obvious expandable count).
-- Preserve persistence per card across reload.
-
-### C) Tagging
-- Keep normalized/deduped tags behavior.
-- Ensure tag picker supports both contexts: new-card and existing card edit.
-- Ensure create/select/remove behavior is consistent and persisted.
-- Make phrasebook search include tags consistently where search is offered.
-
-### D) Phrasebook-level integration
-- Keep card collapsed/expanded structure and existing quick actions unless needed for above fixes.
-- Keep `Use` behavior intact.
-- Keep catalog delete behavior: removing catalog detaches `catalogIds` from cards (cards remain in All).
-- Keep persistence in local storage.
-
-2. Resolve obvious mismatches from the current implementation:
-- Clarify currently relies on browser `prompt()` calls; migrate to inline UI.
-- Clarify history currently truncates with `slice(-3)`; remove that hard cap.
-- Search inconsistency: home search path should include tags the same way catalog search does.
-
-3. Styling/UI direction:
-- Reuse existing design tokens/classes as much as possible.
-- Minimal visual additions; no large theme/layout rewrite.
-- If any unresolved spec gap remains, annotate in code comments with `<placeholder: ...>`.
-
-4. Validation:
-- Run lightweight checks (at minimum: open file sanity and no obvious JS syntax regressions).
-- Keep patch minimal and scoped only to `test.html`.
-
-## Patch requirements
-- Produce a unified diff/patch implementing the actions above.
-- Strictly limit scope to `test.html`.
-- Keep changes minimal and surgical.
+## Output requirements
+- Output only the numbered outline plan.
+- Use concise, objective statements.
+- Every major claim must cite evidence from the two target JSON files.
+- Keep scope strictly limited to analysis and planning.


### PR DESCRIPTION
### Motivation
- Require an evidence-first analysis for selecting a development baseline by suspending prior assumptions (WASM format, entry point) and prioritizing core capability coverage when planning work across repository lineage data.

### Description
- Updated `update_test_html_patch_prompt.txt` to replace the previous `test.html` patching prompt with an instruction set that targets `repo-scan-lineage.json` and `repo-scan.json`, mandates using only empirical code-level evidence, enforces the `track`/`version introduced` convention, classifies capabilities (core 99% / non-core / required add-ons), enumerates required verification steps (including non-Latin normalization checks), and constrains the output to a numbered, editable outline plan limited to analysis (no code changes or assumptions).

### Testing
- This change is a prompt/text update only; a commit was created successfully for `update_test_html_patch_prompt.txt` and no automated code tests were applicable or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065dda26cc832d88a1ba489a6fe8f2)