### PR TITLE
Merge repo board index with local cache to preserve imported boards on refresh

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -478,7 +478,41 @@ function boardFilePath(name){ const prefix=typeof repoSwitchCfg.pathPrefix==="st
 function canonicalBoardKey(name){ return boardSlug(name); }
 async function fetchJson(path){ const r=await fetch(path,{cache:"no-store"}); if(!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
 async function loadRepoSwitch(){ try{ const v=await fetchJson(REPO_SWITCH_FILE); repoSwitchCfg=(v&&typeof v==="object")?v:{}; }catch{ repoSwitchCfg={}; } }
-async function loadRepoBoardsIndex(){ try{ const v=await fetchJson(REPO_BOARDS_FILE); repoBoardsIndex=(v&&typeof v==="object")?v:{version:1,activeBoard:"",boards:[]}; }catch{ repoBoardsIndex={version:1,activeBoard:"",boards:[]}; } repoBoardsIndex.boards=Array.isArray(repoBoardsIndex.boards)?repoBoardsIndex.boards:[]; }
+function loadRepoBoardsIndexCache(){
+  return safeParseJson(localStorage.getItem("kanban_repo_boards_index_cache")||"", null);
+}
+function mergeBoardIndexes(primary, secondary){
+  const left=(primary && typeof primary==="object") ? primary : { version:1, activeBoard:"", boards:[] };
+  const right=(secondary && typeof secondary==="object") ? secondary : { version:1, activeBoard:"", boards:[] };
+  const merged={ version:Number(left.version||right.version||1)||1, activeBoard:String(left.activeBoard||right.activeBoard||""), boards:[] };
+  const byKey=new Map();
+  const push=(items=[])=>{
+    items.forEach((item)=>{
+      const rec=normalizeBoardRecord(item);
+      if(!rec) return;
+      const key=canonicalBoardKey(rec.name);
+      const prev=byKey.get(key);
+      if(!prev || Number(rec.lastUpdated||0)>=Number(prev.lastUpdated||0)) byKey.set(key, rec);
+    });
+  };
+  push(right.boards);
+  push(left.boards);
+  merged.boards=Array.from(byKey.values());
+  if(merged.activeBoard && !merged.boards.some(b=>canonicalBoardKey(b.name)===canonicalBoardKey(merged.activeBoard))){
+    merged.activeBoard=merged.boards.find(b=>!b.archived)?.name || merged.boards[0]?.name || "";
+  }
+  return merged;
+}
+async function loadRepoBoardsIndex(){
+  const cached=loadRepoBoardsIndexCache();
+  try{
+    const remote=await fetchJson(REPO_BOARDS_FILE);
+    repoBoardsIndex=mergeBoardIndexes(remote, cached);
+  }catch{
+    repoBoardsIndex=mergeBoardIndexes(cached, null);
+  }
+  repoBoardsIndex.boards=Array.isArray(repoBoardsIndex.boards)?repoBoardsIndex.boards:[];
+}
 async function refreshBoardsIndexFromRepo(){ await loadRepoBoardsIndex(); saveRepoBoardsIndexCache(); }
 function loadCacheMeta(){ return safeParseJson(localStorage.getItem(BOARD_CACHE_META_KEY)||"{}",{}); }
 function saveCacheMeta(meta){ localStorage.setItem(BOARD_CACHE_META_KEY, JSON.stringify(meta||{})); }


### PR DESCRIPTION
### Motivation
- Imported boards could appear in-session but disappear after a refresh when `kanban-boards.json` was not yet updated or failed to load. 
- The app must retain recently imported boards across reloads by reconciling remote index and local cache.

### Description
- Added `loadRepoBoardsIndexCache()` to read the cached index from `localStorage` key `kanban_repo_boards_index_cache`.
- Added `mergeBoardIndexes(primary, secondary)` which normalizes and merges remote and cached index entries, keeping the newest `lastUpdated` record per board key.
- Replaced the previous `loadRepoBoardsIndex()` with a version that attempts to fetch `REPO_BOARDS_FILE` and merges the result with the cached index, and falls back to the cached index on fetch failure.
- Ensures `activeBoard` is validated/rewritten after merge so it points to an existing (non-archived) board when possible.

### Testing
- Committed the change to the repository using `git add kanban.html && git commit -m "Fix imported board index persistence across refresh"`, which succeeded.
- Verified repository status with `git -C /workspace/stuff status --short`, which returned expected modified file entry.
- Created PR metadata using the repo tooling (`make_pr`), which reported the PR title and body generation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c260e28832d8e05eb24f596324f)