### PR TITLE
Phrasebook UI redesign: single-select chips, tap-to-use, icons, add-phrase BT/tags, repo write

### DIFF
--- a/bridge-post-ship-cc.html
+++ b/bridge-post-ship-cc.html
@@ -163,8 +163,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .room-name-chip{background:rgba(0,0,0,.72);color:#fff;border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:600;white-space:nowrap;max-width:min(78vw,260px);overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(5px);}
 .lang-flags-chip{background:rgba(0,0,0,.55);color:#fff;border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:2px 10px;font-size:15px;backdrop-filter:blur(4px);}
 /* ── Inline phrase search panel ── */
-#pb-inline-panel{display:none;flex-direction:column;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);max-height:44vh;overflow-y:auto;flex-shrink:0;}
+#pb-inline-panel{display:none;flex-direction:column;background:var(--surface);border-top:2px solid rgba(255,255,255,.22);max-height:44vh;overflow-y:auto;flex-shrink:0;}
 #pb-inline-panel.show{display:flex;}
+.pb-ip-hdr{position:sticky;top:0;background:var(--surface);border-bottom:1px solid rgba(255,255,255,.1);padding:4px 10px;display:flex;align-items:center;gap:6px;z-index:1;flex-shrink:0;}
 .pb-irow{display:flex;align-items:center;gap:0;padding:0;border-bottom:1px solid rgba(255,255,255,.05);cursor:pointer;min-height:40px;}
 .pb-irow:hover,.pb-irow.focused{background:rgba(255,255,255,.07);}
 .pb-irow-tags{padding:0 6px;display:flex;flex-wrap:wrap;gap:2px;flex-shrink:0;min-width:0;max-width:72px;}
@@ -180,6 +181,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .pb-irow-tts svg{width:11px;height:11px;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;pointer-events:none;}
 #pb-inline-empty{padding:10px 14px;font-size:12px;color:var(--text-muted);font-style:italic;}
 .chat-compose-strip{display:flex;align-items:flex-end;gap:8px;padding:8px 12px max(8px,env(safe-area-inset-bottom));background:var(--surface);border-top:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+.chat-search-x{background:none;border:none;cursor:pointer;color:#9a9592;padding:4px;line-height:0;flex-shrink:0;}
+.chat-search-x:hover{color:var(--text);}
 .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:"DM Sans",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}
 .chat-compose-ta::-webkit-scrollbar{display:none;}
 .chat-compose-ta::placeholder{color:var(--text-muted);}
@@ -304,6 +307,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .pb-nc-ta{width:100%;border:1.5px solid #e0dbd6;border-radius:10px;padding:9px 12px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;resize:none;outline:none;min-height:60px;color:#1a1714;}
 .pb-nc-ta:focus{border-color:#2e8b8b;}
 .pb-nc-trans{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:8px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;margin:8px 0;}
+.pb-nc-inp{border:1.5px solid #e0dbd6;border-radius:8px;padding:7px 10px;font-size:13px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;color:#1a1714;}
+.pb-nc-inp:focus{border-color:#2e8b8b;}
 .pb-nc-save{background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:15px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;}
 .phrase-mini{border:1px solid rgba(255,255,255,.12);border-radius:10px;padding:8px;margin:8px 0;background:rgba(255,255,255,.03);}
 .phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
@@ -380,9 +385,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 #att-modal-body{flex:1;overflow:auto;padding:14px;}
 #att-modal-body img{max-width:100%;border-radius:8px;}
 #att-modal-body iframe{width:100%;height:60dvh;border:none;border-radius:8px;background:#fff;}
-/* tr-use icon style */
-.tr-use-ico{border:none;background:rgba(255,255,255,.08);color:#c4ccd4;border-radius:5px;padding:3px 6px;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:600;}
-.tr-use-ico:hover{background:rgba(63,193,193,.25);color:var(--teal-bright);}.tr-fail-badge{display:inline-block;font-size:10px;color:#e67e22;background:rgba(230,126,34,.12);border:1px solid rgba(230,126,34,.3);border-radius:4px;padding:1px 5px;margin-top:3px;}.thai-overlay{font-family:"Noto Sans Thai","Sarabun","Kanit",sans-serif;letter-spacing:0.01em;}
+.tr-col-tap{cursor:pointer;}.tr-col-tap:hover{background:rgba(255,255,255,.05);}
+.tr-col-row{display:flex;align-items:center;gap:6px;}
+.tr-col-row .tr-text{flex:1;font-size:15px;font-family:"DM Sans",sans-serif;line-height:1.4;}
+.pb-nc-verdict-btn{background:rgba(255,255,255,.08);color:#c4ccd4;border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:5px 14px;font-size:13px;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-verdict-btn.act{background:#2e8b8b;color:#fff;border-color:#2e8b8b;}
+.pb-nc-act{background:rgba(255,255,255,.1);color:#c4ccd4;border:none;border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-act:hover{background:rgba(255,255,255,.18);}
+.pb-vbadge{font-weight:400!important;}
+.tr-fail-badge{display:inline-block;font-size:10px;color:#e67e22;background:rgba(230,126,34,.12);border:1px solid rgba(230,126,34,.3);border-radius:4px;padding:1px 5px;margin-top:3px;}.thai-overlay{font-family:"Noto Sans Thai","Sarabun","Kanit",sans-serif;letter-spacing:0.01em;}
 /* Chat attach SVG */
 .chat-attach-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;}
 .chat-attach-btn:hover{color:var(--text);}
@@ -413,6 +424,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
           <div class="lobby-label" style="margin-bottom:6px;margin-top:10px;">Cloudflare TURN API token</div>
           <input class="lobby-input" id="cf-turn-tok" type="password" placeholder="Paste API token — stored locally" oninput="onCfTurnInput()">
           <div id="cf-turn-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+          <div><div class="lobby-label" style="margin-bottom:6px;">GitHub PAT <span style="font-size:10px;opacity:.6;">(repo write — optional)</span></div>
+          <input class="lobby-input" id="gh-pat-inp" type="password" placeholder="ghp_… — stored locally" oninput="saveGhPat()">
+          </div>
         </div>
         <div class="recent-rooms" id="recent-rooms" style="display:none;margin-top:14px;">
           <div class="recent-title">Recent rooms</div>
@@ -549,6 +563,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
   <div id="pb-inline-panel"></div>
   <div class="chat-compose-strip" id="chat-compose-strip">
     <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-attach-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><textarea class="chat-compose-ta" id="chat-input" placeholder="type here to chat" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)" ></textarea>
+    <button class="chat-search-x" id="chat-search-x" style="display:none;" onclick="pbSearchExit()" title="Exit search"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
     <button class="chat-send-btn" id="chat-send-btn" onclick="sendChat()" disabled title="Send">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
     </button>
@@ -583,9 +598,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <button class="pb-ov-back" onclick="pbCloseOverlay()" title="Back"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg></button>
     <div class="pb-ov-title">Phrasebook</div>
     <button class="pb-ov-act" onclick="pbOpenNewCardForContext()" title="New phrase"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
-    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
-    <button class="pb-ov-act" onclick="pbOpenGitSheet()" title="Fetch from GitHub"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 14 12 18 16 14"/><line x1="12" y1="12" x2="12" y2="18"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
-    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></button>
+    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import from file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="12 19 12 5"/><polyline points="5 12 12 5 19 12"/></svg></button>
+    <button class="pb-ov-act" onclick="pbOpenGitSheet()" title="Download from library"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/><polyline points="8 14 12 18 16 14"/><line x1="12" y1="9" x2="12" y2="18"/></svg></button>
+    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="5 12 19 12"/><polyline points="12 5 19 12 12 19"/></svg></button>
     <button class="pb-ov-act" onclick="pbCloseOverlay()" title="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
   </div>
   <div class="pb-ov-searchbar">
@@ -626,7 +641,26 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <button class="pb-nc-trans" onclick="pbNcAutoTranslate()">Translate →</button>
     <span class="pb-nc-label">Translation</span>
     <textarea id="pbnc-tgt" class="pb-nc-ta" rows="2" placeholder="Translation…"></textarea>
-    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:12px;">Save to phrasebook</button>
+    <div style="margin-top:10px;">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
+        <span class="pb-nc-label" style="margin-bottom:0;">Back-translate</span>
+        <button class="pb-nc-act" onclick="pbNcRunBt()">↺ Run</button>
+      </div>
+      <div id="pbnc-bt-result" style="font-size:13px;color:#9a9592;min-height:18px;margin-bottom:4px;"></div>
+      <div id="pbnc-bt-verdict" style="display:none;gap:8px;">
+        <button class="pb-nc-verdict-btn" id="pbnc-vgood" onclick="pbNcSetVerdict('good')">✓ Good</button>
+        <button class="pb-nc-verdict-btn" id="pbnc-vflag" onclick="pbNcSetVerdict('flag')">⚑ Flag</button>
+      </div>
+    </div>
+    <div style="margin-top:10px;">
+      <span class="pb-nc-label">Tags</span>
+      <input id="pbnc-tags" class="pb-nc-inp" type="text" placeholder="comma-separated tags" style="width:100%;box-sizing:border-box;">
+    </div>
+    <div style="margin-top:10px;">
+      <span class="pb-nc-label">Clarify note</span>
+      <input id="pbnc-clarify" class="pb-nc-inp" type="text" placeholder="optional clarification" style="width:100%;box-sizing:border-box;">
+    </div>
+    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:14px;">Save to phrasebook</button>
   </div>
 </div>
 
@@ -1015,15 +1049,22 @@ function chatInputEvt(){
   ta.style.height='auto';
   ta.style.height=Math.min(ta.scrollHeight,80)+'px';
   $('chat-send-btn').disabled=!raw.trim()||raw.trim()==='/';
+  var inSearch=raw.length>=1&&raw[0]==='/'&&raw!=='//';
+  var xBtn=$('chat-search-x');if(xBtn)xBtn.style.display=inSearch?'':'none';
   if(raw==='//'){pbIClose();pbOpenCmdDrawer();return;}
-  if(raw.length>=1&&raw[0]==='/'){pbISearch(raw.slice(1));return;}
+  if(inSearch){pbISearch(raw.slice(1));return;}
   pbIClose();
   if(_pbDrawerMode==='search')pbRunSearch();
+}
+function pbSearchExit(){
+  var ta=$('chat-input');if(ta){ta.value='';ta.style.height='';ta.dispatchEvent(new Event('input'));ta.focus();}
+  pbIClose();
+  var xBtn=$('chat-search-x');if(xBtn)xBtn.style.display='none';
 }
 function chatKeydown(e){
   var panel=$('pb-inline-panel');
   if(panel&&panel.classList.contains('show')){
-    if(e.key==='Escape'){e.preventDefault();pbIClose();var ta=$('chat-input');if(ta){ta.value='';ta.style.height='';$('chat-send-btn').disabled=true;}return;}
+    if(e.key==='Escape'){e.preventDefault();pbSearchExit();return;}
   }
   if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}
 }
@@ -1051,10 +1092,11 @@ function pbISearch(q){
   }
   _pbICards=cards.slice(0,30);
   var total=pbGetCards().length;
+  var hdr='<div class="pb-ip-hdr"><span style="font-size:11px;color:var(--text-muted);font-weight:600;letter-spacing:.04em;text-transform:uppercase;">Phrasebook</span><span style="font-size:11px;color:var(--text-muted);margin-left:6px;">'+(_pbICards.length?_pbICards.length+(total>_pbICards.length?' of '+total:''):'')+' </span></div>';
   if(!_pbICards.length){
-    panel.innerHTML='<div id="pb-inline-empty">'+(total?'No matching phrases':'No phrasebook loaded — use // to import')+'</div>';
+    panel.innerHTML=hdr+'<div id="pb-inline-empty">'+(total?'No matching phrases':'No phrasebook loaded — use // to import')+'</div>';
   } else {
-    panel.innerHTML=_pbICards.map(function(c,i){return pbIRowHtml(c,i);}).join('');
+    panel.innerHTML=hdr+_pbICards.map(function(c,i){return pbIRowHtml(c,i);}).join('');
   }
   panel.classList.add('show');
 }
@@ -1248,8 +1290,8 @@ var PB_ICON_TTS='<svg width="13" height="13" viewBox="0 0 24 24" fill="none" str
 var ICO={
   plus:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
   book:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>',
-  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
-  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg>',
+  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="12 19 12 5"/><polyline points="5 12 12 5 19 12"/></svg>',
+  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="5 12 19 12"/><polyline points="12 5 19 12 12 19"/></svg>',
   warn:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
   link:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
   trash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>',
@@ -1300,6 +1342,14 @@ function pbGetCards(){return pbGetAllCards().filter(function(c){return !c.delete
 function pbSaveCards(a){try{localStorage.setItem(PB_CARDS,JSON.stringify(a));}catch(_){toast('Storage full');}}
 function pbGetCats(){try{return JSON.parse(localStorage.getItem(PB_CATS)||'[]');}catch(_){return[];}}
 function pbSaveCats(a){try{localStorage.setItem(PB_CATS,JSON.stringify(a));}catch(_){}}
+function pbCatLangPair(cat){
+  if(cat.sourceLang&&cat.targetLang)return{src:cat.sourceLang,tgt:cat.targetLang};
+  var c=pbGetCards().find(function(x){return(x.catalogIds||[]).indexOf(cat.id)>=0;});
+  return c?{src:c.sourceLang,tgt:c.targetLang}:{src:'?',tgt:'?'};
+}
+function pbGetCatForLangPair(src,tgt){
+  return pbGetCats().find(function(c){var p=pbCatLangPair(c);return p.src===src&&p.tgt===tgt;});
+}
 function pbGetTags(){try{return JSON.parse(localStorage.getItem(PB_TAGS_K)||'[]');}catch(_){return[];}}
 function pbSaveTags(a){try{localStorage.setItem(PB_TAGS_K,JSON.stringify(a));}catch(_){}}
 function pbCardKey(c){return (c.sourceLang||'')+'|'+(c.source||'').trim().toLowerCase()+'|'+(c.targetLang||'')+'|'+(c.target||'').trim().toLowerCase();}
@@ -1382,17 +1432,40 @@ function pbAutoSeed(){
 
 /* ── Import/export ── */
 function pbApplyImport(data,opts){
-  var cards=(data.cards||[]).map(pbNorm);
-  var existing=pbGetCards();var byKey={};
-  existing.forEach(function(c){byKey[pbCardKey(c)]=c;});
-  cards.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  var newCards=(data.cards||[]).map(pbNorm);
+  // Build lang-pair dedup map for catalogs
+  var idRemap={};
+  var existingCats=pbGetCats();
+  (data.catalogs||[]).forEach(function(cat){
+    if(!cat||!cat.id)return;
+    // Infer lang pair from first incoming card in this catalog
+    var sample=newCards.find(function(c){return(c.catalogIds||[]).indexOf(cat.id)>=0;});
+    if(sample){cat.sourceLang=sample.sourceLang;cat.targetLang=sample.targetLang;}
+    var ex=cat.sourceLang&&cat.targetLang?pbGetCatForLangPair(cat.sourceLang,cat.targetLang):null;
+    if(ex&&ex.id!==cat.id){idRemap[cat.id]=ex.id;}
+  });
+  // Apply catalog id remap to incoming cards
+  if(Object.keys(idRemap).length){
+    newCards.forEach(function(c){
+      c.catalogIds=(c.catalogIds||[]).map(function(id){return idRemap[id]||id;});
+    });
+  }
+  // Merge by card key
+  var byKey={};
+  pbGetCards().forEach(function(c){byKey[pbCardKey(c)]=c;});
+  newCards.forEach(function(c){byKey[pbCardKey(c)]=c;});
   pbSaveCards(Object.values(byKey));
+  // Merge catalogs (skip remapped = already exist)
   var cats=pbGetCats();var catIds=cats.map(function(c){return c.id;});
-  (data.catalogs||[]).forEach(function(cat){if(cat&&cat.id&&catIds.indexOf(cat.id)<0)cats.push(cat);});
+  (data.catalogs||[]).forEach(function(cat){
+    if(!cat||!cat.id)return;
+    if(idRemap[cat.id])return; // remapped to existing
+    if(catIds.indexOf(cat.id)<0)cats.push(cat);
+  });
   pbSaveCats(cats);
   var tags=pbGetTags();(data.tags||[]).forEach(function(t){if(tags.indexOf(t)<0)tags.push(t);});
   pbSaveTags(tags);
-  if(!opts||!opts.silent)toast('Imported '+cards.length+' phrases');
+  if(!opts||!opts.silent)toast('Imported '+newCards.length+' phrases');
 }
 function pbExport(name){
   var payload={type:'phrasebook',cards:pbGetCards(),catalogs:pbGetCats(),tags:pbGetTags(),exportedAt:pbNow()};
@@ -1506,13 +1579,26 @@ var _PB_GIT_FILES=[
 ];
 function pbOpenGitSheet(){
   var sheet=document.getElementById('pb-git-sheet');if(!sheet)return;
+  var activePair=null;
+  if(_pbFilter.indexOf('cat:')===0){
+    var _ac=pbGetCats().find(function(c){return'cat:'+c.id===_pbFilter;});
+    if(_ac){var _lp=pbCatLangPair(_ac);activePair={src:_lp.src,tgt:_lp.tgt};}
+  }
+  if(!activePair&&room&&room.myLang&&room.theirLang){activePair={src:room.myLang,tgt:room.theirLang};}
   var list=document.getElementById('pb-git-list');
   if(list){
-    list.innerHTML=_PB_GIT_FILES.map(function(f){
+    var sorted=_PB_GIT_FILES.slice().sort(function(a,b){
+      var am=activePair&&a.src===activePair.src&&a.tgt===activePair.tgt?-1:0;
+      var bm=activePair&&b.src===activePair.src&&b.tgt===activePair.tgt?-1:0;
+      return am-bm;
+    });
+    list.innerHTML=sorted.map(function(f){
+      var isMatch=activePair&&f.src===activePair.src&&f.tgt===activePair.tgt;
       var sf=pbLangFlag(f.src);var tf=pbLangFlag(f.tgt);
-      return '<div style="display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #e0dbd6;">'
-        +'<span style="flex:1;font-size:14px;color:#1a1714;">'+pbEsc(sf+' '+f.src.toUpperCase()+' → '+tf+' '+f.tgt.toUpperCase())+'</span>'
-        +'<button class="pb-nc-save" style="padding:4px 12px;font-size:12px;" onclick="pbGitImport(\''+f.src+'\',\''+f.tgt+'\')">Fetch</button>'
+      var label=sf+' '+f.src.toUpperCase()+' → '+tf+' '+f.tgt.toUpperCase()+(isMatch?' ★':'');
+      return '<div style="display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #e0dbd6;'+(isMatch?'background:#e8f5f5;':'')+'">'
+        +'<span style="flex:1;min-width:0;font-size:14px;color:#1a1714;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+pbEsc(label)+'</span>'
+        +'<button class="pb-nc-save" style="padding:4px 12px;font-size:12px;flex-shrink:0;" onclick="pbGitImport(\''+f.src+'\',\''+f.tgt+'\')">Fetch</button>'
         +'</div>';
     }).join('');
   }
@@ -1792,7 +1878,7 @@ function pbBubbleHtml(card,ctx){
   var vBadge=verdict==='good'?'<span class="pb-vbadge good">\u2713</span>':verdict==='flag'?'<span class="pb-vbadge flag">\u2691</span>':'';
   var _hdrDate=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
   var _hdrTime=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
-  var cBadge=card.confidence>=0.85?'<span class="pb-conf high" title="'+Math.round(card.confidence*100)+'% confidence">✓</span>':card.confidence>=0.5?'<span class="pb-conf med" title="'+Math.round(card.confidence*100)+'% confidence">~</span>':'';
+  var cBadge='';
   var _savedBy=card.savedBy?(' · '+card.savedBy):'';
   var tagChips='';
   if(ctx==='search'&&tags.length){
@@ -1817,7 +1903,7 @@ function pbBubbleHtml(card,ctx){
     +'<div class="pb-bbl-foot">'
     +'<button class="pb-fbt'+(cs.tagsOpen?' on':'')+'" id="pbft-'+id+'" onclick="pbTogTags(\''+id+'\')" title="Tags">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'
     +'<button class="pb-fbt'+(cs.clarifyOpen?' on':'')+'" id="pbfc-'+id+'" onclick="pbTogClarify(\''+id+'\')" title="Clarify">'+ICO.chat+' Clarify'+(cc?' ('+cc+')':'')+'</button>'
-    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ✓':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ·':'')+'</button>'
     +'</div>'
     +'<div class="pb-panel" id="pbtags-'+id+'" style="display:'+(cs.tagsOpen?'block':'none')+';">'+pbTagPanelHtml(card)+'</div>'
     +'<div class="pb-panel" id="pbclarify-'+id+'" style="display:'+(cs.clarifyOpen?'block':'none')+';">'+pbClarifyPanelHtml(card)+'</div>'
@@ -1984,7 +2070,7 @@ function pbReRenderCardPanel(type,id){
   }
   if(type==='bt'){
     var btn3=document.getElementById('pbfb-'+id);
-    if(btn3){var bt=card.backtranslate||{};btn3.innerHTML=ICO.verify+' Verify'+(bt.resultText?' ✓':'');}
+    if(btn3){var bt=card.backtranslate||{};btn3.innerHTML=ICO.verify+' Verify'+(bt.resultText?' ·':'');}
   }
 }
 function pbReRenderBubbleHeader(id){
@@ -2020,11 +2106,20 @@ function pbSetFilter(f){_pbFilter=f;pbRenderOverlayFilter();pbRenderOverlay();}
 function pbRenderOverlayFilter(){
   var host=document.getElementById('pb-ov-filter');if(!host)return;
   var cats=pbGetCats();
-  var html='<button class="pb-fc'+(_pbFilter==='all'?' act':'')+'" onclick="pbSetFilter(\'all\')">All</button>';
+  if(!cats.length){_pbFilter='all';host.innerHTML='';return;}
+  // Auto-select first catalog if current filter is 'all' or invalid
+  if(_pbFilter==='all'||!cats.some(function(c){return _pbFilter==='cat:'+c.id;})){
+    _pbFilter='cat:'+cats[0].id;
+  }
+  var html='';
   cats.forEach(function(cat){
     var k='cat:'+cat.id;
+    var lp=pbCatLangPair(cat);
+    var sf=pbLangFlag(lp.src);var tf=pbLangFlag(lp.tgt);
+    var n=pbGetCards().filter(function(c){return(c.catalogIds||[]).indexOf(cat.id)>=0;}).length;
+    var label=sf+' '+lp.src.toUpperCase()+' → '+tf+' '+lp.tgt.toUpperCase()+' ('+n+')';
     html+='<span class="pb-fc-wrap">'
-      +'<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'+pbEsc((cat.emoji?cat.emoji+' ':'')+cat.name)+'</button>'
+      +'<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'+pbEsc(label)+'</button>'
       +'<button class="pb-fc-x" onclick="pbConfirmRemoveCat(\''+pbEsc(cat.id)+'\')" title="Remove">×</button>'
       +'</span>';
   });
@@ -2052,16 +2147,19 @@ function pbRemoveCat(catId){
 }
 function pbRenderOverlay(){
   var host=document.getElementById('pb-ov-cards');if(!host)return;
+  var cats=pbGetCats();
+  if(!cats.length){
+    host.innerHTML='<div class="pb-empty" style="padding:32px 16px;text-align:center;color:#9a9592;font-size:14px;line-height:1.6;">No phrasebook loaded.<br>Tap ↑ to import a file or ↓ to download from the library.</div>';
+    return;
+  }
   var q=((document.getElementById('pb-ov-search')||{}).value||'').trim();
   var cards=pbGetCards();
-  if(_pbFilter!=='all'){
-    if(_pbFilter.indexOf('cat:')===0){
-      var catId=_pbFilter.slice(4);
-      cards=cards.filter(function(c){return (c.catalogIds||[]).indexOf(catId)>=0;});
-    }else{
-      var p=_pbFilter.split('|');
-      cards=cards.filter(function(c){return (c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});
-    }
+  if(_pbFilter.indexOf('cat:')===0){
+    var catId=_pbFilter.slice(4);
+    cards=cards.filter(function(c){return(c.catalogIds||[]).indexOf(catId)>=0;});
+  }else if(_pbFilter!=='all'){
+    var p=_pbFilter.split('|');
+    cards=cards.filter(function(c){return(c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});
   }
   if(q)cards=pbSearch(q,cards);
   if(!cards.length){host.innerHTML='<div class="pb-empty" style="padding:24px;text-align:center;">No phrases found.</div>';return;}
@@ -2167,11 +2265,18 @@ function pbOpenNewCardForContext(){
 function pbOpenNewCard(opts){
   opts=opts||{};
   _pbNcCatalogIds=opts._catalogIds||[];
+  _pbNcVerdict='';
   var srcLang=opts.sourceLang||(room.myLang||'en');
   var tgtLang=opts.targetLang||(room.theirLang||'en');
   pbPopLangSel('pbnc-sl',srcLang);pbPopLangSel('pbnc-tl',tgtLang);
   var st=document.getElementById('pbnc-src');var tt=document.getElementById('pbnc-tgt');
   if(st)st.value=opts.source||'';if(tt)tt.value=opts.target||'';
+  var br=document.getElementById('pbnc-bt-result');if(br)br.textContent='';
+  var bv=document.getElementById('pbnc-bt-verdict');if(bv)bv.style.display='none';
+  var vg=document.getElementById('pbnc-vgood');if(vg)vg.classList.remove('act');
+  var vf=document.getElementById('pbnc-vflag');if(vf)vf.classList.remove('act');
+  var ti=document.getElementById('pbnc-tags');if(ti)ti.value='';
+  var ci=document.getElementById('pbnc-clarify');if(ci)ci.value='';
   document.getElementById('pb-new-card-sheet').classList.add('open');
   setTimeout(function(){var s=document.getElementById('pbnc-src');if(s)s.focus();},40);
 }
@@ -2185,6 +2290,23 @@ function pbNcAutoTranslate(){
     var tt=document.getElementById('pbnc-tgt');if(tt)tt.value=out||src;
   });
 }
+var _pbNcVerdict='';
+function pbNcRunBt(){
+  var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!tgt){toast('Enter a translation first');return;}
+  var br=document.getElementById('pbnc-bt-result');if(br)br.textContent='Translating…';
+  translateWithRetry(tgt,tl,sl,2).then(function(r){
+    if(br)br.textContent=r||'(no result)';
+    var bv=document.getElementById('pbnc-bt-verdict');if(bv)bv.style.display='flex';
+  }).catch(function(){if(br)br.textContent='Error';});
+}
+function pbNcSetVerdict(v){
+  _pbNcVerdict=v;
+  var vg=document.getElementById('pbnc-vgood');if(vg)vg.classList.toggle('act',v==='good');
+  var vf=document.getElementById('pbnc-vflag');if(vf)vf.classList.toggle('act',v==='flag');
+}
 function pbSaveNewCard(){
   var src=((document.getElementById('pbnc-src')||{}).value||'').trim();
   var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
@@ -2192,14 +2314,43 @@ function pbSaveNewCard(){
   var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
   if(!src){toast('Enter a source phrase');return;}
   if(!tgt){toast('Enter a translation');return;}
-  pbUpsert(pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,catalogIds:_pbNcCatalogIds,savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()}));
+  var tagsRaw=((document.getElementById('pbnc-tags')||{}).value||'').split(',').map(function(t){return t.trim();}).filter(Boolean);
+  var clarifyNote=((document.getElementById('pbnc-clarify')||{}).value||'').trim();
+  var btResultEl=document.getElementById('pbnc-bt-result');
+  var btResult=btResultEl?btResultEl.textContent.trim():'';
+  var validBt=btResult&&btResult!=='Translating…'&&btResult!=='(no result)'&&btResult!=='Error';
+  var btObj=validBt?{sourceLang:tl,targetLang:sl,inputText:tgt,resultText:btResult,verdict:_pbNcVerdict,contentHash:src+'||'+tgt,updatedAt:pbNow()}:{};
+  var card=pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,
+    catalogIds:_pbNcCatalogIds,tags:tagsRaw,backtranslate:btObj,
+    clarifyChain:clarifyNote?[{text:clarifyNote,ts:pbNow(),by:'me'}]:[],
+    savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()});
+  pbUpsert(card);
   pbCloseNewCard();toast('Saved to phrasebook');
   pbRenderOverlayFilter();pbRenderOverlay();
   document.getElementById('pb-overlay').style.display='flex';
+  pbPushCardToRepo(card);
 }
 
 
 
+function saveGhPat(){var v=(document.getElementById('gh-pat-inp')||{}).value||'';if(v.trim())localStorage.setItem('tb_gh_pat',v.trim());}
+async function pbPushCardToRepo(card){
+  var pat=(localStorage.getItem('tb_gh_pat')||'').trim();if(!pat)return;
+  var src=card.sourceLang;var tgt=card.targetLang;
+  var path='phrasebook/phrasebook-'+_pbRepoToken(src)+'-'+_pbRepoToken(tgt)+'-default.json';
+  var url='https://api.github.com/repos/acmeproducts/stuff/contents/'+path;
+  try{
+    var meta=await fetch(url,{headers:{Authorization:'token '+pat,Accept:'application/vnd.github.v3+json'}}).then(function(r){return r.ok?r.json():null;});
+    var cards=pbGetCards().filter(function(c){return c.sourceLang===src&&c.targetLang===tgt;});
+    var cats=pbGetCats().filter(function(c){return cards.some(function(x){return(x.catalogIds||[]).indexOf(c.id)>=0;});});
+    var body={type:'phrasebook',version:'1.1',cards:cards,catalogs:cats,tags:pbGetTags()};
+    var content=btoa(unescape(encodeURIComponent(JSON.stringify(body,null,2))));
+    var payload={message:'phrasebook: update '+src+'-'+tgt+' [talkbridge]',content:content};
+    if(meta&&meta.sha)payload.sha=meta.sha;
+    var res=await fetch(url,{method:'PUT',headers:{Authorization:'token '+pat,'Content-Type':'application/json',Accept:'application/vnd.github.v3+json'},body:JSON.stringify(payload)});
+    if(res.ok){toast('Saved to repo ✓');}else{toast('Repo save failed: '+res.status);}
+  }catch(e){toast('Repo save failed: '+e.message);}
+}
 // ─── Phase 8: Structured log ──────────────────────────────────────────────
 function log(ev,d,l){
   var meta={phase:callPhase,role:room.role||lastSessionContext.role||'?',epoch:sessionEpoch};
@@ -3189,22 +3340,28 @@ function trHtml(e){
   }
   var chatClass=e.type==='chat'?' is-chat':'';
   var failBadge=e.translationFailed?'<span class="tr-fail-badge">&#9888; not translated</span>':'';
+  var TTS_SVG='<svg viewBox="0 0 24 24" width="13" height="13" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg>';
   return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
     +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
     +'<div class="tr-body">'
-    +'<div class="tr-col"><div class="tr-text">'+(e.type==='chat'?renderMd(leftText):thaiWrap(leftText,leftLang))+attachHtml+'</div>'
-    +'<div style="display:flex;gap:5px;align-items:center;flex-wrap:wrap;">'
-    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
-    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(leftText)+'" title="'+esc(L('use_word',leftLang))+'">'+esc(L('use_word',leftLang))+'</button>'
+    +'<div class="tr-col tr-col-tap" data-insert-text="'+esc(leftText)+'" onclick="trInsertText(this)">'
+    +'<div class="tr-col-row">'
+    +'<div class="tr-text" style="flex:1;">'+(e.type==='chat'?renderMd(leftText):thaiWrap(leftText,leftLang))+attachHtml+'</div>'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play" onclick="event.stopPropagation()">'+TTS_SVG+'</button>'
     +'</div></div>'
     +'<div class="tr-divider"></div>'
-    +'<div class="tr-col source"><div class="tr-text">'+(e.type==='chat'?renderMd(rightText):thaiWrap(rightText,rightLang))+'</div>'
-    +'<div style="display:flex;gap:5px;align-items:center;flex-wrap:wrap;">'
-    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
-    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(rightText)+'" title="'+esc(L('use_word',rightLang))+'">'+esc(L('use_word',rightLang))+'</button>'
-    +failBadge
-    +'</div></div>'
+    +'<div class="tr-col tr-col-tap source" data-insert-text="'+esc(rightText)+'" onclick="trInsertText(this)">'
+    +'<div class="tr-col-row">'
+    +'<div class="tr-text" style="flex:1;">'+(e.type==='chat'?renderMd(rightText):thaiWrap(rightText,rightLang))+'</div>'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play" onclick="event.stopPropagation()">'+TTS_SVG+'</button>'
+    +'</div>'+(failBadge?'<div>'+failBadge+'</div>':'')+'</div>'
     +'</div></div></div>';
+}
+function trInsertText(el){
+  var text=el.dataset.insertText||'';if(!text)return;
+  var ta=$('chat-input');if(!ta)return;
+  ta.value=text;ta.dispatchEvent(new Event('input'));ta.focus();
+  pbIClose();
 }
 function appendTrDom(entry){
   var b=$('transcript-body');if(!b)return;
@@ -3465,14 +3622,13 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(
 if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
 if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
 if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
+if(localStorage.getItem('tb_gh_pat')&&$('gh-pat-inp'))$('gh-pat-inp').value=localStorage.getItem('tb_gh_pat').trim();
 log('startup',{v:'3.5.5',ua:navigator.userAgent.slice(0,80)});
 pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();_syncFtStatus();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
 $('call-transcript').addEventListener('click',function(ev){
   var tts=ev.target.closest('.tr-tts');
   if(tts){speakText(tts.getAttribute('data-tts-text')||'',tts.getAttribute('data-tts-lang')||room.myLang||'en');return;}
-  var use=ev.target.closest('.tr-use-ico');
-  if(use){var ci=$('chat-input');if(ci){ci.value=use.getAttribute('data-use-text')||'';ci.dispatchEvent(new Event('input'));}}
 });
 $('local-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('click',swapVideos);

--- a/bridge-ship-cc.html
+++ b/bridge-ship-cc.html
@@ -164,6 +164,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .room-name-chip{background:rgba(0,0,0,.72);color:#fff;border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:600;white-space:nowrap;max-width:min(78vw,260px);overflow:hidden;text-overflow:ellipsis;backdrop-filter:blur(5px);}
 .lang-flags-chip{background:rgba(0,0,0,.55);color:#fff;border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:2px 10px;font-size:15px;backdrop-filter:blur(4px);}
 .chat-compose-strip{display:flex;align-items:flex-end;gap:8px;padding:8px 12px max(8px,env(safe-area-inset-bottom));background:var(--surface);border-top:1px solid rgba(255,255,255,.1);flex-shrink:0;}
+.chat-search-x{background:none;border:none;cursor:pointer;color:#9a9592;padding:4px;line-height:0;flex-shrink:0;}
+.chat-search-x:hover{color:var(--text);}
 .chat-compose-ta{flex:1;background:rgba(255,255,255,.08);color:var(--text);border:1.5px solid rgba(255,255,255,.15);border-radius:20px;padding:8px 14px;font-size:14px;font-family:"DM Sans",sans-serif;resize:none;outline:none;min-height:38px;max-height:80px;line-height:1.4;-webkit-appearance:none;overflow:hidden;box-sizing:border-box;scrollbar-width:none;}
 .chat-compose-ta::-webkit-scrollbar{display:none;}
 .chat-compose-ta::placeholder{color:var(--text-muted);}
@@ -254,8 +256,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .pb-ov-si::placeholder{color:#9a9592;}
 .pb-ov-filter-bar{display:flex;flex-wrap:wrap;gap:6px;padding:8px 14px;border-bottom:1px solid #e0dbd6;background:#fdfaf7;flex-shrink:0;}
 .pb-conf{font-size:10px;margin-left:2px;} .pb-conf.high{color:#27ae60;} .pb-conf.med{color:#f39c12;}
-#pb-inline-panel{display:none;flex-direction:column;background:var(--surface);border-top:1px solid rgba(255,255,255,.12);max-height:44vh;overflow-y:auto;flex-shrink:0;}
+#pb-inline-panel{display:none;flex-direction:column;background:var(--surface);border-top:2px solid rgba(255,255,255,.22);max-height:44vh;overflow-y:auto;flex-shrink:0;}
 #pb-inline-panel.show{display:flex;}
+.pb-ip-hdr{position:sticky;top:0;background:var(--surface);border-bottom:1px solid rgba(255,255,255,.1);padding:4px 10px;display:flex;align-items:center;gap:6px;z-index:1;flex-shrink:0;}
 .pb-irow{display:flex;align-items:stretch;border-bottom:1px solid rgba(255,255,255,.08);min-height:48px;}
 .pb-irow:hover{background:rgba(255,255,255,.04);}
 .pb-iside{display:flex;align-items:center;flex:1;gap:6px;padding:8px 10px;cursor:pointer;}
@@ -301,6 +304,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 .pb-nc-ta{width:100%;border:1.5px solid #e0dbd6;border-radius:10px;padding:9px 12px;font-size:15px;font-family:"DM Sans",sans-serif;background:#fff;resize:none;outline:none;min-height:60px;color:#1a1714;}
 .pb-nc-ta:focus{border-color:#2e8b8b;}
 .pb-nc-trans{background:#e6f4f4;color:#2e8b8b;border:none;border-radius:8px;padding:8px 14px;font-size:13px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;margin:8px 0;}
+.pb-nc-inp{border:1.5px solid #e0dbd6;border-radius:8px;padding:7px 10px;font-size:13px;font-family:"DM Sans",sans-serif;background:#fff;outline:none;color:#1a1714;}
+.pb-nc-inp:focus{border-color:#2e8b8b;}
 .pb-nc-save{background:#2e8b8b;color:#fff;border:none;border-radius:10px;padding:12px;font-size:15px;font-weight:700;cursor:pointer;font-family:"DM Sans",sans-serif;width:100%;}
 .phrase-mini{border:1px solid rgba(255,255,255,.12);border-radius:10px;padding:8px;margin:8px 0;background:rgba(255,255,255,.03);}
 .phrase-mini-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
@@ -377,9 +382,15 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
 #att-modal-body{flex:1;overflow:auto;padding:14px;}
 #att-modal-body img{max-width:100%;border-radius:8px;}
 #att-modal-body iframe{width:100%;height:60dvh;border:none;border-radius:8px;background:#fff;}
-/* tr-use icon style */
-.tr-use-ico{border:none;background:rgba(255,255,255,.08);color:#c4ccd4;border-radius:5px;padding:3px 6px;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:3px;font-size:10px;font-weight:600;}
-.tr-use-ico:hover{background:rgba(63,193,193,.25);color:var(--teal-bright);}.tr-fail-badge{display:inline-block;font-size:10px;color:#e67e22;background:rgba(230,126,34,.12);border:1px solid rgba(230,126,34,.3);border-radius:4px;padding:1px 5px;margin-top:3px;}.thai-overlay{font-family:"Noto Sans Thai","Sarabun","Kanit",sans-serif;letter-spacing:0.01em;}
+.tr-col-tap{cursor:pointer;}.tr-col-tap:hover{background:rgba(255,255,255,.05);}
+.tr-col-row{display:flex;align-items:center;gap:6px;}
+.tr-col-row .tr-text{flex:1;font-size:15px;font-family:"DM Sans",sans-serif;line-height:1.4;}
+.pb-nc-verdict-btn{background:rgba(255,255,255,.08);color:#c4ccd4;border:1px solid rgba(255,255,255,.15);border-radius:8px;padding:5px 14px;font-size:13px;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-verdict-btn.act{background:#2e8b8b;color:#fff;border-color:#2e8b8b;}
+.pb-nc-act{background:rgba(255,255,255,.1);color:#c4ccd4;border:none;border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer;font-family:"DM Sans",sans-serif;}
+.pb-nc-act:hover{background:rgba(255,255,255,.18);}
+.pb-vbadge{font-weight:400!important;}
+.tr-fail-badge{display:inline-block;font-size:10px;color:#e67e22;background:rgba(230,126,34,.12);border:1px solid rgba(230,126,34,.3);border-radius:4px;padding:1px 5px;margin-top:3px;}.thai-overlay{font-family:"Noto Sans Thai","Sarabun","Kanit",sans-serif;letter-spacing:0.01em;}
 /* Chat attach SVG */
 .chat-attach-btn{background:none;border:none;color:var(--text-dim);cursor:pointer;padding:6px;display:flex;align-items:center;line-height:0;flex-shrink:0;}
 .chat-attach-btn:hover{color:var(--text);}
@@ -410,6 +421,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
           <div class="lobby-label" style="margin-bottom:6px;margin-top:10px;">Cloudflare TURN API token</div>
           <input class="lobby-input" id="cf-turn-tok" type="password" placeholder="Paste API token — stored locally" oninput="onCfTurnInput()">
           <div id="cf-turn-status" style="font-size:11px;min-height:16px;margin-top:4px;padding-left:2px;transition:color .2s;"></div></div>
+          <div><div class="lobby-label" style="margin-bottom:6px;">GitHub PAT <span style="font-size:10px;opacity:.6;">(repo write — optional)</span></div>
+          <input class="lobby-input" id="gh-pat-inp" type="password" placeholder="ghp_… — stored locally" oninput="saveGhPat()">
+          </div>
         </div>
         <div class="recent-rooms" id="recent-rooms" style="display:none;margin-top:14px;">
           <div class="recent-title">Recent rooms</div>
@@ -546,6 +560,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
   <div id="pb-inline-panel"></div>
   <div class="chat-compose-strip" id="chat-compose-strip">
     <input type="file" id="chat-file-input" accept=".pdf,.html,.txt,text/*,application/pdf" style="display:none" onchange="handleChatFile(event)"><button class="chat-attach-btn" onclick="document.getElementById('chat-file-input').click()" title="Attach file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><textarea class="chat-compose-ta" id="chat-input" placeholder="type here to chat" rows="1" oninput="chatInputEvt()" onkeydown="chatKeydown(event)" ></textarea>
+    <button class="chat-search-x" id="chat-search-x" style="display:none;" onclick="pbSearchExit()" title="Exit search"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
     <button class="chat-send-btn" id="chat-send-btn" onclick="sendChat()" disabled title="Send">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
     </button>
@@ -580,9 +595,9 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <button class="pb-ov-back" onclick="pbCloseOverlay()" title="Back"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg></button>
     <div class="pb-ov-title">Phrasebook</div>
     <button class="pb-ov-act" onclick="pbOpenNewCardForContext()" title="New phrase"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
-    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
-    <button class="pb-ov-act" onclick="pbOpenGitSheet()" title="Fetch from GitHub"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 14 12 18 16 14"/><line x1="12" y1="12" x2="12" y2="18"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg></button>
-    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg></button>
+    <button class="pb-ov-act" onclick="pbTriggerImport()" title="Import from file"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="12 19 12 5"/><polyline points="5 12 12 5 19 12"/></svg></button>
+    <button class="pb-ov-act" onclick="pbOpenGitSheet()" title="Download from library"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/><polyline points="8 14 12 18 16 14"/><line x1="12" y1="9" x2="12" y2="18"/></svg></button>
+    <button class="pb-ov-act" onclick="pbExportPrompt()" title="Export"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="5 12 19 12"/><polyline points="12 5 19 12 12 19"/></svg></button>
     <button class="pb-ov-act" onclick="pbCloseOverlay()" title="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
   </div>
   <div class="pb-ov-searchbar">
@@ -623,7 +638,26 @@ html,body{height:100%;overflow:hidden;background:var(--bg);font-family:"DM Sans"
     <button class="pb-nc-trans" onclick="pbNcAutoTranslate()">Translate →</button>
     <span class="pb-nc-label">Translation</span>
     <textarea id="pbnc-tgt" class="pb-nc-ta" rows="2" placeholder="Translation…"></textarea>
-    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:12px;">Save to phrasebook</button>
+    <div style="margin-top:10px;">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
+        <span class="pb-nc-label" style="margin-bottom:0;">Back-translate</span>
+        <button class="pb-nc-act" onclick="pbNcRunBt()">↺ Run</button>
+      </div>
+      <div id="pbnc-bt-result" style="font-size:13px;color:#9a9592;min-height:18px;margin-bottom:4px;"></div>
+      <div id="pbnc-bt-verdict" style="display:none;gap:8px;">
+        <button class="pb-nc-verdict-btn" id="pbnc-vgood" onclick="pbNcSetVerdict('good')">✓ Good</button>
+        <button class="pb-nc-verdict-btn" id="pbnc-vflag" onclick="pbNcSetVerdict('flag')">⚑ Flag</button>
+      </div>
+    </div>
+    <div style="margin-top:10px;">
+      <span class="pb-nc-label">Tags</span>
+      <input id="pbnc-tags" class="pb-nc-inp" type="text" placeholder="comma-separated tags" style="width:100%;box-sizing:border-box;">
+    </div>
+    <div style="margin-top:10px;">
+      <span class="pb-nc-label">Clarify note</span>
+      <input id="pbnc-clarify" class="pb-nc-inp" type="text" placeholder="optional clarification" style="width:100%;box-sizing:border-box;">
+    </div>
+    <button class="pb-nc-save" onclick="pbSaveNewCard()" style="margin-top:14px;">Save to phrasebook</button>
   </div>
 </div>
 
@@ -1026,10 +1060,12 @@ function pbISearch(q){
   }
   _pbICards=cards.slice(0,30);
   var total=pbGetCards().length;
+  var hdr='<div class="pb-ip-hdr"><span style="font-size:11px;color:var(--text-muted);font-weight:600;letter-spacing:.04em;text-transform:uppercase;">Phrasebook</span>'
+    +'<span style="font-size:11px;color:var(--text-muted);margin-left:6px;">'+(_pbICards.length?_pbICards.length+(total>_pbICards.length?' of '+total:''):'')+'</span></div>';
   if(!_pbICards.length){
-    panel.innerHTML='<div id="pb-inline-empty">'+(total?'No matching phrases':'No phrasebook loaded — use // to import')+'</div>';
+    panel.innerHTML=hdr+'<div id="pb-inline-empty">'+(total?'No matching phrases':'No phrasebook loaded — use // to import')+'</div>';
   } else {
-    panel.innerHTML=_pbICards.map(function(c,i){return pbIRowHtml(c,i);}).join('');
+    panel.innerHTML=hdr+_pbICards.map(function(c,i){return pbIRowHtml(c,i);}).join('');
   }
   panel.classList.add('show');
 }
@@ -1083,13 +1119,25 @@ function chatInputEvt(){
   ta.style.height='auto';
   ta.style.height=Math.min(ta.scrollHeight,80)+'px';
   $('chat-send-btn').disabled=!raw.trim();
+  var inSearch=raw.length>=1&&raw[0]==='/'&&raw!=='//';
+  var xBtn=$('chat-search-x');if(xBtn)xBtn.style.display=inSearch?'':'none';
   if(raw==='//'){pbIClose();pbOpenCmdDrawer();return;}
-  if(raw.length>=1&&raw[0]==='/'){pbISearch(raw.slice(1));return;}
+  if(inSearch){pbISearch(raw.slice(1));return;}
   pbIClose();
-  // Filter search drawer live if open
   if(_pbDrawerMode==='search')pbRunSearch();
 }
-function chatKeydown(e){if(e.key==='Escape'){pbIClose();}if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}}
+function pbSearchExit(){
+  var ta=$('chat-input');if(ta){ta.value='';ta.style.height='';ta.dispatchEvent(new Event('input'));ta.focus();}
+  pbIClose();
+  var xBtn=$('chat-search-x');if(xBtn)xBtn.style.display='none';
+}
+function chatKeydown(e){
+  var panel=$('pb-inline-panel');
+  if(panel&&panel.classList.contains('show')){
+    if(e.key==='Escape'){e.preventDefault();pbSearchExit();return;}
+  }
+  if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendChat();}
+}
 
 function handleChatFile(ev){
   var file=ev&&ev.target&&ev.target.files&&ev.target.files[0];
@@ -1243,8 +1291,8 @@ var PB_ICON_TTS='<svg width="13" height="13" viewBox="0 0 24 24" fill="none" str
 var ICO={
   plus:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
   book:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>',
-  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
-  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/></svg>',
+  upload:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="12 19 12 5"/><polyline points="5 12 12 5 19 12"/></svg>',
+  download:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="5 12 19 12"/><polyline points="12 5 19 12 12 19"/></svg>',
   warn:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
   link:'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
   trash:'<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>',
@@ -1295,6 +1343,14 @@ function pbGetCards(){return pbGetAllCards().filter(function(c){return !c.delete
 function pbSaveCards(a){try{localStorage.setItem(PB_CARDS,JSON.stringify(a));}catch(_){toast('Storage full');}}
 function pbGetCats(){try{return JSON.parse(localStorage.getItem(PB_CATS)||'[]');}catch(_){return[];}}
 function pbSaveCats(a){try{localStorage.setItem(PB_CATS,JSON.stringify(a));}catch(_){}}
+function pbCatLangPair(cat){
+  if(cat.sourceLang&&cat.targetLang)return{src:cat.sourceLang,tgt:cat.targetLang};
+  var c=pbGetCards().find(function(x){return(x.catalogIds||[]).indexOf(cat.id)>=0;});
+  return c?{src:c.sourceLang,tgt:c.targetLang}:{src:'?',tgt:'?'};
+}
+function pbGetCatForLangPair(src,tgt){
+  return pbGetCats().find(function(c){var p=pbCatLangPair(c);return p.src===src&&p.tgt===tgt;});
+}
 function pbGetTags(){try{return JSON.parse(localStorage.getItem(PB_TAGS_K)||'[]');}catch(_){return[];}}
 function pbSaveTags(a){try{localStorage.setItem(PB_TAGS_K,JSON.stringify(a));}catch(_){}}
 function pbCardKey(c){return (c.sourceLang||'')+'|'+(c.source||'').trim().toLowerCase()+'|'+(c.targetLang||'')+'|'+(c.target||'').trim().toLowerCase();}
@@ -1377,17 +1433,34 @@ function pbAutoSeed(){
 
 /* ── Import/export ── */
 function pbApplyImport(data,opts){
-  var cards=(data.cards||[]).map(pbNorm);
-  var existing=pbGetCards();var byKey={};
-  existing.forEach(function(c){byKey[pbCardKey(c)]=c;});
-  cards.forEach(function(c){byKey[pbCardKey(c)]=c;});
+  var newCards=(data.cards||[]).map(pbNorm);
+  var idRemap={};
+  (data.catalogs||[]).forEach(function(cat){
+    if(!cat||!cat.id)return;
+    var sample=newCards.find(function(c){return(c.catalogIds||[]).indexOf(cat.id)>=0;});
+    if(sample){cat.sourceLang=sample.sourceLang;cat.targetLang=sample.targetLang;}
+    var ex=cat.sourceLang&&cat.targetLang?pbGetCatForLangPair(cat.sourceLang,cat.targetLang):null;
+    if(ex&&ex.id!==cat.id){idRemap[cat.id]=ex.id;}
+  });
+  if(Object.keys(idRemap).length){
+    newCards.forEach(function(c){
+      c.catalogIds=(c.catalogIds||[]).map(function(id){return idRemap[id]||id;});
+    });
+  }
+  var byKey={};
+  pbGetCards().forEach(function(c){byKey[pbCardKey(c)]=c;});
+  newCards.forEach(function(c){byKey[pbCardKey(c)]=c;});
   pbSaveCards(Object.values(byKey));
   var cats=pbGetCats();var catIds=cats.map(function(c){return c.id;});
-  (data.catalogs||[]).forEach(function(cat){if(cat&&cat.id&&catIds.indexOf(cat.id)<0)cats.push(cat);});
+  (data.catalogs||[]).forEach(function(cat){
+    if(!cat||!cat.id)return;
+    if(idRemap[cat.id])return;
+    if(catIds.indexOf(cat.id)<0)cats.push(cat);
+  });
   pbSaveCats(cats);
   var tags=pbGetTags();(data.tags||[]).forEach(function(t){if(tags.indexOf(t)<0)tags.push(t);});
   pbSaveTags(tags);
-  if(!opts||!opts.silent)toast('Imported '+cards.length+' phrases');
+  if(!opts||!opts.silent)toast('Imported '+newCards.length+' phrases');
 }
 function pbExport(name){
   var payload={type:'phrasebook',cards:pbGetCards(),catalogs:pbGetCats(),tags:pbGetTags(),exportedAt:pbNow()};
@@ -1510,13 +1583,26 @@ var _PB_GIT_FILES=[
 ];
 function pbOpenGitSheet(){
   var sheet=document.getElementById('pb-git-sheet');if(!sheet)return;
+  var activePair=null;
+  if(_pbFilter.indexOf('cat:')===0){
+    var _ac=pbGetCats().find(function(c){return'cat:'+c.id===_pbFilter;});
+    if(_ac){var _lp=pbCatLangPair(_ac);activePair={src:_lp.src,tgt:_lp.tgt};}
+  }
+  if(!activePair&&room&&room.myLang&&room.theirLang){activePair={src:room.myLang,tgt:room.theirLang};}
   var list=document.getElementById('pb-git-list');
   if(list){
-    list.innerHTML=_PB_GIT_FILES.map(function(f){
+    var sorted=_PB_GIT_FILES.slice().sort(function(a,b){
+      var am=activePair&&a.src===activePair.src&&a.tgt===activePair.tgt?-1:0;
+      var bm=activePair&&b.src===activePair.src&&b.tgt===activePair.tgt?-1:0;
+      return am-bm;
+    });
+    list.innerHTML=sorted.map(function(f){
+      var isMatch=activePair&&f.src===activePair.src&&f.tgt===activePair.tgt;
       var sf=pbLangFlag(f.src);var tf=pbLangFlag(f.tgt);
-      return '<div style="display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #e0dbd6;">'
-        +'<span style="flex:1;font-size:14px;color:#1a1714;">'+pbEsc(sf+' '+f.src.toUpperCase()+' → '+tf+' '+f.tgt.toUpperCase())+'</span>'
-        +'<button class="pb-nc-save" style="padding:4px 12px;font-size:12px;" onclick="pbGitImport(\''+f.src+'\',\''+f.tgt+'\')">Fetch</button>'
+      var label=sf+' '+f.src.toUpperCase()+' → '+tf+' '+f.tgt.toUpperCase()+(isMatch?' ★':'');
+      return '<div style="display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #e0dbd6;'+(isMatch?'background:#e8f5f5;':'')+'">'
+        +'<span style="flex:1;min-width:0;font-size:14px;color:#1a1714;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+pbEsc(label)+'</span>'
+        +'<button class="pb-nc-save" style="padding:4px 12px;font-size:12px;flex-shrink:0;" onclick="pbGitImport(\''+f.src+'\',\''+f.tgt+'\')">Fetch</button>'
         +'</div>';
     }).join('');
   }
@@ -1659,10 +1745,10 @@ function pbBubbleHtml(card,ctx){
   var vBadge=verdict==='good'?'<span class="pb-vbadge good">\u2713</span>':verdict==='flag'?'<span class="pb-vbadge flag">\u2691</span>':'';
   var _hdrDate=card.createdAt?new Date(card.createdAt).toLocaleDateString([],{month:'short',day:'numeric',year:'2-digit'}):'';
   var _hdrTime=card.createdAt?new Date(card.createdAt).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}):'';
-  var cBadge=card.confidence>=0.85?'<span class="pb-conf high" title="'+Math.round(card.confidence*100)+'% confidence">✓</span>':card.confidence>=0.5?'<span class="pb-conf med" title="'+Math.round(card.confidence*100)+'% confidence">~</span>':'';
+  var cBadge='';
   var _savedBy=card.savedBy?(' · '+card.savedBy):'';
   return '<div class="pb-bubble'+(isDel?' deleted':'')+'" id="pbb-'+id+'">'
-    +'<div class="pb-bbl-hdr">'+vBadge+cBadge+'<span class="pb-bbl-ts">'+pbEsc(_hdrDate+' '+_hdrTime+_savedBy)+'</span></div>'
+    +'<div class="pb-bbl-hdr">'+vBadge+'<span class="pb-bbl-ts">'+pbEsc(_hdrDate+' '+_hdrTime+_savedBy)+'</span></div>'
     +'<div class="pb-bbl-body">'
     +'<div class="pb-bbl-col"><div class="pb-bbl-txt" id="pbsrc-'+id+'" contenteditable="true" onblur="pbCommitSrcEdit(\''+id+'\')" spellcheck="false">'+pbEsc(card.source)+'</div>'
     +'<div class="pb-bbl-acts"><button class="pb-use-btn" onclick="pbUseText(\''+id+'\',\'src\')" title="'+pbEsc(useL)+'">'+pbEsc(useL)+'</button>'
@@ -1675,7 +1761,7 @@ function pbBubbleHtml(card,ctx){
     +'<div class="pb-bbl-foot">'
     +'<button class="pb-fbt'+(cs.tagsOpen?' on':'')+'" id="pbft-'+id+'" onclick="pbTogTags(\''+id+'\')" title="Tags">'+ICO.tag+' Tags'+(tags.length?' ('+tags.length+')':'')+'</button>'
     +'<button class="pb-fbt'+(cs.clarifyOpen?' on':'')+'" id="pbfc-'+id+'" onclick="pbTogClarify(\''+id+'\')" title="Clarify">'+ICO.chat+' Clarify'+(cc?' ('+cc+')':'')+'</button>'
-    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ✓':'')+'</button>'
+    +'<button class="pb-fbt'+(cs.btOpen?' on':'')+'" id="pbfb-'+id+'" onclick="pbTogBt(\''+id+'\')" title="Back-translate">'+ICO.verify+' Verify'+(bt.resultText?' ·':'')+'</button>'
     +'</div>'
     +'<div class="pb-panel" id="pbtags-'+id+'" style="display:'+(cs.tagsOpen?'block':'none')+';">'+pbTagPanelHtml(card)+'</div>'
     +'<div class="pb-panel" id="pbclarify-'+id+'" style="display:'+(cs.clarifyOpen?'block':'none')+';">'+pbClarifyPanelHtml(card)+'</div>'
@@ -1874,11 +1960,19 @@ function pbSetFilter(f){_pbFilter=f;pbRenderOverlayFilter();pbRenderOverlay();}
 function pbRenderOverlayFilter(){
   var host=document.getElementById('pb-ov-filter');if(!host)return;
   var cats=pbGetCats();
-  var html='<button class="pb-fc'+(_pbFilter==='all'?' act':'')+'" onclick="pbSetFilter(\'all\')">All</button>';
+  if(!cats.length){_pbFilter='all';host.innerHTML='';return;}
+  if(_pbFilter==='all'||!cats.some(function(c){return _pbFilter==='cat:'+c.id;})){
+    _pbFilter='cat:'+cats[0].id;
+  }
+  var html='';
   cats.forEach(function(cat){
     var k='cat:'+cat.id;
+    var lp=pbCatLangPair(cat);
+    var sf=pbLangFlag(lp.src);var tf=pbLangFlag(lp.tgt);
+    var n=pbGetCards().filter(function(c){return(c.catalogIds||[]).indexOf(cat.id)>=0;}).length;
+    var label=sf+' '+lp.src.toUpperCase()+' → '+tf+' '+lp.tgt.toUpperCase()+' ('+n+')';
     html+='<span class="pb-fc-wrap">'
-      +'<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'+pbEsc((cat.emoji?cat.emoji+' ':'')+cat.name)+'</button>'
+      +'<button class="pb-fc'+(_pbFilter===k?' act':'')+'" onclick="pbSetFilter(\''+pbEsc(k)+'\')">'+pbEsc(label)+'</button>'
       +'<button class="pb-fc-x" onclick="pbConfirmRemoveCat(\''+pbEsc(cat.id)+'\')" title="Remove">×</button>'
       +'</span>';
   });
@@ -1906,16 +2000,19 @@ function pbRemoveCat(catId){
 }
 function pbRenderOverlay(){
   var host=document.getElementById('pb-ov-cards');if(!host)return;
+  var cats=pbGetCats();
+  if(!cats.length){
+    host.innerHTML='<div class="pb-empty" style="padding:32px 16px;text-align:center;color:#9a9592;font-size:14px;line-height:1.6;">No phrasebook loaded.<br>Tap ↑ to import a file or ↓ to download from the library.</div>';
+    return;
+  }
   var q=((document.getElementById('pb-ov-search')||{}).value||'').trim();
   var cards=pbGetCards();
-  if(_pbFilter!=='all'){
-    if(_pbFilter.indexOf('cat:')===0){
-      var catId=_pbFilter.slice(4);
-      cards=cards.filter(function(c){return (c.catalogIds||[]).indexOf(catId)>=0;});
-    }else{
-      var p=_pbFilter.split('|');
-      cards=cards.filter(function(c){return (c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});
-    }
+  if(_pbFilter.indexOf('cat:')===0){
+    var catId=_pbFilter.slice(4);
+    cards=cards.filter(function(c){return (c.catalogIds||[]).indexOf(catId)>=0;});
+  }else if(_pbFilter!=='all'){
+    var p=_pbFilter.split('|');
+    cards=cards.filter(function(c){return (c.sourceLang===p[0]&&c.targetLang===p[1])||(c.sourceLang===p[1]&&c.targetLang===p[0]);});
   }
   if(q)cards=pbSearch(q,cards);
   if(!cards.length){host.innerHTML='<div class="pb-empty" style="padding:24px;text-align:center;">No phrases found.</div>';return;}
@@ -2021,11 +2118,18 @@ function pbOpenNewCardForContext(){
 function pbOpenNewCard(opts){
   opts=opts||{};
   _pbNcCatalogIds=opts._catalogIds||[];
+  _pbNcVerdict='';
   var srcLang=opts.sourceLang||(room.myLang||'en');
   var tgtLang=opts.targetLang||(room.theirLang||'en');
   pbPopLangSel('pbnc-sl',srcLang);pbPopLangSel('pbnc-tl',tgtLang);
   var st=document.getElementById('pbnc-src');var tt=document.getElementById('pbnc-tgt');
   if(st)st.value=opts.source||'';if(tt)tt.value=opts.target||'';
+  var br=document.getElementById('pbnc-bt-result');if(br)br.textContent='';
+  var bv=document.getElementById('pbnc-bt-verdict');if(bv)bv.style.display='none';
+  var vg=document.getElementById('pbnc-vgood');if(vg)vg.classList.remove('act');
+  var vf=document.getElementById('pbnc-vflag');if(vf)vf.classList.remove('act');
+  var ti=document.getElementById('pbnc-tags');if(ti)ti.value='';
+  var ci=document.getElementById('pbnc-clarify');if(ci)ci.value='';
   document.getElementById('pb-new-card-sheet').classList.add('open');
   setTimeout(function(){var s=document.getElementById('pbnc-src');if(s)s.focus();},40);
 }
@@ -2039,6 +2143,23 @@ function pbNcAutoTranslate(){
     var tt=document.getElementById('pbnc-tgt');if(tt)tt.value=out||src;
   });
 }
+var _pbNcVerdict='';
+function pbNcRunBt(){
+  var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
+  var sl=(document.getElementById('pbnc-sl')||{}).value||'en';
+  var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
+  if(!tgt){toast('Enter a translation first');return;}
+  var br=document.getElementById('pbnc-bt-result');if(br)br.textContent='Translating…';
+  translateWithRetry(tgt,tl,sl,2).then(function(r){
+    if(br)br.textContent=r||'(no result)';
+    var bv=document.getElementById('pbnc-bt-verdict');if(bv)bv.style.display='flex';
+  }).catch(function(){if(br)br.textContent='Error';});
+}
+function pbNcSetVerdict(v){
+  _pbNcVerdict=v;
+  var vg=document.getElementById('pbnc-vgood');if(vg)vg.classList.toggle('act',v==='good');
+  var vf=document.getElementById('pbnc-vflag');if(vf)vf.classList.toggle('act',v==='flag');
+}
 function pbSaveNewCard(){
   var src=((document.getElementById('pbnc-src')||{}).value||'').trim();
   var tgt=((document.getElementById('pbnc-tgt')||{}).value||'').trim();
@@ -2046,10 +2167,39 @@ function pbSaveNewCard(){
   var tl=(document.getElementById('pbnc-tl')||{}).value||'en';
   if(!src){toast('Enter a source phrase');return;}
   if(!tgt){toast('Enter a translation');return;}
-  pbUpsert(pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,catalogIds:_pbNcCatalogIds,savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()}));
+  var tagsRaw=((document.getElementById('pbnc-tags')||{}).value||'').split(',').map(function(t){return t.trim();}).filter(Boolean);
+  var clarifyNote=((document.getElementById('pbnc-clarify')||{}).value||'').trim();
+  var btResultEl=document.getElementById('pbnc-bt-result');
+  var btResult=btResultEl?btResultEl.textContent.trim():'';
+  var validBt=btResult&&btResult!=='Translating…'&&btResult!=='(no result)'&&btResult!=='Error';
+  var btObj=validBt?{sourceLang:tl,targetLang:sl,inputText:tgt,resultText:btResult,verdict:_pbNcVerdict,contentHash:src+'||'+tgt,updatedAt:pbNow()}:{};
+  var card=pbNorm({sourceLang:sl,targetLang:tl,source:src,target:tgt,
+    catalogIds:_pbNcCatalogIds,tags:tagsRaw,backtranslate:btObj,
+    clarifyChain:clarifyNote?[{text:clarifyNote,ts:pbNow(),by:'me'}]:[],
+    savedBy:'me',createdAt:pbNow(),updatedAt:pbNow()});
+  pbUpsert(card);
   pbCloseNewCard();toast('Saved to phrasebook');
   pbRenderOverlayFilter();pbRenderOverlay();
   document.getElementById('pb-overlay').style.display='flex';
+  pbPushCardToRepo(card);
+}
+function saveGhPat(){var v=(document.getElementById('gh-pat-inp')||{}).value||'';if(v.trim())localStorage.setItem('tb_gh_pat',v.trim());}
+async function pbPushCardToRepo(card){
+  var pat=(localStorage.getItem('tb_gh_pat')||'').trim();if(!pat)return;
+  var src=card.sourceLang;var tgt=card.targetLang;
+  var path='phrasebook/phrasebook-'+_pbRepoToken(src)+'-'+_pbRepoToken(tgt)+'-default.json';
+  var url='https://api.github.com/repos/acmeproducts/stuff/contents/'+path;
+  try{
+    var meta=await fetch(url,{headers:{Authorization:'token '+pat,Accept:'application/vnd.github.v3+json'}}).then(function(r){return r.ok?r.json():null;});
+    var cards=pbGetCards().filter(function(c){return c.sourceLang===src&&c.targetLang===tgt;});
+    var cats=pbGetCats().filter(function(c){return cards.some(function(x){return(x.catalogIds||[]).indexOf(c.id)>=0;});});
+    var body={type:'phrasebook',version:'1.1',cards:cards,catalogs:cats,tags:pbGetTags()};
+    var content=btoa(unescape(encodeURIComponent(JSON.stringify(body,null,2))));
+    var payload={message:'phrasebook: update '+src+'-'+tgt+' [talkbridge]',content:content};
+    if(meta&&meta.sha)payload.sha=meta.sha;
+    var res=await fetch(url,{method:'PUT',headers:{Authorization:'token '+pat,'Content-Type':'application/json',Accept:'application/vnd.github.v3+json'},body:JSON.stringify(payload)});
+    if(res.ok){toast('Saved to repo ✓');}else{toast('Repo save failed: '+res.status);}
+  }catch(e){toast('Repo save failed: '+e.message);}
 }
 
 
@@ -2970,22 +3120,26 @@ function trHtml(e){
   }
   var chatClass=e.type==='chat'?' is-chat':'';
   var failBadge=e.translationFailed?'<span class="tr-fail-badge">&#9888; not translated</span>':'';
+  var TTS_SVG='<svg viewBox="0 0 24 24" width="13" height="13" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg>';
   return '<div class="tr-entry"><div class="tr-bubble'+chatClass+'">'
     +'<div class="tr-head"><div class="tr-who '+(isMine?'mine':'')+'">'+esc(speaker)+'</div><div class="tr-time">'+esc(ts)+'</div></div>'
     +'<div class="tr-body">'
-    +'<div class="tr-col"><div class="tr-text">'+(e.type==='chat'?renderMd(leftText):thaiWrap(leftText,leftLang))+attachHtml+'</div>'
-    +'<div style="display:flex;gap:5px;align-items:center;flex-wrap:wrap;">'
-    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
-    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(leftText)+'" title="'+esc(L('use_word',leftLang))+'">'+esc(L('use_word',leftLang))+'</button>'
+    +'<div class="tr-col tr-col-tap" data-insert-text="'+esc(leftText)+'" onclick="trInsertText(this)">'
+    +'<div class="tr-col-row"><div class="tr-text" style="flex:1;">'+(e.type==='chat'?renderMd(leftText):thaiWrap(leftText,leftLang))+attachHtml+'</div>'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(leftText)+'" data-tts-lang="'+esc(leftLang)+'" title="Play" onclick="event.stopPropagation()">'+TTS_SVG+'</button>'
     +'</div></div>'
     +'<div class="tr-divider"></div>'
-    +'<div class="tr-col source"><div class="tr-text">'+(e.type==='chat'?renderMd(rightText):thaiWrap(rightText,rightLang))+'</div>'
-    +'<div style="display:flex;gap:5px;align-items:center;flex-wrap:wrap;">'
-    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play"><svg viewBox="0 0 24 24"><path d="M4 10h4l5-4v12l-5-4H4z"/><path d="M16 9a4 4 0 0 1 0 6"/></svg></button>'
-    +'<button class="tr-use-ico" type="button" data-use-text="'+esc(rightText)+'" title="'+esc(L('use_word',rightLang))+'">'+esc(L('use_word',rightLang))+'</button>'
-    +failBadge
-    +'</div></div>'
+    +'<div class="tr-col tr-col-tap source" data-insert-text="'+esc(rightText)+'" onclick="trInsertText(this)">'
+    +'<div class="tr-col-row"><div class="tr-text" style="flex:1;">'+(e.type==='chat'?renderMd(rightText):thaiWrap(rightText,rightLang))+'</div>'
+    +'<button class="tr-tts" type="button" data-tts-text="'+esc(rightText)+'" data-tts-lang="'+esc(rightLang)+'" title="Play" onclick="event.stopPropagation()">'+TTS_SVG+'</button>'
+    +'</div>'+(failBadge?'<div>'+failBadge+'</div>':'')+'</div>'
     +'</div></div></div>';
+}
+function trInsertText(el){
+  var text=el.dataset.insertText||'';if(!text)return;
+  var ta=$('chat-input');if(!ta)return;
+  ta.value=text;ta.dispatchEvent(new Event('input'));ta.focus();
+  pbIClose();
 }
 function appendTrDom(entry){
   var b=$('transcript-body');if(!b)return;
@@ -3247,14 +3401,13 @@ if(localStorage.getItem('tb_dg_key')&&$('dg-key')){var _sk=localStorage.getItem(
 if(localStorage.getItem('tb_cf_tid')&&$('cf-turn-id'))$('cf-turn-id').value=localStorage.getItem('tb_cf_tid').trim();
 if(localStorage.getItem('tb_cf_tok')&&$('cf-turn-tok'))$('cf-turn-tok').value=localStorage.getItem('tb_cf_tok').trim();
 if(localStorage.getItem('tb_cf_tid')&&localStorage.getItem('tb_cf_tok'))setCfTurnStatus('✅ Saved','#2ecc71');
+if(localStorage.getItem('tb_gh_pat')&&$('gh-pat-inp'))$('gh-pat-inp').value=localStorage.getItem('tb_gh_pat').trim();
 log('startup',{v:'3.5.5',ua:navigator.userAgent.slice(0,80)});
 pbAutoSeed();populateLangs();renderRecent();syncMic();syncCam();syncTranscriptToggleButton();syncTranscriptTtsButton();syncBtn();_loadFastText();_syncFtStatus();
 $('call-transcript').addEventListener('scroll',function(){if(transcriptNearBottom())setTranscriptMore(false)});
 $('call-transcript').addEventListener('click',function(ev){
   var tts=ev.target.closest('.tr-tts');
   if(tts){speakText(tts.getAttribute('data-tts-text')||'',tts.getAttribute('data-tts-lang')||room.myLang||'en');return;}
-  var use=ev.target.closest('.tr-use-ico');
-  if(use){var ci=$('chat-input');if(ci){ci.value=use.getAttribute('data-use-text')||'';ci.dispatchEvent(new Event('input'));}}
 });
 $('local-video').addEventListener('click',swapVideos);
 $('remote-video').addEventListener('click',swapVideos);


### PR DESCRIPTION
## Summary

- **Single-select catalog chips**: no "All" button; chip label shows `🇺🇸 EN → 🇹🇭 TH (24)` with flags and card count; clicking active chip is a no-op; auto-selects first catalog on open
- **Catalog dedup by lang pair**: `pbApplyImport` remaps incoming catalog IDs when an existing catalog covers the same lang pair — prevents duplicate chips
- **Icon corrections**: upload = plain up-arrow, GitHub fetch = cloud + down-arrow, export = right-arrow
- **Add Phrase sheet expanded**: backtranslate (↺ Run + Good/Flag verdict), tags (comma-separated), clarify note fields; all saved to card
- **GitHub PAT for repo write**: `tb_gh_pat` field in credentials panel; `pbPushCardToRepo` writes the full lang-pair phrasebook JSON to `phrasebook/` on card save
- **Bubble header cleanup**: single ✓ (verdict badge only); Verify footer button shows `·` dot instead of `✓` when back-translate result exists
- **GitHub sheet**: auto-sorts active lang pair to top with ★; `min-width:0` + ellipsis on label spans fixes visibility
- **Inline search header**: sticky "Phrasebook / N of M" bar prepended to `#pb-inline-panel`
- **Empty state**: "No phrasebook loaded. Tap ↑ to import a file or ↓ to download from the library." when no catalogs exist
- **Transcript tap-to-use**: removed "Use" buttons; `.tr-col-tap` makes each column tappable; TTS button sits inline to the right; `trInsertText` populates compose
- **Compose X button**: `#chat-search-x` appears when in `/` search mode; `pbSearchExit` clears compose and closes inline panel
- **Escape key**: calls `pbSearchExit` when inline panel is open

## Test plan

- [ ] Open phrasebook overlay → only catalog chips visible (no "All"), each shows `🇺🇸 EN → 🇹🇭 TH (24)` format
- [ ] Import two phrasebooks with the same lang pair → only one chip, cards merged
- [ ] Tap × on a chip → confirm dialog → removed; last chip gone → empty-state message
- [ ] Cloud-down button → GitHub sheet opens with active lang pair highlighted and sorted to top
- [ ] Upload icon = plain up-arrow; Export icon = right-arrow
- [ ] Add Phrase → back-translate runs, verdict selectable, tags and clarify save on card
- [ ] Bubble header: only one ✓ (verdict); Verify button has no ✓, shows · when result exists
- [ ] Tap transcript text column → populates compose field; TTS button plays without triggering insert
- [ ] Type `/hello` → X appears in compose strip; tap X → clears and exits search
- [ ] Escape while inline panel open → clears compose and closes panel

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJE5eqDx4FrNtausaQwfTz)_