### PR TITLE
Fix pointer capture/release for touch/pen card dragging

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -904,11 +904,11 @@ function hasActiveTextSelection(){
 function isTextSelectableCardTarget(target){
   return !!targetClosest(target,'.card-detail,.live-notes-preview,.attachment-list,.attachment-item,.attachment-link,.card-tags,.chip');
 }
-function pointerFromCardStart(card, e){
+function pointerFromCardStart(cardEl, card, e){
   if(e.pointerType==="mouse") return;
   if(isInteractiveCardTarget(e.target) || isTextSelectableCardTarget(e.target) || hasActiveTextSelection()) return;
   pointerDrag={id:card.id,pointerId:e.pointerId,startX:e.clientX,startY:e.clientY,startAt:Date.now(),active:false};
-  card.setPointerCapture?.(e.pointerId);
+  cardEl.setPointerCapture?.(e.pointerId);
 }
 function pointerFromCardMove(cardEl, e){
   if(!pointerDrag || pointerDrag.pointerId!==e.pointerId) return;
@@ -927,6 +927,7 @@ function pointerFromCardEnd(cardEl, e){
   const wasActive=pointerDrag.active;
   const dragId=pointerDrag.id;
   const endTarget=e.target;
+  cardEl.releasePointerCapture?.(e.pointerId);
   pointerDrag=null;
   cardEl.classList.remove("dragging");
   draggingId=null;
@@ -1097,7 +1098,7 @@ function renderCard(card){
     e.dataTransfer.effectAllowed="move";
   });
   el.addEventListener("dragend", ()=>{ draggingId=null; el.classList.remove("dragging"); setHighlight(null); });
-  el.addEventListener("pointerdown", (e)=> pointerFromCardStart(card, e));
+  el.addEventListener("pointerdown", (e)=> pointerFromCardStart(el, card, e));
   el.addEventListener("pointermove", (e)=> pointerFromCardMove(el, e));
   el.addEventListener("pointerup", (e)=> pointerFromCardEnd(el, e));
   el.addEventListener("pointercancel", (e)=> pointerFromCardEnd(el, e));


### PR DESCRIPTION
### Motivation
- Pointer capture was being called on the wrong variable when starting and ending pointer drags, which could cause errors for touch/pen interactions and prevent proper drag behavior.

### Description
- Change `pointerFromCardStart` signature to accept the card element as `cardEl` and use `cardEl.setPointerCapture` when initiating pointer capture.
- Add `cardEl.releasePointerCapture` to `pointerFromCardEnd` to properly release pointer capture when a drag ends.
- Update the `pointerdown` listener in `renderCard` to pass the element (`el`) into `pointerFromCardStart` so the DOM element is used for capture operations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1399b07090832db93c400e40daa32d)