### PR TITLE
Add Program Matrix view, program settings, and standalone Program Organizer

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -180,6 +180,14 @@ main#board[data-layout="vertical"] .card{margin-inline:6px}
 .board-inline-edit{display:flex;align-items:center;gap:8px;flex:1}
 .empty-boarding{padding:20px;border:1px dashed var(--border);border-radius:12px;background:#fff;color:var(--muted)}
 
+.program-toolbar{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:10px}
+.program-grid{display:grid;gap:8px;grid-auto-rows:minmax(110px,auto)}
+.program-col-header,.program-row-header{font-size:12px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;padding:8px 10px;border:1px solid var(--border);border-radius:10px;background:#f8fafc}
+.program-cell{min-height:110px;border:1px solid var(--border);border-radius:10px;padding:8px;background:#fff;display:flex;flex-direction:column;gap:6px}
+.program-board-tile{width:100%;text-align:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.toolbar .btn.small.active{background:var(--accent);color:#fff;border-color:var(--accent)}
+
+
 /* Dialogs */
 .hidden{display:none}
 dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
@@ -248,6 +256,8 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
     </button>
         <!-- board key pill -->
     <div class="board-key-pill" id="boardKeyPill" title="Switch board / list boards">board: <span class="bkp-name" id="boardKeyLabel">kanban</span> ▾</div>
+    <button id="btnProjectView" class="btn small">Project</button>
+    <button id="btnProgramView" class="btn small">Program</button>
     <input id="fileImport" type="file" accept="application/json" class="hidden" aria-hidden="true" tabindex="-1" />
   </div>
   <div class="searchbar">
@@ -258,6 +268,13 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
 </header>
 
 <div id="resultsContainer"></div>
+<section id="programView" class="hidden" style="padding:16px">
+  <div class="program-toolbar">
+    <h3 style="margin:0">Program Matrix</h3>
+    <button id="btnProgramSettings" class="btn icon-btn" title="Program settings">⚙</button>
+  </div>
+  <div id="programMatrix"></div>
+</section>
 <main id="board" aria-live="polite" data-layout="auto"></main>
 <div class="footer" id="status"></div>
 <div id="toast"><div class="tmsg"></div><div class="tdesc"></div></div>
@@ -414,6 +431,16 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
   </form>
 </dialog>
 
+<dialog id="programSettingsDialog" style="width:min(560px,96vw)">
+  <form method="dialog" class="modal">
+    <button type="button" class="modal-close" id="programSettingsClose" aria-label="Close"></button>
+    <h3>Program Matrix Settings</h3>
+    <div class="field"><label>Stage axis (rows, bottom→top)</label><input id="programStagesInput" placeholder="Dev, Test, Prod"></div>
+    <div class="field"><label>Phase axis (columns, left→right)</label><input id="programPhasesInput" placeholder="Concept, Initial, Pilot, Beta, Graduate"></div>
+    <div class="row"><button class="btn primary" value="save">Save</button><button class="btn" value="cancel">Cancel</button></div>
+  </form>
+</dialog>
+
 <div id="tooltip" role="tooltip" aria-hidden="true">
   <div class="t-title"></div>
   <div class="t-meta"></div>
@@ -435,6 +462,27 @@ let repoSwitchCfg = {};
 let repoBoardsIndex = { version:1, activeBoard:"", boards:[] };
 let boardsBootstrapped = false;
 
+const PROGRAM_CFG_KEY = "kanban_program_cfg_v1";
+const DEFAULT_PROGRAM_CFG = {
+  stages:[{id:"dev",label:"Dev"},{id:"test",label:"Test"},{id:"prod",label:"Prod"}],
+  phases:[{id:"concept",label:"Concept"},{id:"initial",label:"Initial"},{id:"pilot",label:"Pilot"},{id:"beta",label:"Beta"},{id:"graduate",label:"Graduate"}]
+};
+let programCfg = loadProgramCfg();
+
+function loadProgramCfg(){
+  const parsed=safeParseJson(localStorage.getItem(PROGRAM_CFG_KEY)||"", null);
+  if(parsed?.stages && parsed?.phases) return parsed;
+  return JSON.parse(JSON.stringify(DEFAULT_PROGRAM_CFG));
+}
+function saveProgramCfg(){ localStorage.setItem(PROGRAM_CFG_KEY, JSON.stringify(programCfg)); }
+function ensureProgramMeta(rec){
+  rec.program=rec.program||{};
+  rec.program.enabled = rec.program.enabled!==false;
+  rec.program.stageId = rec.program.stageId || programCfg.stages[0]?.id;
+  rec.program.phaseId = rec.program.phaseId || programCfg.phases[0]?.id;
+  return rec;
+}
+
 
 function _cleanKey(raw){ return (raw||"").trim().replace(/[^A-Za-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"")||"kanban"; }
 function getBoardKey(){ return _cleanKey(urlBoardParamRaw || localStorage.getItem(BOARD_KEY_LS) || "kanban"); }
@@ -454,13 +502,23 @@ function boardSlug(name){ return _cleanKey(String(name||"kanban").toLowerCase())
 function boardFilePath(name){ const prefix=typeof repoSwitchCfg.pathPrefix==="string" ? repoSwitchCfg.pathPrefix : ""; return `${prefix}${boardSlug(name)}.json`; }
 async function fetchJson(path){ const r=await fetch(path,{cache:"no-store"}); if(!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
 async function loadRepoSwitch(){ try{ const v=await fetchJson(REPO_SWITCH_FILE); repoSwitchCfg=(v&&typeof v==="object")?v:{}; }catch{ repoSwitchCfg={}; } }
-async function loadRepoBoardsIndex(){ try{ const v=await fetchJson(REPO_BOARDS_FILE); repoBoardsIndex=(v&&typeof v==="object")?v:{version:1,activeBoard:"",boards:[]}; }catch{ repoBoardsIndex={version:1,activeBoard:"",boards:[]}; } repoBoardsIndex.boards=Array.isArray(repoBoardsIndex.boards)?repoBoardsIndex.boards:[]; }
+async function loadRepoBoardsIndex(){
+  try{
+    const v=await fetchJson(REPO_BOARDS_FILE);
+    if(!(v && typeof v==="object")) throw new Error("Invalid boards index payload");
+    repoBoardsIndex=v;
+  }catch(err){
+    repoBoardsIndex={version:1,activeBoard:"",boards:[]};
+    throw new Error(`Failed to load ${REPO_BOARDS_FILE}: ${err?.message||err}`);
+  }
+  repoBoardsIndex.boards=(Array.isArray(repoBoardsIndex.boards)?repoBoardsIndex.boards:[]).map(normalizeBoardRecord).filter(Boolean);
+}
 function loadCacheMeta(){ return safeParseJson(localStorage.getItem(BOARD_CACHE_META_KEY)||"{}",{}); }
 function saveCacheMeta(meta){ localStorage.setItem(BOARD_CACHE_META_KEY, JSON.stringify(meta||{})); }
 function normalizeBoardRecord(record){
   const name=_cleanKey(record?.name||"");
   if(!name) return null;
-  return { name, archived:!!record?.archived, lastUpdated:Number(record?.lastUpdated||Date.now()) };
+  return ensureProgramMeta({ name, archived:!!record?.archived, lastUpdated:Number(record?.lastUpdated||Date.now()), program:record?.program||{} });
 }
 function saveRepoBoardsIndex(){
   repoBoardsIndex.boards=(repoBoardsIndex.boards||[]).map(normalizeBoardRecord).filter(Boolean);
@@ -756,6 +814,39 @@ function render(){
   refillSelects();
   applySearch($("#search").value);
 }
+
+function renderProgramView(){
+  const wrap=$("#programMatrix"); if(!wrap) return;
+  const stages=[...programCfg.stages];
+  const phases=[...programCfg.phases];
+  wrap.innerHTML="";
+  const grid=document.createElement("div");
+  grid.className="program-grid";
+  grid.style.gridTemplateColumns=`180px repeat(${phases.length}, minmax(170px,1fr))`;
+  grid.appendChild(document.createElement("div"));
+  phases.forEach(ph=>{ const h=document.createElement("div"); h.className="program-col-header"; h.textContent=ph.label; grid.appendChild(h); });
+  [...stages].reverse().forEach(st=>{
+    const rowLabel=document.createElement("div"); rowLabel.className="program-row-header"; rowLabel.textContent=st.label; grid.appendChild(rowLabel);
+    phases.forEach(ph=>{
+      const cell=document.createElement("div");
+      cell.className="program-cell";
+      cell.dataset.stageId=st.id; cell.dataset.phaseId=ph.id;
+      const boards=(repoBoardsIndex.boards||[]).map(normalizeBoardRecord).filter(Boolean).filter(b=>!b.archived && b.program?.enabled && b.program?.stageId===st.id && b.program?.phaseId===ph.id).sort((a,b)=>a.name.localeCompare(b.name));
+      boards.forEach(b=>{
+        const tile=document.createElement("button"); tile.className="btn small program-board-tile"; tile.textContent=b.name;
+        tile.draggable=true; tile.dataset.boardName=b.name;
+        tile.addEventListener("dragstart",e=>{ e.dataTransfer.setData("text/program-board", b.name); e.dataTransfer.effectAllowed="move"; });
+        tile.addEventListener("click",()=>switchBoard(b.name));
+        cell.appendChild(tile);
+      });
+      cell.addEventListener("dragover",e=>{ e.preventDefault(); });
+      cell.addEventListener("drop",e=>{ e.preventDefault(); const name=e.dataTransfer.getData("text/program-board"); if(!name) return; const existing=repoBoardsIndex.boards.find(x=>x.name===name)||{}; upsertBoardRecord(name,{ program:{...(existing.program||{}), enabled:true, stageId:st.id, phaseId:ph.id } }); renderProgramView(); });
+      grid.appendChild(cell);
+    });
+  });
+  wrap.appendChild(grid);
+}
+
 document.addEventListener("dragover", e=> e.preventDefault());
 
 let pointerDrag=null;
@@ -1557,6 +1648,12 @@ function readAsDataURL(file){ return new Promise((res,rej)=>{ const r=new FileRe
 /* ===== Settings ===== */
 const settingsDialog=$("#settingsDialog");
 $("#btnNew").onclick=()=> openEditor(null, state.stages[0]);
+$("#btnProjectView").onclick=()=>{ $("#programView").classList.add("hidden"); $("#board").classList.remove("hidden"); $("#resultsContainer").classList.remove("hidden"); $("#btnProjectView").classList.add("active"); $("#btnProgramView").classList.remove("active"); };
+$("#btnProgramView").onclick=()=>{ $("#board").classList.add("hidden"); $("#resultsContainer").classList.add("hidden"); $("#programView").classList.remove("hidden"); $("#btnProgramView").classList.add("active"); $("#btnProjectView").classList.remove("active"); renderProgramView(); };
+$("#btnProgramSettings").onclick=()=>{ $("#programStagesInput").value=programCfg.stages.map(s=>s.label).join(", "); $("#programPhasesInput").value=programCfg.phases.map(s=>s.label).join(", "); $("#programSettingsDialog").showModal(); };
+$("#programSettingsDialog").addEventListener("close",()=>{ if($("#programSettingsDialog").returnValue!=="save") return; const stages=$("#programStagesInput").value.split(",").map(s=>s.trim()).filter(Boolean); const phases=$("#programPhasesInput").value.split(",").map(s=>s.trim()).filter(Boolean); if(stages.length) programCfg.stages=stages.map((label,i)=>({id:_cleanKey(label)||`stage-${i+1}`,label})); if(phases.length) programCfg.phases=phases.map((label,i)=>({id:_cleanKey(label)||`phase-${i+1}`,label})); saveProgramCfg(); renderProgramView(); });
+$("#programSettingsClose").onclick=()=>$("#programSettingsDialog").close("cancel");
+
 $("#btnSettings").onclick=()=>{
   $("#sPlatforms").value=state.platforms.join(", ");
   $("#sStages").value=state.stages.join(", ");
@@ -2074,6 +2171,7 @@ function sanitizeMarkdownImages(s){
     const key = setBoardKey(name);
     currentBoardKey = key;
     updateKeyLabel();
+$("#btnProjectView")?.classList.add("active");
     const fresh = loadState();
     if(fresh){
       state = fresh;
@@ -2123,7 +2221,8 @@ function sanitizeMarkdownImages(s){
           if(!isBoardNameUnique(next,b.name)){ alert("Board name must be unique."); return; }
           const oldKey=_cleanKey(b.name), newKey=_cleanKey(next);
           repoBoardsIndex.boards=repoBoardsIndex.boards.map(x=>_cleanKey(x.name)===oldKey?{...x,name:newKey,lastUpdated:Date.now()}:x);
-          if(_cleanKey(currentBoardKey)===oldKey){ setBoardKey(newKey); currentBoardKey=newKey; updateKeyLabel(); }
+          if(_cleanKey(currentBoardKey)===oldKey){ setBoardKey(newKey); currentBoardKey=newKey; updateKeyLabel();
+$("#btnProjectView")?.classList.add("active"); }
           saveRepoBoardsIndex(); renderBoardManager();
         };
       };
@@ -2204,7 +2303,16 @@ document.getElementById("boardKeyPill").addEventListener("click", ()=>{
 
 async function bootstrapBoardsLifecycle(){
   await loadRepoSwitch();
-  await loadRepoBoardsIndex();
+  try{
+    await loadRepoBoardsIndex();
+  }catch(err){
+    console.error(err);
+    setStatus(err.message||"Failed to load board index");
+    toast("Board index load failed", String(err.message||err), true);
+    window.__openBoardManager?.("new-board");
+    boardsBootstrapped=true;
+    return;
+  }
   const boards=repoBoardsIndex.boards.filter(b=>!b.archived);
   const requested=(urlBoardParamRaw||"").trim().toLowerCase();
   const requestedBoard=boards.find(b=>String(b.name||"").toLowerCase()===requested||boardSlug(b.name)===requested);
@@ -2228,6 +2336,7 @@ async function bootstrapBoardsLifecycle(){
     return;
   }
   const key=setBoardKey(chosen.name); currentBoardKey=key; updateKeyLabel();
+$("#btnProjectView")?.classList.add("active");
   try{
     const remote=await fetchJson(boardFilePath(chosen.name));
     if(!isValidBoardData(remote)) throw new Error("Invalid repo board payload");
@@ -2246,6 +2355,7 @@ async function bootstrapBoardsLifecycle(){
 
 /* ===== Init ===== */
 updateKeyLabel();
+$("#btnProjectView")?.classList.add("active");
 window.addEventListener("beforeunload", ()=>{ if(dirty) persistNow(); });
 (async ()=>{
   render();

--- a/program.html
+++ b/program.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Program Board Organizer</title>
+<style>
+:root{--bg:#f3f6fb;--panel:#fff;--text:#111827;--muted:#6b7280;--border:#d1d9e6;--accent:#2563eb}
+*{box-sizing:border-box} body{margin:0;font-family:system-ui,sans-serif;background:var(--bg);color:var(--text)}
+header{position:sticky;top:0;background:#fff;border-bottom:1px solid var(--border);padding:10px 14px;z-index:10}
+.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.btn{border:1px solid var(--border);background:#fff;border-radius:10px;padding:8px 12px;cursor:pointer;font-weight:600}
+.btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}
+main{padding:14px}
+.panel{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:10px}
+.grid{display:grid;grid-template-columns:160px repeat(5,minmax(180px,1fr));gap:8px}
+.hdr{font-size:12px;text-transform:uppercase;color:var(--muted);font-weight:700;padding:8px;border:1px solid var(--border);border-radius:10px;background:#f8fafc}
+.cell{min-height:110px;border:1px solid var(--border);border-radius:10px;background:#fff;padding:8px;display:flex;flex-direction:column;gap:6px}
+.tile{border:1px solid var(--border);border-radius:10px;padding:8px;background:#fff;cursor:grab}
+.tile .n{font-weight:700}.tile .m{font-size:12px;color:var(--muted)}
+.dot{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border:1px solid var(--border);border-radius:999px;font-size:12px}
+dialog{border:none;border-radius:12px;padding:0;width:min(620px,96vw)}
+.modal{padding:14px;border:1px solid var(--border);border-radius:12px;background:#fff}
+.field{display:flex;flex-direction:column;gap:6px;margin:8px 0}
+input,textarea,select{border:1px solid var(--border);border-radius:8px;padding:8px;font:inherit}
+small{color:var(--muted)}
+</style>
+</head>
+<body>
+<header>
+  <div class="row">
+    <strong>Program Organizer</strong>
+    <button id="btnReload" class="btn">Reload Boards</button>
+    <button id="btnNewBoard" class="btn">New Board</button>
+    <button id="btnExportMeta" class="btn">Export Program Metadata</button>
+    <span id="status" style="color:#6b7280;font-size:12px"></span>
+  </div>
+</header>
+<main>
+  <section class="panel">
+    <div id="matrix" class="grid"></div>
+  </section>
+</main>
+
+<dialog id="boardDialog">
+  <form method="dialog" class="modal" id="boardForm">
+    <h3 id="dlgTitle" style="margin:0 0 8px">Board Metadata</h3>
+    <div class="field"><label>Board Name</label><input id="fName" required /></div>
+    <div class="row">
+      <div class="field" style="flex:1"><label>Stage</label><select id="fStage"></select></div>
+      <div class="field" style="flex:1"><label>Phase</label><select id="fPhase"></select></div>
+    </div>
+    <div class="row">
+      <div class="field" style="flex:1"><label>Status color/emoji</label><input id="fStatus" placeholder="gray or ✅" /></div>
+      <div class="field" style="flex:1"><label>Tags (comma separated)</label><input id="fTags" placeholder="infra, api" /></div>
+    </div>
+    <div class="field"><label>Notes</label><textarea id="fNotes" rows="4"></textarea></div>
+    <small>Program metadata is stored in browser localStorage under <code>kanban_program_meta_v1</code>.</small>
+    <div class="row" style="justify-content:flex-end;margin-top:8px">
+      <button class="btn" value="cancel">Cancel</button>
+      <button class="btn primary" value="save">Save</button>
+    </div>
+  </form>
+</dialog>
+
+<script>
+const PHASES=["concept","initial","pilot","beta","graduate"];
+const STAGES=["dev","test","prod"];
+const INDEX_FILE="kanban-boards.json";
+const META_KEY="kanban_program_meta_v1";
+let boardsIndex={version:1,activeBoard:"",boards:[]};
+let programMeta={};
+let editingBoard=null;
+
+const $=s=>document.querySelector(s);
+function setStatus(t){ $("#status").textContent=t||""; }
+function loadMeta(){ try{return JSON.parse(localStorage.getItem(META_KEY)||"{}");}catch{return{};} }
+function saveMeta(){ localStorage.setItem(META_KEY, JSON.stringify(programMeta)); }
+function getMeta(name){
+  const key=String(name||"").trim();
+  if(!programMeta[key]) programMeta[key]={ stage:"dev", phase:"concept", tags:[], notes:"", status:"gray" };
+  return programMeta[key];
+}
+function normalizedTags(v){ return [...new Set(String(v||"").split(",").map(x=>x.trim()).filter(Boolean))]; }
+async function loadBoards(){
+  const res=await fetch(INDEX_FILE,{cache:"no-store"});
+  if(!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data=await res.json();
+  if(!data || !Array.isArray(data.boards)) throw new Error("Invalid kanban-boards.json payload");
+  boardsIndex=data;
+}
+function boardTiles(stage,phase){
+  return boardsIndex.boards.filter(b=>!b.archived).filter(b=>{const m=getMeta(b.name); return m.stage===stage && m.phase===phase;});
+}
+function render(){
+  const matrix=$("#matrix"); matrix.innerHTML="";
+  matrix.appendChild(document.createElement("div"));
+  PHASES.forEach(p=>{ const h=document.createElement("div"); h.className="hdr"; h.textContent=p; matrix.appendChild(h); });
+  [...STAGES].reverse().forEach(stage=>{
+    const rh=document.createElement("div"); rh.className="hdr"; rh.textContent=stage; matrix.appendChild(rh);
+    PHASES.forEach(phase=>{
+      const cell=document.createElement("div"); cell.className="cell";
+      cell.addEventListener("dragover",e=>e.preventDefault());
+      cell.addEventListener("drop",e=>{ e.preventDefault(); const name=e.dataTransfer.getData("text/board"); if(!name) return; const m=getMeta(name); m.stage=stage; m.phase=phase; saveMeta(); render(); });
+      boardTiles(stage,phase).forEach(b=>{
+        const m=getMeta(b.name);
+        const t=document.createElement("div"); t.className="tile"; t.draggable=true;
+        t.addEventListener("dragstart",e=>e.dataTransfer.setData("text/board", b.name));
+        t.addEventListener("dblclick",()=>openBoardMeta(b.name,false));
+        t.innerHTML=`<div class="n">${b.name}</div><div class="m"><span class="dot">${m.status||"•"}</span> ${m.tags?.join(", ")||"no-tags"}</div>`;
+        const launch=document.createElement("button"); launch.className="btn"; launch.textContent="Open";
+        launch.addEventListener("click",()=>{ const u=new URL("kanban.html", location.href); u.searchParams.set("board", b.name); location.href=u.toString(); });
+        t.appendChild(launch);
+        cell.appendChild(t);
+      });
+      matrix.appendChild(cell);
+    });
+  });
+  setStatus(`Loaded ${boardsIndex.boards.filter(b=>!b.archived).length} boards.`);
+}
+function fillSelect(el, values){ el.innerHTML=values.map(v=>`<option value="${v}">${v}</option>`).join(""); }
+function openBoardMeta(name,isNew){
+  editingBoard={name,isNew};
+  $("#dlgTitle").textContent=isNew?"Create Board":"Edit Board Metadata";
+  fillSelect($("#fStage"), STAGES); fillSelect($("#fPhase"), PHASES);
+  const m=getMeta(name);
+  $("#fName").value=name; $("#fName").readOnly=!isNew;
+  $("#fStage").value=m.stage||"dev"; $("#fPhase").value=m.phase||"concept";
+  $("#fStatus").value=m.status||"gray"; $("#fTags").value=(m.tags||[]).join(", "); $("#fNotes").value=m.notes||"";
+  $("#boardDialog").showModal();
+}
+function saveDialog(){
+  const name=$("#fName").value.trim();
+  if(!name) return;
+  if(editingBoard?.isNew){ boardsIndex.boards.push({name, archived:false, lastUpdated:Date.now()}); }
+  const m=getMeta(name);
+  m.stage=$("#fStage").value; m.phase=$("#fPhase").value; m.status=$("#fStatus").value.trim()||"gray";
+  m.tags=normalizedTags($("#fTags").value); m.notes=$("#fNotes").value.trim();
+  saveMeta(); render();
+}
+$("#boardForm").addEventListener("submit",e=>{ if((document.activeElement?.value||"")!=="save") return; e.preventDefault(); saveDialog(); $("#boardDialog").close(); });
+$("#btnReload").onclick=async()=>{ try{ await loadBoards(); render(); }catch(err){ setStatus(`Load failed: ${err.message}`); } };
+$("#btnNewBoard").onclick=()=>openBoardMeta("", true);
+$("#btnExportMeta").onclick=()=>{ const blob=new Blob([JSON.stringify(programMeta,null,2)],{type:"application/json"}); const a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="kanban-program-meta.json"; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href),1000); };
+(async()=>{ programMeta=loadMeta(); try{ await loadBoards(); render(); }catch(err){ setStatus(`Load failed: ${err.message}`); }})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a program-level matrix to organize boards by `stage` and `phase` so teams can view and reorder boards in a program context.
- Persist configurable program axes and per-board program metadata in localStorage to make board grouping reusable.
- Offer a dedicated standalone page for editing program metadata and exporting metadata across boards.
- Harden repo boards index loading to validate and normalize records early and surface failures to the UI.

### Description
- Added inline Program UI to `kanban.html` including toolbar buttons (`#btnProgramView`, `#btnProjectView`), the `#programView` section, a `#programSettingsDialog`, and related CSS classes (`.program-grid`, `.program-cell`, etc.).
- Implemented program configuration persistence with `PROGRAM_CFG_KEY` and helper functions `loadProgramCfg`, `saveProgramCfg`, and `ensureProgramMeta`, and a `renderProgramView` function that renders a grid and enables drag/drop assignment of boards to program cells.
- Updated board index handling: `loadRepoBoardsIndex` now validates payloads, normalizes records via `normalizeBoardRecord` (which now includes `program` metadata), and throws on invalid input; bootstrap lifecycle handles load failures and prompts the board manager.
- Updated board manager and switch flow to preserve program metadata markers and set the project view active after switching/renaming boards.
- Added a new standalone `program.html` page to manage program metadata (stage/phase/status/tags/notes), load `kanban-boards.json`, persist program metadata under `kanban_program_meta_v1`, and export metadata as JSON.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2e07ef6c832da491225b24b28616)