### PR TITLE
Upgrade kanban-manager with left board management, actions panel drops, and attribute normalization

### DIFF
--- a/kanban-manager.html
+++ b/kanban-manager.html
@@ -3,58 +3,88 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Kanban Program Manager</title>
+<title>Kanban Manager</title>
 <style>
-body{margin:0;font-family:system-ui;background:#f3f6fb;color:#0f172a}header{padding:10px 12px;border-bottom:1px solid #d7deea;background:#fff;display:flex;gap:8px;align-items:center;position:sticky;top:0}.shell{display:grid;grid-template-columns:300px 1fr;height:calc(100vh - 52px)}aside{border-right:1px solid #d7deea;background:#fff;display:flex;flex-direction:column}main{padding:10px;overflow:auto}.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}input,select,button{border:1px solid #d7deea;border-radius:8px;padding:8px;background:#fff}.boards{overflow:auto;padding:8px;display:flex;flex-direction:column;gap:6px}.board{padding:8px;border:1px solid #d7deea;border-radius:8px;background:#fff;cursor:pointer}.board.active{border-color:#2563eb;background:#eff6ff}.lane{border:1px solid #d7deea;border-radius:8px;padding:8px;min-height:110px;background:#fff}.lane h4{margin:0 0 8px}.cards{display:flex;flex-direction:column;gap:6px}.card{border:1px solid #d7deea;border-radius:8px;padding:6px;background:#fff;cursor:grab}.muted{color:#64748b;font-size:12px}.grid{display:grid;gap:10px}.lanes{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}.matrix{grid-template-columns:150px repeat(3,minmax(180px,1fr))}.head{font-weight:700;font-size:12px;color:#64748b;text-transform:uppercase}.chip{font-size:11px;border:1px solid #d7deea;border-radius:999px;padding:2px 8px;cursor:pointer}.modal{position:fixed;inset:0;background:rgba(2,6,23,.45);display:none;align-items:center;justify-content:center}.modal.open{display:flex}.modal-card{background:#fff;border-radius:10px;padding:12px;width:min(720px,95vw)}.form{display:grid;grid-template-columns:1fr 1fr;gap:8px}.form .full{grid-column:1/-1}
+:root{--bg:#f4f7fb;--panel:#fff;--muted:#64748b;--line:#d7deea;--accent:#2563eb;--danger:#b91c1c}
+*{box-sizing:border-box}body{margin:0;font-family:system-ui;background:var(--bg);color:#0f172a}button,input,select{font:inherit}
+.app{display:grid;grid-template-columns:360px 1fr 320px;height:100vh}
+.left,.right{border-right:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;overflow:hidden}.right{border-right:0;border-left:1px solid var(--line)}
+.main{display:flex;flex-direction:column;min-width:0}
+.section{padding:10px;border-bottom:1px solid var(--line)}
+.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}input,select,button{border:1px solid var(--line);border-radius:8px;padding:7px;background:#fff}
+.tabbtn{padding:4px 8px}.tabbtn.active{border-color:var(--accent);color:var(--accent)}
+.boards{overflow:auto;padding:8px;display:flex;flex-direction:column;gap:6px}.board{padding:8px;border:1px solid var(--line);border-radius:8px;display:flex;align-items:center;gap:6px}.board.active{border-color:var(--accent);background:#eff6ff}
+.board .name{flex:1;cursor:pointer}.icon{border:0;background:transparent;cursor:pointer;color:#334155}
+.muted{color:var(--muted);font-size:12px}
+.top{padding:10px;border-bottom:1px solid var(--line);display:flex;gap:8px;align-items:center;flex-wrap:wrap;background:#fff}
+.view{padding:10px;overflow:auto}.lanes{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:10px}
+.lane{background:#fff;border:1px solid var(--line);border-radius:8px;min-height:140px;padding:8px}.lane h4{margin:0 0 8px}
+.card{background:#fff;border:1px solid var(--line);border-radius:8px;padding:6px;margin:0 0 6px;cursor:grab}
+.card .title{font-weight:700;color:var(--accent);cursor:pointer}
+.chip{display:inline-block;padding:1px 7px;border:1px solid var(--line);border-radius:999px;font-size:11px;margin:2px}
+.right h3{margin:0}.target{padding:8px;border:1px solid var(--line);border-radius:8px;margin-top:8px}.drop{min-height:60px;background:#f8fafc;border-radius:8px;padding:6px}
+.target.active{border-color:var(--accent)}
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.35);display:none;align-items:center;justify-content:center}.modal.open{display:flex}
+.modal .box{background:#fff;padding:12px;border-radius:10px;width:min(800px,96vw)}.form{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.full{grid-column:1/-1}
 </style>
 </head>
 <body>
-<header>
-  <strong>Kanban Program Manager</strong>
-  <button id="reloadBtn">Reload</button><button id="saveBtn">Download JSON</button>
-  <span id="status" class="muted">Ready</span>
-</header>
-<div class="shell">
-  <aside>
-    <div class="row" style="padding:8px">
-      <input id="boardSearch" placeholder="Omnisearch boards (-term exclude)" style="flex:1"/>
+<div class="app">
+  <aside class="left">
+    <div class="section">
+      <div class="row"><strong>Kanban Manager</strong><button id="gear" style="margin-left:auto">⚙️</button></div>
+      <div class="row" style="margin-top:8px"><button class="tabbtn active">List</button><button class="tabbtn">New</button><button class="tabbtn">Import</button></div>
+      <input id="boardSearch" placeholder="Board omnisearch (-exclude)" style="margin-top:8px;width:100%"/>
     </div>
     <div class="boards" id="boards"></div>
   </aside>
-  <main>
-    <div class="row" style="margin-bottom:8px">
-      <select id="tabSel"><option>LANE</option><option>STAGE</option><option>PHASE</option><option>MATRIX</option></select>
+  <main class="main">
+    <div class="top">
+      <select id="tab"><option>LANE</option><option>STAGE</option><option>PHASE</option><option>MATRIX</option></select>
+      <select id="fx"></select><select id="fy"></select>
       <select id="fltPlatform"></select><select id="fltStatus"></select><select id="fltTurn"></select>
-      <input id="cardSearch" placeholder="Omnisearch cards" style="min-width:260px"/>
+      <input id="cardSearch" placeholder="Card omnisearch" style="min-width:220px;flex:1"/>
+      <button id="newCard">+ Card</button><button id="save">Export JSON</button>
     </div>
-    <div id="view"></div>
+    <div class="view" id="view"></div>
   </main>
+  <aside class="right section">
+    <h3>Actions Panel</h3><div class="muted">Select board + lane target, then drop a card here.</div>
+    <div id="targets"></div>
+  </aside>
 </div>
-<div class="modal" id="cardModal"><div class="modal-card"><div class="row"><strong id="mTitle">Card</strong><button id="closeM" style="margin-left:auto">Close</button></div><div id="mForm" class="form"></div></div></div>
+<div class="modal" id="cardModal"><div class="box"><div class="row"><strong id="mt">Card</strong><button id="close" style="margin-left:auto">Close</button></div><div class="form" id="mf"></div></div></div>
+<div class="modal" id="settings"><div class="box"><div class="row"><strong>Control Panel</strong><button id="closeS" style="margin-left:auto">Close</button></div><p class="muted">Attribute order: DevPlatform, Lanes, Status, Stage, Turn, Phase.</p></div></div>
 <script>
 const DATA_FILE='kanban-manager.json';
 const DEVPLATFORMS=['OC','CC','Codex','ChatGpt','Gemini','Perpelxity','Other'];
+const STATUSES=['Dev','Tst','Prod'];
 const STAGES=['Pre-Base','Base','Pre-Ship','Ship','Post-Ship'];
 const TURNS=['Turn01','Turn02','Turn03','Turn04','Turn05','Turn06','Turn07','Turn08','Turn09','Turn10'];
 const PHASES=['Concept','Alpha','Pilot','Beta','Launch V1','Launch V2','Launch V3','Launch V4','Launch V5','Launch V6','Launch V7','Launch V8','Launch V9','Launch V10'];
-const STATUSES=['Dev','Tst','Prod'];
-let data={controlPanel:{lanes:['Doing','Done','Backlog'],stages:STAGES,phases:PHASES,devPlatforms:DEVPLATFORMS,statuses:STATUSES,turns:TURNS},boards:[]},activeBoardId='';
-const $=s=>document.querySelector(s); const byId=id=>data.boards.find(b=>b.boardId===id);
-function defaults(c,b){c.devPlatform=c.devPlatform||DEVPLATFORMS[0];c.status=c.status||STATUSES[0];c.stage=c.stage||STAGES[0];c.turn=c.turn||TURNS[0];c.phase=c.phase||PHASES[0];c.lane=c.lane||data.controlPanel.lanes[0];c.boardId=b.boardId;c.boardName=b.boardName;return c}
-async function boot(){const r=await fetch(DATA_FILE,{cache:'no-store'});data=await r.json();data.boards.forEach(b=>{b.cards=(b.cards||[]).map(c=>defaults(c,b));});activeBoardId=data.boards[0]?.boardId||'';fillFilters();render();}
-function fillFilters(){[['#fltPlatform',['All',...DEVPLATFORMS]],['#fltStatus',['All',...STATUSES]],['#fltTurn',['All',...TURNS]]].forEach(([id,list])=>{$(id).innerHTML=list.map(v=>`<option>${v}</option>`).join('')});}
-function passText(text,q){if(!q.trim())return true;let inc=q.toLowerCase().split(/\s+/).filter(Boolean);for(const t of inc){if(t.startsWith('-')&&text.includes(t.slice(1)))return false;if(!t.startsWith('-')&&!text.includes(t))return false;}return true}
-function filteredCards(board){let cards=[...(board?.cards||[])];const p=$('#fltPlatform').value,s=$('#fltStatus').value,t=$('#fltTurn').value,q=$('#cardSearch').value.toLowerCase();return cards.filter(c=>(p==='All'||c.devPlatform===p)&&(s==='All'||c.status===s)&&(t==='All'||c.turn===t)&&passText((`${c.title} ${(c.tags||[]).join(' ')} ${c.status}`).toLowerCase(),q));}
-function renderBoards(){const q=$('#boardSearch').value.toLowerCase();const root=$('#boards');root.innerHTML='';data.boards.filter(b=>passText((b.boardName+' '+b.boardId).toLowerCase(),q)).forEach(b=>{const d=document.createElement('div');d.className='board'+(b.boardId===activeBoardId?' active':'');d.textContent=`${b.boardName} (${b.cards?.length||0})`;d.onclick=()=>{activeBoardId=b.boardId;render();};d.ondragover=e=>e.preventDefault();d.ondrop=e=>{const raw=e.dataTransfer.getData('text/cardref');if(!raw)return;const {boardId,cardId}=JSON.parse(raw);moveBoardCard(boardId,b.boardId,cardId)};root.append(d);});}
-function moveBoardCard(from,to,id){if(from===to)return;const a=byId(from),b=byId(to);const i=a.cards.findIndex(c=>c.id===id);if(i<0)return;const [card]=a.cards.splice(i,1);defaults(card,b);b.cards.push(card);render();}
-function render(){renderBoards();const b=byId(activeBoardId);const tab=$('#tabSel').value;$('#view').innerHTML='';if(!b)return; if(tab==='MATRIX') return renderMatrix(b); if(tab==='LANE') return renderByAttr(b,'lane',data.controlPanel.lanes); if(tab==='STAGE') return renderByAttr(b,'stage',data.controlPanel.stages); return renderByAttr(b,'phase',data.controlPanel.phases);}
-function renderByAttr(board,key,list){const cards=filteredCards(board),v=$('#view');const g=document.createElement('div');g.className='grid lanes';list.forEach(k=>{const lane=document.createElement('div');lane.className='lane';lane.innerHTML=`<h4>${k}</h4>`;const wrap=document.createElement('div');wrap.className='cards';cards.filter(c=>c[key]===k).forEach(c=>wrap.append(cardEl(c,board,key)));lane.append(wrap);lane.ondragover=e=>e.preventDefault();lane.ondrop=e=>{const {boardId,cardId}=JSON.parse(e.dataTransfer.getData('text/cardref'));const src=byId(boardId);const cd=(src.cards||[]).find(x=>x.id===cardId);if(cd){cd[key]=k; if(boardId!==board.boardId) moveBoardCard(boardId,board.boardId,cardId); render();}};g.append(lane)});v.append(g)}
-function cardEl(c,b,key){const d=document.createElement('div');d.className='card';d.draggable=true;d.ondragstart=e=>e.dataTransfer.setData('text/cardref',JSON.stringify({boardId:b.boardId,cardId:c.id}));d.innerHTML=`<div><strong class='ct'>${c.title}</strong></div><div class='muted'>${c.devPlatform} · ${c.status} · ${c.turn}</div><div>${(c.tags||[]).slice(0,4).map(t=>`<span class='chip'>${t}</span>`).join(' ')}</div>`;d.querySelector('.ct').onclick=(e)=>{e.stopPropagation();openModal(c,b)};return d}
-function renderMatrix(board){const attrs=[['lane',data.controlPanel.lanes],['stage',data.controlPanel.stages],['phase',data.controlPanel.phases],['devPlatform',DEVPLATFORMS],['status',STATUSES],['turn',TURNS]];const x=attrs[0], y=attrs[1]; const cards=filteredCards(board); const v=$('#view');const g=document.createElement('div');g.className='grid matrix';g.append(Object.assign(document.createElement('div'),{className:'head',textContent:`${y[0]} / ${x[0]}`}));x[1].slice(0,3).forEach(h=>g.append(Object.assign(document.createElement('div'),{className:'head',textContent:h})));y[1].slice(0,8).forEach(r=>{g.append(Object.assign(document.createElement('div'),{className:'head',textContent:r}));x[1].slice(0,3).forEach(c=>{const cell=document.createElement('div');cell.className='lane';cards.filter(k=>k[x[0]]===c&&k[y[0]]===r).forEach(k=>cell.append(cardEl(k,board,x[0])));g.append(cell);});});v.append(g)}
-function openModal(c,b){$('#cardModal').classList.add('open');$('#mTitle').textContent=`${b.boardName} · ${c.title}`;const fields=['title','lane','stage','phase','devPlatform','status','turn','tags'];$('#mForm').innerHTML=fields.map(f=>`<label>${f}<input data-f='${f}' value='${Array.isArray(c[f])?c[f].join(', '):(c[f]??'')}'/></label>`).join('')+"<label class='full'>notes<textarea data-f='notes'>"+(c.notes||"")+"</textarea></label>";$('#mForm').querySelectorAll('[data-f]').forEach(inp=>inp.onchange=()=>{const f=inp.dataset.f; c[f]=f==='tags'?inp.value.split(',').map(x=>x.trim()).filter(Boolean):inp.value; render();});}
-$('#closeM').onclick=()=>$('#cardModal').classList.remove('open');['#reloadBtn','#saveBtn','#boardSearch','#cardSearch','#tabSel','#fltPlatform','#fltStatus','#fltTurn'].forEach(id=>$(id).addEventListener('input',()=>id==='#reloadBtn'?boot():render()));
-$('#reloadBtn').onclick=()=>boot();
-$('#saveBtn').onclick=()=>{const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=DATA_FILE;a.click();URL.revokeObjectURL(a.href);$('#status').textContent='Downloaded JSON snapshot.';};
-boot().catch(e=>$('#status').textContent='Boot failed: '+e.message);
+let data={controlPanel:{devPlatforms:DEVPLATFORMS,lanes:['Doing','Done','Backlog'],statuses:STATUSES,stages:STAGES,turns:TURNS,phases:PHASES},boards:[]},activeBoardId='';
+const $=s=>document.querySelector(s),byId=id=>data.boards.find(b=>b.boardId===id);
+const seq=(v,list)=>list.includes(v)?v:list[0];
+function normalizeCard(c,b){c.devPlatform=seq(c.devPlatform,DEVPLATFORMS);c.lane=seq(c.lane,data.controlPanel.lanes);c.status=seq(c.status,STATUSES);c.stage=seq(c.stage,STAGES);c.turn=seq(c.turn,TURNS);c.phase=seq(c.phase,PHASES);c.boardId=b.boardId;c.boardName=b.boardName;return c;}
+function normalize(){data.controlPanel={devPlatforms:DEVPLATFORMS,lanes:data.controlPanel?.lanes?.length?data.controlPanel.lanes:['Doing','Done','Backlog'],statuses:STATUSES,stages:STAGES,turns:TURNS,phases:PHASES};data.boards=(data.boards||[]).filter(b=>!b.deleted).map(b=>({...b,cards:(b.cards||[]).map(c=>normalizeCard(c,b))}));if(!activeBoardId)activeBoardId=data.boards[0]?.boardId||'';}
+async function boot(){try{const r=await fetch(DATA_FILE,{cache:'no-store'});data=await r.json();}catch{}normalize();fillFilters();render();}
+function fillFilters(){[['#fltPlatform',['All',...DEVPLATFORMS]],['#fltStatus',['All',...STATUSES]],['#fltTurn',['All',...TURNS]],['#fx',['LANE','STAGE','PHASE','DEVPLATFORM','STATUS','TURN']],['#fy',['STAGE','PHASE','DEVPLATFORM','STATUS','TURN','LANE']]].forEach(([id,list])=>$(id).innerHTML=list.map(v=>`<option>${v}</option>`).join(''));}
+function passText(text,q){if(!q.trim())return true;for(const t of q.toLowerCase().split(/\s+/).filter(Boolean)){if(t.startsWith('-')&&text.includes(t.slice(1)))return false;if(!t.startsWith('-')&&!text.includes(t))return false;}return true}
+function filteredCards(b){const p=$('#fltPlatform').value,s=$('#fltStatus').value,t=$('#fltTurn').value,q=$('#cardSearch').value;return (b.cards||[]).filter(c=>(p==='All'||c.devPlatform===p)&&(s==='All'||c.status===s)&&(t==='All'||c.turn===t)&&passText(`${c.title} ${(c.tags||[]).join(' ')} ${c.notes||''}`.toLowerCase(),q));}
+function renderBoards(){const q=$('#boardSearch').value.toLowerCase();const root=$('#boards');root.innerHTML='';data.boards.filter(b=>passText((b.boardName+' '+b.boardId).toLowerCase(),q)).forEach(b=>{const d=document.createElement('div');d.className='board'+(b.boardId===activeBoardId?' active':'');d.innerHTML=`<div class='name'>${b.boardName}</div><span class='muted'>${b.cards.length}</span><button class='icon' title='rename'>✎</button><button class='icon' title='export'>⤓</button><button class='icon' title='soft delete'>🗑</button>`;d.querySelector('.name').onclick=()=>{activeBoardId=b.boardId;render();};d.querySelectorAll('.icon')[0].onclick=()=>{const n=prompt('Rename board',b.boardName);if(n){b.boardName=n;b.cards.forEach(c=>c.boardName=n);render();}};d.querySelectorAll('.icon')[1].onclick=()=>download(`${b.boardName}.json`,JSON.stringify(b,null,2));d.querySelectorAll('.icon')[2].onclick=()=>{b.deleted=true;if(activeBoardId===b.boardId)activeBoardId='';normalize();render();};d.ondragover=e=>e.preventDefault();d.ondrop=e=>{const raw=e.dataTransfer.getData('text/cardref');if(!raw)return;const {boardId,cardId}=JSON.parse(raw);moveCard(boardId,b.boardId,cardId,null)};root.append(d);});const add=document.createElement('button');add.textContent='+ New board';add.onclick=()=>{const name=prompt('Board name','New Board');if(!name)return;const id='b'+Date.now();data.boards.push({boardId:id,boardName:name,cards:[]});activeBoardId=id;render();};root.append(add);const imp=document.createElement('input');imp.type='file';imp.accept='application/json';imp.onchange=async e=>{const f=e.target.files[0];if(!f)return;const obj=JSON.parse(await f.text());if(obj.boardId){data.boards.push({...obj,deleted:false});}else if(obj.boards){data=obj;}normalize();render();};root.append(imp)}
+function renderTargets(){const root=$('#targets');root.innerHTML='';data.boards.forEach(b=>{const t=document.createElement('div');t.className='target';t.innerHTML=`<strong>${b.boardName}</strong><div class='muted'>Drop into lane:</div><div class='drop'></div>`;const drop=t.querySelector('.drop');data.controlPanel.lanes.forEach(l=>{const x=document.createElement('div');x.className='chip';x.textContent=l;x.ondragover=e=>e.preventDefault();x.ondrop=e=>{const raw=e.dataTransfer.getData('text/cardref');if(!raw)return;const {boardId,cardId}=JSON.parse(raw);moveCard(boardId,b.boardId,cardId,l)};drop.append(x)});root.append(t);});}
+function moveCard(from,to,id,lane){const a=byId(from),b=byId(to);if(!a||!b)return;const i=a.cards.findIndex(c=>c.id===id);if(i<0)return;const [c]=a.cards.splice(i,1);normalizeCard(c,b);if(lane)c.lane=lane;b.cards.push(c);render();}
+function cardEl(c,b){const d=document.createElement('div');d.className='card';d.draggable=true;d.ondragstart=e=>e.dataTransfer.setData('text/cardref',JSON.stringify({boardId:b.boardId,cardId:c.id}));d.innerHTML=`<div class='title'>${c.title}</div><div class='muted'>${c.devPlatform} · ${c.status} · ${c.turn}</div><div>${(c.tags||[]).slice(0,4).map(t=>`<span class='chip'>${t}</span>`).join('')}</div>`;d.querySelector('.title').onclick=()=>openModal(c,b);return d;}
+function renderBy(key,list){const b=byId(activeBoardId);if(!b)return;const cards=filteredCards(b),v=$('#view');v.innerHTML='';const wrap=document.createElement('div');wrap.className='lanes';list.forEach(k=>{const lane=document.createElement('div');lane.className='lane';lane.innerHTML=`<h4>${k}</h4>`;cards.filter(c=>c[key]===k).forEach(c=>lane.append(cardEl(c,b)));lane.ondragover=e=>e.preventDefault();lane.ondrop=e=>{const {boardId,cardId}=JSON.parse(e.dataTransfer.getData('text/cardref'));const src=byId(boardId);const cd=src.cards.find(x=>x.id===cardId);if(cd)cd[key]=k;if(boardId!==b.boardId)moveCard(boardId,b.boardId,cardId,null);else render();};wrap.append(lane)});v.append(wrap)}
+function renderMatrix(){const map={LANE:['lane',data.controlPanel.lanes],STAGE:['stage',STAGES],PHASE:['phase',PHASES],DEVPLATFORM:['devPlatform',DEVPLATFORMS],STATUS:['status',STATUSES],TURN:['turn',TURNS]};const X=map[$('#fx').value],Y=map[$('#fy').value],b=byId(activeBoardId);if(!b)return;const cards=filteredCards(b);const v=$('#view');v.innerHTML='';const tbl=document.createElement('table');tbl.border='1';tbl.cellPadding='6';tbl.style.borderCollapse='collapse';tbl.style.background='#fff';let h='<tr><th>'+Y[0]+' / '+X[0]+'</th>'+X[1].map(x=>`<th>${x}</th>`).join('')+'</tr>';Y[1].forEach(y=>{h+='<tr><th>'+y+'</th>'+X[1].map(x=>`<td>${cards.filter(c=>c[X[0]]===x&&c[Y[0]]===y).length}</td>`).join('')+'</tr>'});tbl.innerHTML=h;v.append(tbl)}
+function openModal(c,b){$('#cardModal').classList.add('open');$('#mt').textContent=`${b.boardName} · ${c.title}`;const f=['title','devPlatform','lane','status','stage','turn','phase','tags','notes'];$('#mf').innerHTML=f.map(k=>`<label class='${k==='notes'?'full':''}'>${k}<input data-k='${k}' value='${Array.isArray(c[k])?c[k].join(', '):(c[k]??'')}'/></label>`).join('');$$('#mf [data-k]').forEach(i=>i.onchange=()=>{const k=i.dataset.k;c[k]=k==='tags'?i.value.split(',').map(x=>x.trim()).filter(Boolean):i.value;normalizeCard(c,b);render();});}
+const $$=s=>Array.from(document.querySelectorAll(s));
+function render(){renderBoards();renderTargets();const t=$('#tab').value;if(t==='LANE')renderBy('lane',data.controlPanel.lanes);else if(t==='STAGE')renderBy('stage',STAGES);else if(t==='PHASE')renderBy('phase',PHASES);else renderMatrix();}
+function download(name,text){const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([text],{type:'application/json'}));a.download=name;a.click();URL.revokeObjectURL(a.href)}
+$('#close').onclick=()=>$('#cardModal').classList.remove('open');$('#gear').onclick=()=>$('#settings').classList.add('open');$('#closeS').onclick=()=>$('#settings').classList.remove('open');
+['#boardSearch','#cardSearch','#tab','#fltPlatform','#fltStatus','#fltTurn','#fx','#fy'].forEach(id=>$(id).addEventListener('input',render));
+$('#newCard').onclick=()=>{const b=byId(activeBoardId);if(!b)return;const c=normalizeCard({id:'c'+Date.now(),title:'New Card',tags:[]},b);b.cards.unshift(c);render();};
+$('#save').onclick=()=>download(DATA_FILE,JSON.stringify(data,null,2));
+boot();
 </script>
 </body></html>


### PR DESCRIPTION
### Motivation
- Unify the navigation pattern from `repo-live-lineage-v4.html` with the full kanban functionality present in `kanban.html` so users can manage boards from the left and use an actions panel to drop cards to board+lane targets.
- Ensure every card stores the full set of required attributes and add deterministic backfill/conversion logic so older data is normalized into the new attribute sequence (`DevPlatform`, `Lanes`, `Status`, `Stage`, `Turn`, `Phase`).

### Description
- Reworked `kanban-manager.html` into a 3-pane layout with a left board management column, center kanban view and filters, and a right Actions Panel exposing board+lane drop targets and a control-gear modal for the control panel.
- Implemented left-panel board operations including board list/search (omnisearch with `-exclude`), new board creation, rename prompt, soft-delete, per-board export, and JSON import hooks.
- Ported and extended drag/drop behavior so cards can be moved across lanes, across boards by dropping onto board rows, and directly to a selected board+lane via the Actions Panel; added UI targets with drop handlers and `moveCard` logic.
- Added card edit modal that exposes and persists fields `title`, `devPlatform`, `lane`, `status`, `stage`, `turn`, `phase`, `tags`, and `notes`, and keeps `boardId`/`boardName` synchronized at card level.
- Added data normalization with `normalizeCard` and `normalize` functions (uses `seq` fallback to first allowed value) and filter/matrix rendering with selectable X/Y attributes across the six dimensions.

### Testing
- Ran `git -C /workspace/stuff status --short` and it completed successfully.
- Added and committed the modified `kanban-manager.html` using `git -C /workspace/stuff add ... && git -C /workspace/stuff commit -m ...` and the commit succeeded.
- Printed the updated file head with `nl -ba /workspace/stuff/kanban-manager.html | sed -n '1,220p'` to inspect changes and it succeeded.
- Created the PR metadata via the `make_pr` helper and it returned the PR title/body payload successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a178636df84832d9a46e2f5d32b53f6)