### PR TITLE
Fix inline pulldown widths and remove lane chip

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -103,8 +103,8 @@ main#board[data-layout="vertical"] .card{margin-inline:6px}
 .card-line{display:flex;align-items:center;gap:8px;flex-wrap:nowrap;width:100%;min-width:0;justify-content:flex-start}
 .card-line{padding-right:26px}
 .card-title{font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:0 1 auto;min-width:0;max-width:100%;border:none;background:transparent;padding:0;text-align:left;cursor:pointer;color:#1f6feb}
-.card-platform,.card-lineage,.card-stage{font-size:12px;color:var(--muted);border:1px solid var(--border);padding:2px 8px;border-radius:999px;flex:1 1 0;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.card-platform.tag-search-btn,.card-lineage.tag-search-btn,.card-stage.tag-search-btn{color:#1f6feb}
+.card-platform,.card-lineage{font-size:12px;color:var(--muted);border:1px solid var(--border);padding:2px 8px;border-radius:999px}
+.card-platform.tag-search-btn,.card-lineage.tag-search-btn{color:#1f6feb}
 .card-edit-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px}
 .card-links{display:inline-flex;align-items:center;gap:8px;position:relative;z-index:1;flex:0 0 auto}
 .card-status-btn{border:1px solid var(--border);background:#fff;padding:0;display:inline-flex;align-items:center;justify-content:center;color:#6b7280;cursor:pointer;flex:0 0 auto;border-radius:999px;width:14px;height:14px}
@@ -129,6 +129,9 @@ main#board[data-layout="vertical"] .card{margin-inline:6px}
 .card-edit-field label{font-size:11px;color:var(--muted);font-weight:600}
 .card-edit-field input,.card-edit-field select,.card-edit-field textarea{width:100%;border:1px solid var(--border);border-radius:8px;padding:6px 8px;font:inherit;background:#fff;color:inherit}
 .card-edit-field select{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.card-edit-pulldowns{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px;grid-column:1/-1;min-width:0}
+.card-edit-pulldowns .card-edit-field{min-width:0;overflow:hidden}
+.card-edit-pulldowns .card-edit-field select{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .card-edit-field textarea{resize:vertical;min-height:72px}
 .card-edit-field input,.card-edit-field textarea,.card-edit-field select,
 .field input,.field textarea,.field select,
@@ -1174,11 +1177,9 @@ function renderCard(card){
   const tagsRow=document.createElement("div"); tagsRow.className="card-tags";
   const p=document.createElement("button"); p.type="button"; p.className="chip card-platform tag-search-btn"; p.textContent=card.platform; p.title=`Search platform: ${card.platform}`;
   p.addEventListener("click",(e)=>{ e.stopPropagation(); applyTagSearch(card.platform); });
-  const stageChip=document.createElement("button"); stageChip.type="button"; stageChip.className="chip card-stage tag-search-btn"; stageChip.textContent=card.stage; stageChip.title=`Search lane: ${card.stage}`;
-  stageChip.addEventListener("click",(e)=>{ e.stopPropagation(); applyTagSearch(card.stage); });
   const lineageChip=document.createElement("button"); lineageChip.type="button"; lineageChip.className="chip card-lineage tag-search-btn"; lineageChip.textContent=normalizeLineage(card.lineage); lineageChip.title=`Search lineage: ${normalizeLineage(card.lineage)}`;
   lineageChip.addEventListener("click",(e)=>{ e.stopPropagation(); applyTagSearch(normalizeLineage(card.lineage)); });
-  tagsRow.append(p,stageChip,lineageChip);
+  tagsRow.append(p,lineageChip);
   if(card.tags?.length){
     card.tags.forEach(t=>{
       const chip=document.createElement("button");
@@ -1400,11 +1401,17 @@ function renderCard(card){
   attachmentsWrap.addEventListener("pointerup", e=>e.stopPropagation());
   renderInlineAttachments();
 
-  grid.append(
-    makeField("Title", titleInput, true),
+  const pulldownRow=document.createElement("div");
+  pulldownRow.className="card-edit-pulldowns";
+  pulldownRow.append(
     makeField("Platform", platformSelect),
     makeField("Lane", stageSelect),
-    makeField("Lineage", lineageSelect),
+    makeField("Lineage", lineageSelect)
+  );
+
+  grid.append(
+    makeField("Title", titleInput, true),
+    pulldownRow,
     makeField("Dev Link", devInput),
     makeField("Live Link", liveInput),
     makeField("Tags", inlineTagEditor, true),   // NEW: replaced tagsInput


### PR DESCRIPTION
### Motivation
- Prevent long values in the inline card editor from expanding the pulldown row and producing mixed-size pulldowns. 
- Restore the intended chip model so `Lane` is not rendered as a chip while `Platform` and `Lineage` remain searchable chips. 

### Description
- Remove the lane/stage chip from the card metadata rendering so only `Platform` and `Lineage` chips are created and remain wired to `applyTagSearch(...)`.
- Add a `.card-edit-pulldowns` wrapper and CSS rules to enforce a 3-column equal-width layout with truncation safeguards (`min-width:0`, `overflow:hidden`, `text-overflow:ellipsis`, `white-space:nowrap`) and apply identical width behavior to each pulldown select.
- Group the three inline editor pulldowns into the new `pulldownRow` (`div.card-edit-pulldowns`) so `Platform`, `Lane`, and `Lineage` render on a single row with identical sizing, leaving unrelated code paths unchanged.

### Testing
- Verified the produced diff targeted only `kanban.html` and showed the intended CSS/DOM edits using `git diff -- kanban.html`, which succeeded.
- Verified there were no other workspace changes via `git status --short`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fde342360832d9d2e402e2bd81cc9)