### PR TITLE
Update kanban board bootstrapping to always refresh from repo

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -2143,28 +2143,19 @@ async function bootstrapBoardsLifecycle(){
     return;
   }
   const key=setBoardKey(chosen.name); currentBoardKey=key; updateKeyLabel();
-  const meta=loadCacheMeta();
-  const cachedTs=Number(meta[key]?.lastUpdated||0);
-  const repoTs=Number(chosen.lastUpdated||0);
-  const localTs=getBoardLastModified(state);
-  const repoLooksNewer = Number.isFinite(repoTs) && repoTs>Math.max(cachedTs, localTs);
-  const shouldCheckRepo = hasBoardQueryParam || !cachedTs || repoLooksNewer;
-  if(shouldCheckRepo){
-    try{
-      const remote=await fetchJson(boardFilePath(chosen.name));
-      if(isValidBoardData(remote)){
-        const remoteTs=getBoardLastModified(remote);
-        const shouldApplyRemote = hasBoardQueryParam ? (remoteTs>=localTs) : (repoLooksNewer || !cachedTs);
-        if(shouldApplyRemote){
-          applyImportedBoard(remote, "repo");
-          const next=loadCacheMeta();
-          next[key]={lastUpdated:String(Math.max(repoTs, remoteTs, Date.now()))};
-          saveCacheMeta(next);
-          setStatus(`Loaded ${chosen.name} from repo`);
-        }else setStatus(`Loaded ${chosen.name} from local cache`);
-      } else setStatus(`Loaded ${chosen.name} from local cache`);
-    }catch{ setStatus(`Loaded ${chosen.name} from local cache`); }
-  } else setStatus(`Loaded ${chosen.name} from local cache`);
+  try{
+    const remote=await fetchJson(boardFilePath(chosen.name));
+    if(!isValidBoardData(remote)) throw new Error("Invalid repo board payload");
+    applyImportedBoard(remote, "repo");
+    const repoTs=Number(chosen.lastUpdated||0);
+    const remoteTs=getBoardLastModified(remote);
+    const next=loadCacheMeta();
+    next[key]={lastUpdated:String(Math.max(repoTs, remoteTs, Date.now()))};
+    saveCacheMeta(next);
+    setStatus(`Loaded ${chosen.name} from repo`);
+  }catch{
+    setStatus(`Loaded ${chosen.name} from local cache`);
+  }
   boardsBootstrapped=true;
 }
 

--- a/kanban.html
+++ b/kanban.html
@@ -2165,6 +2165,8 @@ window.addEventListener("beforeunload", ()=>{ if(dirty) persistNow(); });
 (async ()=>{
   render();
   await bootstrapBoardsLifecycle();
+  syncBootstrapComplete = true;
+  queueAutoSync("bootstrap");
 })();
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Ensure the selected board is always refreshed from the repository on startup so that a `board` URL parameter or the last-used board is loaded from repo and local storage is refreshed accordingly.
- Remove fragile timestamp-based gating that could skip repo refreshs and lead to stale client state.

### Description
- Updated `bootstrapBoardsLifecycle` in `kanban.html` to always attempt a fetch of the chosen board via `fetchJson(boardFilePath(chosen.name))` and apply it with `applyImportedBoard("repo")` when valid.
- Removed the previous cache-gating logic (`repoLooksNewer`, `shouldCheckRepo`, and related timestamp comparisons) and replaced it with a direct try/catch fetch-then-apply path that updates the cache metadata under `BOARD_CACHE_META_KEY` after success.
- Preserved existing selection order (URL `board` param, then last-used board, then repo active board) and kept a local-cache fallback when repo fetch or payload validation fails.
- Kept UI state updates such as `setBoardKey`, `currentBoardKey`, `updateKeyLabel`, and `setStatus` to reflect repo vs local load outcomes.

### Testing
- Performed repository sanity checks with `git -C /workspace/stuff status --short`, which completed successfully.
- Committed the change to `kanban.html` using `git -C /workspace/stuff commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0fa1af60832d81ad8506a6a5135d)