### PR TITLE
Support loading board-specific repo JSON via ?board= query parameter

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -420,9 +420,11 @@ const BUILD = "2025-10-28";
 /* ===== NEW: Board Key System ===== */
 const BOARD_KEY_LS   = "kanban_board_key";
 const BOARD_REPO_LS  = "kanban_repo_url";
+const urlBoardParamRaw = new URLSearchParams(location.search).get("board");
+const hasBoardQueryParam = !!(urlBoardParamRaw && urlBoardParamRaw.trim());
 
 function _cleanKey(raw){ return (raw||"").trim().replace(/[^A-Za-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"")||"kanban"; }
-function getBoardKey(){ return _cleanKey(new URLSearchParams(location.search).get("board") || localStorage.getItem(BOARD_KEY_LS) || "kanban"); }
+function getBoardKey(){ return _cleanKey(urlBoardParamRaw || localStorage.getItem(BOARD_KEY_LS) || "kanban"); }
 function setBoardKey(raw){
   const k=_cleanKey(raw);
   localStorage.setItem(BOARD_KEY_LS, k);
@@ -1779,7 +1781,8 @@ function resetGithubToken(){
   localStorage.removeItem(GITHUB_PAT_KEY);
 }
 function getGitHubSyncConfig(){
-  return DEFAULT_GITHUB_SYNC_CONFIG;
+  if(!hasBoardQueryParam) return DEFAULT_GITHUB_SYNC_CONFIG;
+  return { ...DEFAULT_GITHUB_SYNC_CONFIG, path:`${currentBoardKey}.json` };
 }
 async function githubFetch(url, options={}){
   const token=await ensureGithubToken();


### PR DESCRIPTION
## Summary
- Detect when `kanban.html` is opened with a `?board=` query parameter.
- Keep existing behavior unchanged when no query parameter is present.
- When a query parameter is present, use `<board>.json` as the GitHub sync path so startup loads a fresh board copy from the repository for that board key.

## Details
- Added `urlBoardParamRaw` and `hasBoardQueryParam` near board-key setup.
- Updated `getBoardKey()` to reuse the parsed query param value.
- Updated `getGitHubSyncConfig()` to conditionally return:
  - default `kanban.json` path when no `?board=` is provided, or
  - `${currentBoardKey}.json` when `?board=` is provided.

## Behavior impact
- `kanban.html` (no URL qualifier): same as before.
- `kanban.html?board=myboard`: starts with board key `myboard` and pulls/pushes `myboard.json` from/to the repo, giving a fresh board copy sourced from repository content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098dc29924832da1ab6802af7dad9b)