### PR TITLE
Fix Kanban JSON board discovery and repolist column/search persistence

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -392,9 +392,9 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
     </div>
 
     <div class="field">
-      <label for="bRepoUrl">GitHub repo contents URL (to list *.js boards)</label>
+      <label for="bRepoUrl">GitHub repo contents URL (to list *.json boards)</label>
       <div class="row">
-        <input id="bRepoUrl" placeholder="https://api.github.com/repos/acmeproducts/stuff/contents" style="font-family:ui-monospace,monospace;font-size:12px;flex:1"/>
+        <input id="bRepoUrl" placeholder="https://api.github.com/repos/" style="font-family:ui-monospace,monospace;font-size:12px;flex:1"/>
         <button type="button" class="btn" id="bListBoards">List</button>
       </div>
     </div>
@@ -1459,7 +1459,7 @@ settingsDialog.addEventListener("close", ()=>{
 const boardsDialog = $("#boardsDialog");
 $("#boardKeyPill").addEventListener("click", ()=>{
   $("#bKeyInput").value = currentBoardKey;
-  $("#bRepoUrl").value = localStorage.getItem(BOARD_REPO_LS)||"https://api.github.com/repos/acmeproducts/stuff/contents";
+  $("#bRepoUrl").value = localStorage.getItem(BOARD_REPO_LS)||"https://api.github.com/repos/";
   $("#bBoardList").classList.add("hidden");
   boardsDialog.showModal();
 });
@@ -1495,14 +1495,14 @@ $("#bListBoards").addEventListener("click", async ()=>{
     const res = await fetch(url, { headers:{ Accept:"application/vnd.github.v3+json" } });
     if(!res.ok) throw new Error("HTTP "+res.status);
     const files = await res.json();
-    const jsFiles = files.filter(f=> f.type==="file" && f.name?.endsWith(".js"));
+    const jsFiles = files.filter(f=> f.type==="file" && f.name?.endsWith(".json"));
     const listEl = $("#bBoardList");
     listEl.innerHTML = "";
     if(!jsFiles.length){
-      listEl.innerHTML = "<span class='muted'>No .js files found.</span>";
+      listEl.innerHTML = "<span class='muted'>No .json files found.</span>";
     } else {
       jsFiles.forEach(f=>{
-        const key = f.name.replace(/\.js$/,"");
+        const key = f.name.replace(/\.json$/,"");
         const row = document.createElement("div");
         row.style.cssText = "display:flex;align-items:center;gap:8px;padding:7px 10px;border:1px solid var(--border);border-radius:10px;background:#fff";
         if(key===currentBoardKey) row.style.borderColor="var(--accent)";
@@ -1535,9 +1535,9 @@ $("#btnExport").onclick=()=>{
   const data=JSON.stringify(state,null,2);
   const blob=new Blob([data],{type:"application/json"});
   const url=URL.createObjectURL(blob);
-  const a=document.createElement("a"); a.href=url; a.download=`${currentBoardKey}.js`; a.click();
+  const a=document.createElement("a"); a.href=url; a.download=`${currentBoardKey}.json`; a.click();
   URL.revokeObjectURL(url);
-  setStatus(`Exported as ${currentBoardKey}.js`);
+  setStatus(`Exported as ${currentBoardKey}.json`);
 };
 
 function toast(title, desc="", isErr=false){ const t=document.getElementById("toast"); t.className=isErr? "err":""; t.querySelector(".tmsg").textContent=title; t.querySelector(".tdesc").textContent=desc; t.style.display="block"; clearTimeout(t._timer); t._timer=setTimeout(()=>{ t.style.display="none"; }, 2800); }
@@ -1976,7 +1976,7 @@ function sanitizeMarkdownImages(s){
   const dlg = document.getElementById("boardsDialog");
   document.getElementById("boardKeyPill").addEventListener("click", ()=>{
     document.getElementById("bKeyInput").value = currentBoardKey;
-    document.getElementById("bRepoUrl").value = localStorage.getItem(BOARD_REPO_LS)||"https://api.github.com/repos/acmeproducts/stuff/contents";
+    document.getElementById("bRepoUrl").value = localStorage.getItem(BOARD_REPO_LS)||"https://api.github.com/repos/";
     document.getElementById("bBoardList").classList.add("hidden");
     dlg.showModal();
   });
@@ -2014,13 +2014,13 @@ function sanitizeMarkdownImages(s){
       const res = await fetch(url, { headers:{ Accept:"application/vnd.github.v3+json" } });
       if(!res.ok) throw new Error("HTTP "+res.status);
       const files = await res.json();
-      const jsFiles = files.filter(f=> f.type==="file" && f.name?.endsWith(".js"));
+      const jsFiles = files.filter(f=> f.type==="file" && f.name?.endsWith(".json"));
       listEl.innerHTML = "";
       if(!jsFiles.length){
-        listEl.innerHTML = "<span class='muted'>No .js files found.</span>";
+        listEl.innerHTML = "<span class='muted'>No .json files found.</span>";
       } else {
         jsFiles.forEach(f=>{
-          const key = f.name.replace(/\.js$/,"");
+          const key = f.name.replace(/\.json$/,"");
           const row = document.createElement("div");
           row.className = "board-list-row" + (key===currentBoardKey?" current":"");
           const nm = document.createElement("span"); nm.className="brow-name"; nm.textContent=f.name;

--- a/repolist.html
+++ b/repolist.html
@@ -280,7 +280,7 @@
     <div class="controls">
       <input id="repoInput" placeholder="owner/repo or github.com/owner/repo">
       <input id="tokenInput" type="password" placeholder="GitHub PAT (optional, persisted)">
-      <input id="omniSearch" placeholder="Omni-search: name, date, time, commit, size, message">
+      <div style="display:flex;gap:8px;align-items:center"><input id="omniSearch" placeholder="Omni-search: name, date, time, commit, size, message" style="flex:1"><button id="clearSearchBtn" class="ghost" type="button" title="Clear search">✕</button></div>
       <button id="scanBtn" type="button">Scan</button>
     </div>
     <div class="status-row">
@@ -339,6 +339,7 @@
     const LAST_SCAN_KEY = 'repolist:lastScan';
     const LAST_SEARCH_KEY = 'repolist:lastSearch';
     const state = { files: [], sortKey: 'changed', sortDir: 'desc', repo: null, recycleOpen: false, editPath: null, loading: false, search: '' };
+    const getColumnOrder = () => [...document.querySelectorAll('#headRow th')].map((th) => th.dataset.col);
 
     function parseRepoLike(value) {
       if (!value) return null;
@@ -602,23 +603,23 @@
         tbody.innerHTML = files.map((f) => {
           const canLaunch = /\.html?$/i.test(f.path);
           return `<tr>
-            <td class="mono name-cell" title="${esc(f.path)}">
+            <td class="mono name-cell" data-col="name" title="${esc(f.path)}">
               ${canLaunch ? `<a class="file-primary" href="${esc(f.pagesUrl)}" target="_blank" rel="noopener" title="${esc(f.path)}">${esc(shortFileName(f.path))}</a>` : `<span class="file-primary" title="${esc(f.path)}">${esc(shortFileName(f.path))}</span>`}
             </td>
-            <td class="open-cell">
+            <td class="open-cell" data-col="open">
               <a class="file-external" href="${esc(f.ghListingUrl)}" target="_blank" rel="noopener" aria-label="Open GitHub blob for ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z"></path><path fill="currentColor" d="M5 5h6v2H7v10h10v-4h2v6H5z"></path></svg></a>
             </td>
-            <td class="delete-cell">
+            <td class="delete-cell" data-col="delete">
               <button class="action-btn delete" type="button" data-delete="${esc(f.path)}" aria-label="Delete ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M9 3h6l1 2h4v2H4V5h4l1-2zm1 6h2v9h-2V9zm4 0h2v9h-2V9zM7 9h2v9H7V9z"></path></svg></button>
             </td>
-            <td class="edit-cell">
+            <td class="edit-cell" data-col="edit">
               <button class="action-btn" type="button" data-edit="${esc(f.path)}" aria-label="Edit ${esc(f.path)}"><svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M3 17.25V21h3.75L17.8 9.94l-3.75-3.75L3 17.25zm18-11.5a1 1 0 0 0 0-1.41l-1.34-1.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75L21 5.75z"></path></svg></button>
             </td>
-            <td class="desc-cell" title="${esc(f.commitMessage || '')}">
+            <td class="desc-cell" data-col="desc" title="${esc(f.commitMessage || '')}">
               <span class="commit-msg">${esc(commitWrappedPreview(f.commitMessage || ''))}</span>
             </td>
-            <td class="size-cell" title="${esc(String(f.size))}">${esc(fmtSize(f.size))}</td>
-            <td class="changed-cell" title="${esc(f.changed || '')}">${esc(fmtAgo(f.changed))}</td>
+            <td class="size-cell" data-col="size" title="${esc(String(f.size))}">${esc(fmtSize(f.size))}</td>
+            <td class="changed-cell" data-col="changed" title="${esc(f.changed || '')}">${esc(fmtAgo(f.changed))}</td>
           </tr>`;
         }).join('');
         document.querySelectorAll('[data-delete]').forEach((btn) => btn.addEventListener('click', () => softDelete(btn.getAttribute('data-delete'))));
@@ -630,6 +631,28 @@
         const active = el.dataset.sortKey === state.sortKey;
         el.dataset.active = active ? 'true' : 'false';
         el.dataset.dir = active ? (state.sortDir === 'asc' ? '▲' : '▼') : '';
+      });
+      syncColumnLayout();
+    }
+    function syncColumnLayout() {
+      const row = document.getElementById('headRow');
+      if (!row) return;
+      const order = [...row.querySelectorAll('th')].map((th) => th.dataset.col);
+      const widthMap = {};
+      row.querySelectorAll('th').forEach((th) => { if (th.style.width) widthMap[th.dataset.col] = th.style.width; });
+      document.querySelectorAll('#rows tr').forEach((tr) => {
+        const map = {};
+        tr.querySelectorAll('td[data-col]').forEach((td) => { map[td.dataset.col] = td; });
+        order.forEach((col) => { if (map[col]) tr.appendChild(map[col]); });
+      });
+      row.querySelectorAll('th').forEach((th) => { if (widthMap[th.dataset.col]) th.style.width = widthMap[th.dataset.col]; });
+      const idx = Object.fromEntries(order.map((col, i) => [col, i + 1]));
+      document.querySelectorAll('#rows tr').forEach((tr) => {
+        tr.querySelectorAll('td[data-col]').forEach((td) => {
+          const col = td.dataset.col;
+          if (widthMap[col]) td.style.width = widthMap[col];
+          td.style.display = idx[col] ? 'table-cell' : td.style.display;
+        });
       });
     }
 
@@ -845,6 +868,13 @@
       state.search = e.target.value || '';
       localStorage.setItem(LAST_SEARCH_KEY, state.search);
       document.getElementById('lastSearchText').textContent = `▸ Last search: ${state.search || '—'}`;
+      render();
+    });
+    document.getElementById('clearSearchBtn').addEventListener('click', () => {
+      state.search = '';
+      document.getElementById('omniSearch').value = '';
+      localStorage.setItem(LAST_SEARCH_KEY, '');
+      document.getElementById('lastSearchText').textContent = '▸ Last search: —';
       render();
     });
     document.getElementById('scanBtn').addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Make the Kanban board manager discover board files as JSON (not JS) and avoid pre-populating the repo URL with `acmeproducts/stuff` so users can list arbitrary repositories without that seed value.
- Allow multiple boards to be persisted and exported with `.json` filenames to match the on-disk format.
- Improve `repolist.html` UX by letting users clear the omni-search and by fixing table column drag/resize so visual column order and widths persist correctly across renders.

### Description
- Updated `kanban.html` board listing to look for `*.json` files from the GitHub contents API and changed the boards modal repo placeholder to `https://api.github.com/repos/` instead of the `acmeproducts/stuff` default, and adjusted the export filename/status to use `.json`.
- In `repolist.html` added a clear button (`#clearSearchBtn`) wired to clear `LAST_SEARCH_KEY` and reset the search UI, and preserved the last-search text behavior.
- Added `data-col` attributes to `td` cells in `repolist.html` and implemented `syncColumnLayout()` to reorder body cells to match header order and to apply persisted header widths to corresponding body cells after `render()`.
- Added a small helper (`getColumnOrder`) and wired `syncColumnLayout()` to run after rendering so drag/drop and resize UX persist and reflect saved state.

### Testing
- Verified code changes by searching for updated strings with `rg` to confirm `*.json` usage and element additions, and those checks succeeded.
- Applied the patch and inspected the diff to ensure only `kanban.html` and `repolist.html` were changed, and the patch applied successfully.
- Performed a repository commit of the changes to confirm no file conflicts, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097bc1d544832dbdecb12732a332f9)