### PR TITLE
Rework Board Manager modal (List/New), toolbar cleanup, import/download/soft-delete actions

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -180,6 +180,8 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
 .modal{position:relative;padding:16px;background:var(--panel);border:1px solid var(--border);border-radius:14px}
 .modal .modal-close{position:absolute;top:10px;right:12px;border:none;background:transparent;font-weight:800;font-size:18px;cursor:pointer;color:#777;line-height:1;padding:2px 6px;border-radius:8px}
 .modal .modal-close:hover{color:#000;background:#f2f2f6}
+.modal .modal-close::before{content:"";display:block;width:18px;height:18px;background:currentColor;-webkit-mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.59 13.4 4.29 19.7 2.88 18.3l6.3-6.29-6.3-6.29L4.3 4.29l6.29 6.3 6.3-6.3z'/%3E%3C/svg%3E") center/contain no-repeat;mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.59 13.4 4.29 19.7 2.88 18.3l6.3-6.29-6.3-6.29L4.3 4.29l6.29 6.3 6.3-6.3z'/%3E%3C/svg%3E") center/contain no-repeat;}
+
 .field{display:flex;flex-direction:column;gap:6px;margin:10px 0}
 .field input,.field textarea,.field select{border:1px solid var(--border);border-radius:10px;padding:10px;font-size:14px;width:100%}
 .field textarea#fNotes{min-height:144px;max-height:40vh;resize:vertical;line-height:1.45}
@@ -237,15 +239,6 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
     <button id="btnNew" class="btn icon-btn" title="New card" aria-label="New card">+</button>
     <button id="btnSettings" class="btn icon-btn" title="Settings" aria-label="Settings">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.18 7.18 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.49-.42h-3.84a.5.5 0 0 0-.49.42L9.2 5.32c-.58.23-1.12.54-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.66 8.84a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32c.13.22.39.31.6.22l2.39-.96c.5.4 1.05.72 1.63.94l.36 2.54c.04.24.24.42.49.42h3.84c.25 0 .45-.18.49-.42l.36-2.54c.58-.23 1.12-.54 1.63-.94l2.39.96c.22.09.47 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>
-    </button>
-    <button id="btnExport" class="btn icon-btn" title="Export JSON" aria-label="Export JSON">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 20h14v-2H5v2Zm7-16v9.17l3.09-3.08 1.41 1.41L12 17l-4.5-5.5 1.41-1.41L11 13.17V4h1Z"/></svg>
-    </button>
-    <button id="btnImport" class="btn icon-btn" title="Import JSON" aria-label="Import JSON">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 13h10.17l-3.58 3.59L12 18l6-6-6-6-1.41 1.41L14.17 11H4v2Z"/></svg>
-    </button>
-    <button id="btnShare" class="btn icon-btn" title="Share" aria-label="Share">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16a3 3 0 0 0-2.39 1.2l-6.71-3.35a3.1 3.1 0 0 0 0-1.7l6.7-3.35A3 3 0 1 0 15 7a3.1 3.1 0 0 0 .1.75l-6.7 3.35a3 3 0 1 0 0 1.8l6.7 3.35A3 3 0 1 0 18 16Z"/></svg>
     </button>
         <!-- board key pill -->
     <div class="board-key-pill" id="boardKeyPill" title="Switch board / list boards">board: <span class="bkp-name" id="boardKeyLabel">kanban</span> ▾</div>
@@ -381,27 +374,37 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
 </dialog>
 
 <!-- NEW: Boards dialog -->
-<dialog id="boardsDialog" style="width:min(620px,96vw)">
+<dialog id="boardsDialog" style="width:min(700px,96vw)">
   <form method="dialog" class="modal">
-    <button type="button" class="modal-close" id="boardsClose">×</button>
+    <button type="button" class="modal-close" id="boardsClose" aria-label="Close"></button>
     <h3>Board Manager</h3>
-    <p style="font-size:12px;color:var(--muted);margin:4px 0 12px">Boards are managed from <code style="background:#f0f4ff;padding:1px 5px;border-radius:4px">kanban-boards.json</code>.</p>
-    <div class="field">
-      <label for="bKeyInput">Board name</label>
-      <div class="row">
-        <input id="bKeyInput" placeholder="kanban" style="font-family:ui-monospace,monospace;flex:1"/>
-        <input id="new-board-datetime" type="datetime-local" />
-        <button type="button" class="btn primary" id="bCreateBoard">New</button>
-      </div>
+    <div class="row" style="margin:4px 0 12px;gap:6px">
+      <button type="button" class="btn small" id="tabList">List</button>
+      <button type="button" class="btn small" id="tabNew">New</button>
     </div>
-    <div class="field">
-      <label>Active boards</label>
+    <section id="tabListPane">
       <div id="bBoardList" style="margin-top:4px;display:flex;flex-direction:column;gap:6px;max-height:34vh;overflow:auto"></div>
-    </div>
-    <details id="bArchivedWrap" style="margin-top:10px">
-      <summary style="cursor:pointer;font-weight:600;">Archived boards</summary>
-      <div id="bArchivedList" style="margin-top:8px;display:flex;flex-direction:column;gap:6px;max-height:26vh;overflow:auto"></div>
-    </details>
+      <details id="bArchivedWrap" style="margin-top:10px">
+        <summary style="cursor:pointer;font-weight:600;">Soft deleted boards</summary>
+        <div id="bArchivedList" style="margin-top:8px;display:flex;flex-direction:column;gap:6px;max-height:26vh;overflow:auto"></div>
+      </details>
+    </section>
+    <section id="tabNewPane" class="hidden">
+      <div class="field">
+        <label for="bKeyInput">Board name</label>
+        <div class="row">
+          <input id="bKeyInput" placeholder="kanban" style="font-family:ui-monospace,monospace;flex:1"/>
+          <button type="button" class="btn primary" id="bCreateBoard">Create</button>
+        </div>
+      </div>
+      <div class="field">
+        <label for="bImportFile">Import board JSON</label>
+        <div class="row">
+          <input id="bImportFile" type="file" accept="application/json"/>
+          <button type="button" class="btn" id="bImportBoard">Import</button>
+        </div>
+      </div>
+    </section>
   </form>
 </dialog>
 
@@ -1501,16 +1504,6 @@ const DRIVE_JSON_URLS = DRIVE_FILE_ID
     ]
   : [];
 
-// Export filename = currentBoardKey.json
-$("#btnExport").onclick=()=>{
-  const data=JSON.stringify(state,null,2);
-  const blob=new Blob([data],{type:"application/json"});
-  const url=URL.createObjectURL(blob);
-  const a=document.createElement("a"); a.href=url; a.download=`${currentBoardKey}.json`; a.click();
-  URL.revokeObjectURL(url);
-  setStatus(`Exported as ${currentBoardKey}.json`);
-};
-
 function toast(title, desc="", isErr=false){ const t=document.getElementById("toast"); t.className=isErr? "err":""; t.querySelector(".tmsg").textContent=title; t.querySelector(".tdesc").textContent=desc; t.style.display="block"; clearTimeout(t._timer); t._timer=setTimeout(()=>{ t.style.display="none"; }, 2800); }
 function applyImportedBoard(obj, sourceLabel="import", options={}){
   if(!(Array.isArray(obj?.cards)&&Array.isArray(obj?.platforms)&&Array.isArray(obj?.stages))){
@@ -1622,9 +1615,8 @@ async function forceRefreshFromDrive(){
   }
   applyImportedBoard(remote, "Google Drive refresh");
 }
-$("#btnImport").onclick=()=> $("#fileImport").click();
 $("#fileImport").onchange=(e)=>{ const f=e.target.files?.[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ const board=parseBoardPayload(r.result); if(board){ const raw=prompt("Name for imported board:",""); if(raw===null){ e.target.value=""; return; } const name=raw.trim(); if(!name){ alert("Board name cannot be blank."); e.target.value=""; return; } if((repoBoardsIndex.boards||[]).some(b=>_cleanKey(b.name)===_cleanKey(name))){ alert("Board name must be unique."); e.target.value=""; return; } const rec=upsertBoardRecord(name,{ archived:false }); window.__switchToBoard?.(rec.name); applyImportedBoard(board, "JSON file"); }else{ toast("Import failed","Could not parse board file", true); alert("Failed to parse board file. Expected .json board data."); } }; r.readAsText(f); e.target.value=""; };
-$("#btnShare").onclick=()=>{ window.open(DRIVE_SHARE_URL, "_blank", "noopener"); };
+
 /* ===== Archive UI ===== */
 const archiveDialog=$("#archiveDialog");
 $("#btnOpenArchive").onclick=()=>{ renderArchiveList(); archiveDialog.showModal(); };
@@ -1958,11 +1950,10 @@ function sanitizeMarkdownImages(s){
   const activeList=document.getElementById("bBoardList");
   const archivedList=document.getElementById("bArchivedList");
   const nameInput=document.getElementById("bKeyInput");
-  const dtInput=document.getElementById("new-board-datetime");
-  dtInput.value=localDateTimeInputValue();
-  const pencilSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.8 9.94l-3.75-3.75L3 17.25Zm18-11.5a1 1 0 0 0 0-1.41l-1.34-1.34a1 1 0 0 0-1.41 0l-1.57 1.57 3.75 3.75L21 5.75Z"/></svg>';
-  const xSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.59 13.4 4.29 19.7 2.88 18.3l6.3-6.29-6.3-6.29L4.3 4.29l6.29 6.3 6.3-6.3z"/></svg>';
-  const chevronSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m10 17 5-5-5-5v10Z"/></svg>';
+    const pencilSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.8 9.94l-3.75-3.75L3 17.25Zm18-11.5a1 1 0 0 0 0-1.41l-1.34-1.34a1 1 0 0 0-1.41 0l-1.57 1.57 3.75 3.75L21 5.75Z"/></svg>';
+  const downloadSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 20h14v-2H5v2Zm7-16v9.17l3.09-3.08 1.41 1.41L12 17l-4.5-5.5 1.41-1.41L11 13.17V4h1Z"/></svg>';
+  const trashSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 3h6l1 2h5v2H3V5h5l1-2Zm1 6h2v9h-2V9Zm4 0h2v9h-2V9ZM7 9h2v9H7V9Z"/></svg>';
+    const chevronSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m10 17 5-5-5-5v10Z"/></svg>';
   function switchToBoard(name){
     const key = setBoardKey(name);
     currentBoardKey = key;
@@ -1988,15 +1979,14 @@ function sanitizeMarkdownImages(s){
   }
   function setBoardInputDefaults(raw=""){
     nameInput.value = raw || "new-board";
-    dtInput.value = localDateTimeInputValue();
-  }
+      }
   function renderBoardManager(){
     const boards=(repoBoardsIndex.boards||[]).map(normalizeBoardRecord).filter(Boolean);
-    const active=boards.filter(b=>!b.archived).sort((a,b)=>a.name.localeCompare(b.name));
-    const archived=boards.filter(b=>b.archived).sort((a,b)=>a.name.localeCompare(b.name));
+    const active=boards.filter(b=>!b.archived).sort((a,b)=>b.lastUpdated-a.lastUpdated);
+    const archived=boards.filter(b=>b.archived).sort((a,b)=>b.lastUpdated-a.lastUpdated);
     activeList.innerHTML="";
     archivedList.innerHTML="";
-    if(!active.length) activeList.innerHTML="<span class='muted'>No active boards yet.</span>";
+    if(!active.length) activeList.innerHTML="<div class='empty-boarding'>Click on the New tab to create a new board.</div>";
     active.forEach(b=>{
       const row=document.createElement("div");
       row.className="board-list-row"+(_cleanKey(b.name)===currentBoardKey?" current":"");
@@ -2021,9 +2011,11 @@ function sanitizeMarkdownImages(s){
           saveRepoBoardsIndex(); renderBoardManager();
         };
       };
-      const archive=document.createElement("button"); archive.type="button"; archive.className="btn icon-btn small"; archive.style.color="#6b7280"; archive.title="Archive board"; archive.innerHTML=xSvg;
+      const download=document.createElement("button"); download.type="button"; download.className="btn icon-btn small"; download.style.color="#6b7280"; download.title="Download board"; download.innerHTML=downloadSvg;
+      download.onclick=()=>{ const payload=localStorage.getItem(`ai_jobs_kanban__${_cleanKey(b.name)}`)||"{}"; const blob=new Blob([payload],{type:"application/json"}); const a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download=`${_cleanKey(b.name)}-${Date.now()}.json`; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href),1200); };
+      const archive=document.createElement("button"); archive.type="button"; archive.className="btn icon-btn small"; archive.style.color="#6b7280"; archive.title="Soft delete board"; archive.innerHTML=trashSvg;
       archive.onclick=()=>{ upsertBoardRecord(b.name,{ archived:true }); renderBoardManager(); };
-      row.append(open,edit,archive); activeList.appendChild(row);
+      row.append(open,edit,download,archive); activeList.appendChild(row);
     });
     if(!archived.length) archivedList.innerHTML="<span class='muted'>No archived boards.</span>";
     archived.forEach(b=>{
@@ -2038,9 +2030,23 @@ function sanitizeMarkdownImages(s){
       row.append(controls); archivedList.appendChild(row);
     });
   }
-  document.getElementById("boardKeyPill").addEventListener("click", ()=>{
+  const tabListBtn=document.getElementById("tabList");
+  const tabNewBtn=document.getElementById("tabNew");
+  const tabListPane=document.getElementById("tabListPane");
+  const tabNewPane=document.getElementById("tabNewPane");
+  function setBoardTab(tab){
+    const listMode=tab!=="new";
+    tabListPane.classList.toggle("hidden",!listMode);
+    tabNewPane.classList.toggle("hidden",listMode);
+    tabListBtn.classList.toggle("primary",listMode);
+    tabNewBtn.classList.toggle("primary",!listMode);
+  }
+  tabListBtn.addEventListener("click",()=>setBoardTab("list"));
+  tabNewBtn.addEventListener("click",()=>setBoardTab("new"));
+document.getElementById("boardKeyPill").addEventListener("click", ()=>{
     setBoardInputDefaults(currentBoardKey);
     renderBoardManager();
+    setBoardTab("list");
     dlg.showModal();
   });
   document.getElementById("boardsClose").addEventListener("click", ()=> dlg.close());
@@ -2052,6 +2058,28 @@ function sanitizeMarkdownImages(s){
     const next=upsertBoardRecord(raw,{ archived:false });
     switchToBoard(next.name);
     dlg.close();
+  });
+  
+  document.getElementById("bImportBoard").addEventListener("click", ()=>{
+    const fi=document.getElementById("bImportFile");
+    const [file]=fi.files||[];
+    if(!file){ alert("Choose a JSON file to import."); return; }
+    const reader=new FileReader();
+    reader.onload=()=>{
+      try{
+        const parsed=JSON.parse(String(reader.result||"{}"));
+        if(!isValidBoardData(parsed)) throw new Error("Invalid board JSON");
+        const raw=nameInput.value.trim();
+        if(!raw){ alert("Enter a board name."); return; }
+        if(!isBoardNameUnique(raw)){ alert("Board name must be unique."); return; }
+        const next=upsertBoardRecord(raw,{ archived:false });
+        setBoardKey(next.name); currentBoardKey=next.name;
+        localStorage.setItem(boardLS(), JSON.stringify(parsed));
+        switchToBoard(next.name);
+        dlg.close();
+      }catch(err){ alert("Import failed: "+err.message); }
+    };
+    reader.readAsText(file);
   });
   window.__switchToBoard=switchToBoard;
   window.__openBoardManager=(name="new-board")=>{ setBoardInputDefaults(name); renderBoardManager(); dlg.showModal(); };


### PR DESCRIPTION
### Motivation
- Consolidate board management UX so the repo-driven index (`kanban-boards.json`) is used to present and manage multiple boards from a single modal. 
- Redo the Board Manager to provide clear `List` and `New` flows and remove confusing toolbar actions. 
- Provide explicit inline edit, download, and soft-delete controls plus a clean gray SVG close icon to match the requested interaction model.

### Description
- Removed the top-ribbon `Export`, `Import`, and `Share` toolbar buttons and kept only the existing `+`, `gear` and board chip (`boardKeyPill`) controls by deleting handlers for `#btnExport`, `#btnImport`, and `#btnShare` and their UI buttons. 
- Reworked the Board Manager dialog HTML to a tabbed layout with `List` and `New` tabs using `#tabList`, `#tabNew`, `#tabListPane`, and `#tabNewPane` and added a `setBoardTab` controller to switch panes. 
- Replaced the textual close `×` with a cleaner gray SVG-styled close via CSS on `.modal .modal-close::before` for a consistent gray "X" look and added `aria-label="Close"` to the button. 
- Updated `renderBoardManager` to show active boards sorted by `lastUpdated` descending, to display the empty-list guidance `Click on the New tab to create a new board.`, and to render action buttons per row: edit (pencil), download (JSON), and soft-delete (trash) instead of an inline row-level `X`. 
- Implemented a `New` tab import/create flow that validates JSON via `isValidBoardData`, enforces unique board names (`isBoardNameUnique`), calls `upsertBoardRecord`, stores imported board payload to the keyed slot `boardLS()`, and switches to the imported board; wired the file input handler to `#bImportBoard`. 
- Kept soft-delete (archive) behavior under a chevron details in the modal with `Restore` and permanent `Delete` actions that remove metadata and the keyed local storage payload. 

### Testing
- Performed repository inspections using `rg`/`sed` to verify injected DOM and handlers were present and updated successfully. 
- Verified working-tree and commit operations by running `git status --short` and creating a commit which succeeded (`git commit` completed and a new commit recorded). 
- Confirmed the last commit with `git log -1 --oneline` to validate the change was committed; no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaf7f77d4832daa1a5b998da24e9c)