### PR TITLE
Respect `?board` param and stop cycling boards on startup; open Board Manager list for empty/missing boards

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -2351,7 +2351,7 @@ document.getElementById("boardKeyPill").addEventListener("click", ()=>{
     }
   });
   window.__switchToBoard=switchToBoard;
-  window.__openBoardManager=(name="new-board")=>{ setBoardInputDefaults(name); renderBoardManager(); dlg.showModal(); };
+  window.__openBoardManager=(name="new-board", tab="new")=>{ setBoardInputDefaults(name); renderBoardManager(); setBoardTab(tab); dlg.showModal(); };
 })();
 
 
@@ -2361,66 +2361,48 @@ async function bootstrapBoardsLifecycle(){
   const boards=(repoBoardsIndex.boards||[]).map(normalizeBoardRecord).filter(b=>b && !b.archived);
   boards.sort((a,b)=>Number(b.lastUpdated||0)-Number(a.lastUpdated||0));
   const requested=canonicalBoardKey((urlBoardParamRaw||"").trim());
-  const lastSeen=canonicalBoardKey(localStorage.getItem(LAST_SEEN_BOARD_LS)||"");
-  const requestedBoard=boards.find(b=>canonicalBoardKey(b.name)===requested);
-  const lastSeenBoard=boards.find(b=>canonicalBoardKey(b.name)===lastSeen);
-  const activeMatch=boards.find(b=>String(b.name||"")===String(repoBoardsIndex.activeBoard||""));
-  const ordered=[requestedBoard,lastSeenBoard,activeMatch,...boards].filter((b,i,a)=>b && a.findIndex(x=>canonicalBoardKey(x.name)===canonicalBoardKey(b.name))===i);
-  const chosen=ordered[0]||null;
-  if(!chosen){
-    if(hasBoardQueryParam){ window.__openBoardManager?.(_cleanKey(urlBoardParamRaw)); }
-    else{
-      window.__openBoardManager?.("new-board");
-      state={ cards:[], archive:[], stages:["Done","Doing","Next"], platforms:["Gemini","Claude","ChatGPT","Perplexity"], collapsed:{}, cardCollapsed:{}, layout:"auto", lastModified:Date.now() };
-      render();
-      const msg=document.createElement("div");
-      msg.className="empty-boarding";
-      msg.textContent="Welcome. Create a board from Board Manager to get started.";
-      document.getElementById("board").appendChild(msg);
-    }
+  if(!hasBoardQueryParam){
+    state={ cards:[], archive:[], stages:["Done","Doing","Next"], platforms:["Gemini","Claude","ChatGPT","Perplexity"], collapsed:{}, cardCollapsed:{}, layout:"auto", lastModified:Date.now() };
+    render();
+    const msg=document.createElement("div");
+    msg.className="empty-boarding";
+    msg.textContent="Welcome. Create a board from Board Manager to get started.";
+    document.getElementById("board").appendChild(msg);
+    window.__openBoardManager?.("new-board","list");
     setStatus("Select or create a board to begin");
     boardsBootstrapped=true;
     return;
   }
-  const key=setBoardKey(chosen.name); currentBoardKey=canonicalBoardKey(key); updateKeyLabel();
-  startupBoardName=chosen.name;
-  let loaded=false;
-  let lastErr=null;
-  for(const candidate of ordered){
-    try{
-      const remote=await fetchJson(boardFilePath(candidate.name));
-      if(!isValidBoardData(remote)) throw new Error("Invalid repo board payload");
-      startupBoardName=candidate.name;
-      setBoardKey(candidate.name); currentBoardKey=canonicalBoardKey(candidate.name); updateKeyLabel();
-      applyImportedBoard(remote, "repo");
-      const repoTs=Number(candidate.lastUpdated||0);
-      const remoteTs=getBoardLastModified(remote);
-      const next=loadCacheMeta();
-      next[currentBoardKey]={lastUpdated:String(Math.max(repoTs, remoteTs, Date.now()))};
-      saveCacheMeta(next);
-      clearRepoLoadBlocked();
-      setStatus(`Loaded ${candidate.name} from repo`);
-      loaded=true;
-      break;
-    }catch(err){
-      lastErr=err;
-    }
-  }
-  if(loaded){
+
+  const requestedBoard=boards.find(b=>canonicalBoardKey(b.name)===requested);
+  if(!requestedBoard){
+    toast("Board not found",`${requested} not found`,true);
+    window.__openBoardManager?.(requested||"new-board","list");
+    setStatus("Requested board not found");
     boardsBootstrapped=true;
     return;
   }
+
   try{
-    const remote=await fetchJson(boardFilePath(chosen.name));
+    const remote=await fetchJson(boardFilePath(requestedBoard.name));
     if(!isValidBoardData(remote)) throw new Error("Invalid repo board payload");
-    applyImportedBoard(remote, "repo fallback");
+    startupBoardName=requestedBoard.name;
+    setBoardKey(requestedBoard.name); currentBoardKey=canonicalBoardKey(requestedBoard.name); updateKeyLabel();
+    applyImportedBoard(remote, "repo");
+    const repoTs=Number(requestedBoard.lastUpdated||0);
+    const remoteTs=getBoardLastModified(remote);
+    const next=loadCacheMeta();
+    next[currentBoardKey]={lastUpdated:String(Math.max(repoTs, remoteTs, Date.now()))};
+    saveCacheMeta(next);
+    clearRepoLoadBlocked();
+    setStatus(`Loaded ${requestedBoard.name} from repo`);
+    boardsBootstrapped=true;
+    return;
   }catch(err){
-    setRepoLoadBlocked(lastErr||err);
-    const msg=document.createElement("div");
-    msg.className="empty-boarding";
-    msg.textContent=`No active boards could be loaded from repo. Open Board Manager to create/import. Last error: ${(lastErr||err)?.message||"unknown"}`;
-    document.getElementById("board").appendChild(msg);
-    window.__openBoardManager?.(chosen?.name||"new-board");
+    setRepoLoadBlocked(err);
+    toast("Board not found",`${requested} not found`,true);
+    window.__openBoardManager?.(requested||"new-board","list");
+    setStatus(`Requested board failed to load: ${err.message}`);
   }
   boardsBootstrapped=true;
 }


### PR DESCRIPTION
### Motivation
- Implement the requested UX: do not cycle through boards on startup and make URL-driven board loading deterministic.
- If the URL contains `?board=...` only attempt to load that board and show a clear recovery path when it is missing or fails to load.
- If the URL has no `?board` parameter, render a blank board using control-panel defaults and surface the Board Manager for user selection.

### Description
- Extended `__openBoardManager` signature to `(__openBoardManager(name="new-board", tab="new"))` so callers can open specific tabs (list/new/import) programmatically and used `setBoardTab(tab)` when showing it in startup flows.
- Reworked `bootstrapBoardsLifecycle()` to branch on `hasBoardQueryParam`: when `false` it initializes a blank `state`, calls `render()`, shows a welcome message, and opens the Board Manager on the `list` tab.
- When a `?board` parameter is present the code now looks up only the requested board in the repo index and, if not found, shows a toast `"<board> not found"` and opens Board Manager on the `list` tab (no fallback to last-seen/active/other boards).
- When the requested board is found the code attempts a single authoritative fetch of that board, applies it on success and updates cache/meta/status, and on fetch/parse failure sets repo load blocked, toasts the not-found message, and opens Board Manager on the `list` tab.
- Single file changed: `kanban.html`.

### Testing
- Ran `git -C /workspace/stuff status --short` to confirm file changes and it completed successfully.
- Ran `git -C /workspace/stuff diff -- kanban.html | head -n 120` to inspect the diff and it completed successfully.
- Staged and committed the change with `git -C /workspace/stuff add kanban.html && git -C /workspace/stuff commit -m "Update board startup behavior for URL param and blank default"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9cced92c832d80b663f44aae18a4)