### PR TITLE
Reuse non-empty saved PAT on startup to avoid repeated prompts

### DIFF
--- a/gg.html
+++ b/gg.html
@@ -813,13 +813,10 @@
   // --- Bootstrap ---
   async function init(){
     const storedToken = localStorage.getItem(GITHUB_PAT_KEY);
-    if (storedToken && await validateToken(storedToken)) {
+    if (storedToken && storedToken.trim()) {
       GITHUB_TOKEN = storedToken.trim();
     } else {
-      if (storedToken) {
-        localStorage.removeItem(GITHUB_PAT_KEY);
-      }
-      let message = storedToken ? 'Saved token is no longer valid. Enter a new token.' : '';
+      let message = '';
       while (!GITHUB_TOKEN) {
         const input = await requestTokenInApp(message);
         if (await validateToken(input)) {


### PR DESCRIPTION
### Motivation
- Avoid repeatedly prompting the user for a GitHub Personal Access Token on page load by reusing a non-empty saved token from `localStorage` keyed by `GITHUB_PAT_KEY` instead of immediately revalidating or removing it.

### Description
- Update the bootstrap `init` flow in `gg.html` to set `GITHUB_TOKEN` when `localStorage.getItem(GITHUB_PAT_KEY)` returns a non-empty value and only run `validateToken` for newly entered tokens via the in-app prompt, leaving the rest of the token-handling logic unchanged.

### Testing
- Verified the patch by inspecting the repository diff and the updated lines around the `init` function in `gg.html`, and confirmed the automated pattern-replacement script executed successfully; no unit tests were added or run for this client-side change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098a311688832db2b090c07efea4b2)