### PR TITLE
Improve folder bulk and tile workflows

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -106,7 +106,7 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .acq-log{background:var(--raised);border-radius:var(--rs);padding:8px 11px;height:80px;overflow-y:auto;font-family:var(--mono);font-size:10px;color:var(--tm);line-height:1.9;margin-top:6px}
 .acq-log::-webkit-scrollbar{width:3px}
 .acq-log::-webkit-scrollbar-thumb{background:var(--hover)}
-.acq-ctrs{display:flex;gap:18px;font-family:var(--mono);font-size:11px;color:var(--ts);margin-bottom:6px}
+.acq-ctrs{display:flex;gap:18px;flex-wrap:wrap;font-family:var(--mono);font-size:11px;color:var(--ts);margin-bottom:6px}
 .acq-ctrs strong{color:var(--acc)}
 
 /* Enrollment banner */
@@ -170,7 +170,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 /* Bulk operations */
 #bulk-bar{display:flex;align-items:center;gap:8px;padding:5px 12px;background:var(--raised);border-bottom:1px solid var(--border);font-size:12px;color:var(--ts);flex-shrink:0}
 #bulk-bar.hidden{display:none}
-#bulk-count{color:var(--acc);font-weight:600;font-family:var(--mono);font-size:11px;margin-right:4px}
+#bulk-count{display:inline-flex;align-items:center;gap:7px;color:var(--acc);font-weight:600;font-family:var(--mono);font-size:11px;margin-right:4px;background:var(--acc-d);border:1px solid var(--bacc);border-radius:999px;padding:3px 8px}
+#bulk-count button{background:transparent;border:0;color:var(--acc);cursor:pointer;font:inherit;line-height:1;padding:0}
 .bulk-panel-body{display:flex;flex-direction:column;gap:10px;margin:12px 0;min-width:280px}
 .bulk-stack-row{display:flex;gap:8px;flex-wrap:wrap}
 .tag-editor{display:flex;flex-direction:column;gap:8px}.tag-list{display:flex;gap:6px;flex-wrap:wrap}.tag-pill{display:inline-flex;gap:5px;align-items:center;background:var(--acc-d);border:1px solid var(--bacc);color:var(--acc);border-radius:20px;padding:2px 8px;font-family:var(--mono);font-size:11px}.tag-pill button{background:transparent;border:none;color:inherit;cursor:pointer}.notes-editor{display:flex;flex-direction:column;gap:8px}.notes-editor textarea{min-height:100px;resize:vertical}.rating-row{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--ts)}
@@ -255,13 +256,30 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .ptl-btn{background:transparent;border:none;color:var(--tm);cursor:pointer;font-size:12px;padding:2px 4px;border-radius:3px;transition:all .15s}
 .ptl-btn:hover{background:var(--hover);color:var(--ts)}
 .ptl-btn.danger:hover{color:var(--red)}
-.ptl-content{flex:1 1 auto;display:flex;align-items:center;justify-content:center;background:var(--bg);overflow:hidden;min-height:80px}
-.ptl-content img{width:100%;height:100%;max-width:100%;max-height:100%;object-fit:contain}
+.ptl-content{flex:1 1 auto;display:flex;align-items:center;justify-content:center;background:var(--bg);overflow:hidden;min-height:80px;aspect-ratio:1/1}
+.ptl-content img,.ptl-content video{width:100%;height:100%;max-width:100%;max-height:100%;object-fit:contain;background:var(--bg)}
 .ptl-content-placeholder{text-align:center;padding:10px;color:var(--tm);font-size:11px}
 .ptl-foot{display:flex;align-items:center;gap:4px;padding:5px 8px;border-top:1px solid var(--border);background:var(--raised)}
 .ptl-stk{font-family:var(--mono);font-size:10px;flex:1}
 .ptl-fab{background:transparent;border:none;color:var(--acc);cursor:pointer;font-size:14px;padding:2px;transition:all .15s}
 .ptl-fab:hover{color:#fbbf24}
+
+
+/* Item workspace window */
+.item-win{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);width:min(920px,92vw);height:min(680px,86vh);min-width:360px;min-height:260px;background:var(--surface);border:1px solid var(--bmd);border-radius:14px;box-shadow:0 24px 72px rgba(0,0,0,.65);z-index:260;display:grid;grid-template-rows:auto auto 1fr;overflow:hidden;resize:both}
+.item-win.minimized{height:44px!important;min-height:44px;overflow:hidden;top:auto!important;bottom:36px;transform:none}
+.item-win.maximized{inset:8px!important;width:auto!important;height:auto!important;transform:none!important;resize:none}
+.item-titlebar{display:flex;align-items:center;gap:10px;padding:8px 10px;background:var(--raised);border-bottom:1px solid var(--border);cursor:move;user-select:none}
+.item-titlebar strong{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;color:var(--tp)}
+.item-win-btn{background:transparent;border:1px solid var(--border);color:var(--ts);border-radius:5px;width:26px;height:24px;cursor:pointer}
+.item-win-btn:hover{background:var(--hover);color:var(--tp)}
+.item-ribbon{display:flex;align-items:center;gap:6px;flex-wrap:wrap;padding:8px 10px;background:var(--surface);border-bottom:1px solid var(--border)}
+.item-ribbon .fav-on{background:var(--yel-d);border-color:var(--yel);color:var(--yel)}
+.item-body{display:grid;grid-template-columns:minmax(220px,1fr) 300px;gap:12px;padding:12px;min-height:0;overflow:auto}
+.item-media{display:flex;align-items:center;justify-content:center;background:var(--bg);border:1px solid var(--border);border-radius:var(--r);min-height:240px;overflow:hidden}
+.item-media img,.item-media video{max-width:100%;max-height:100%;object-fit:contain}.item-media audio{width:90%}.item-media iframe{width:100%;height:100%;min-height:360px;border:0}.item-media pre{max-height:100%;overflow:auto;padding:12px;white-space:pre-wrap;word-break:break-word;font:11px var(--mono);color:var(--ts)}
+.item-side{display:flex;flex-direction:column;gap:10px;min-width:0}.item-detail{display:flex;justify-content:space-between;gap:8px;font-size:11px}.item-detail span:first-child{color:var(--ts)}.item-detail span:last-child{font-family:var(--mono);text-align:right;word-break:break-all}
+.ptl-fav-icon{position:absolute;top:8px;right:8px;z-index:3;background:rgba(0,0,0,.55);border:1px solid var(--bmd);border-radius:999px;color:var(--tm);width:26px;height:26px;cursor:pointer}.ptl-fav-icon.on{color:var(--yel);background:var(--yel-d);border-color:var(--yel)}
 
 /* Empty state */
 .empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--tm);font-size:13px;gap:8px;padding:32px}
@@ -546,7 +564,7 @@ function showIndexingModal(){
   let ov=$id('acq-modal');
   if(!ov){
     ov=document.createElement('div');ov.id='acq-modal';ov.className='confirm-overlay acq-modal';
-    ov.innerHTML=`<div class="confirm-box"><div class="acq-head"><div class="acq-title">Indexing Folder</div><div style="display:flex;gap:6px"><button class="btn btn-ghost btn-sm" id="btn-acq-pause">Pause</button><button class="btn btn-pri btn-sm hidden" id="btn-acq-resume">Resume</button><button class="btn btn-danger btn-sm" id="btn-acq-cancel">Cancel</button></div></div><div class="acq-fname" id="acq-folder">Initializing…</div><div class="pb-wrap"><div class="pb-fill" id="acq-pb"></div></div><div class="acq-ctrs"><div>Folders: <strong id="acq-fc">0</strong></div><div>Files: <strong id="acq-ic">0</strong></div><div>Time: <strong id="acq-el">0s</strong></div></div><div class="acq-log" id="acq-log"></div></div>`;
+    ov.innerHTML=`<div class="confirm-box"><div class="acq-head"><div class="acq-title">Indexing Folder</div><div style="display:flex;gap:6px"><button class="btn btn-ghost btn-sm" id="btn-acq-pause">Pause</button><button class="btn btn-pri btn-sm hidden" id="btn-acq-resume">Resume</button><button class="btn btn-danger btn-sm" id="btn-acq-cancel">Cancel</button></div></div><div class="acq-fname" id="acq-folder">Initializing…</div><div class="pb-wrap"><div class="pb-fill" id="acq-pb"></div></div><div class="acq-ctrs"><div>Current: <strong id="acq-current">—</strong></div><div>Done: <strong id="acq-done">—</strong></div><div>Folders: <strong id="acq-fc">0</strong></div><div>Files: <strong id="acq-ic">0</strong></div><div>Time: <strong id="acq-el">0s</strong></div></div><div class="acq-log" id="acq-log"></div></div>`;
     document.body.appendChild(ov);
     $id('btn-acq-cancel')?.addEventListener('click',cancelIndexing);
     $id('btn-acq-pause')?.addEventListener('click',pauseIndexing);
@@ -581,7 +599,7 @@ function updateIntelSummary(){
   if(changed)summary+=' · changes detected';
   txt.textContent=summary;dot.className=changed?'dot-changed':'dot-indexed';
 }
-function updateBulkBar(){const bar=$id('bulk-bar');const count=$id('bulk-count');if(!bar)return;const n=st.ui.selectedIds.size;if(n===0){bar.classList.add('hidden');return;}bar.classList.remove('hidden');if(count)count.textContent=`${n} selected`;}
+function updateBulkBar(){const bar=$id('bulk-bar');const count=$id('bulk-count');if(!bar)return;const n=st.ui.selectedIds.size;if(n===0){bar.classList.add('hidden');return;}bar.classList.remove('hidden');if(count){count.innerHTML=`<span>${n} selected</span><button type="button" title="Deselect all">×</button>`;count.querySelector('button').addEventListener('click',()=>{st.ui.selectedIds.clear();updateBulkBar();RightPane.renderContent();});}}
 const TagService={
   normalize(tag){const t=String(tag||'').trim().replace(/^#+/,'').toLowerCase();return t?`#${t}`:'';},
   normalizeList(tags=[]){const out=[];(tags||[]).forEach(tag=>{const t=this.normalize(tag);if(t&&!out.includes(t))out.push(t);});return out;},
@@ -590,8 +608,8 @@ const TagService={
   allTags(){const set=new Set();Object.values(st.intel?.files||{}).forEach(f=>this.normalizeList(f.tags||[]).forEach(t=>set.add(t)));return [...set].sort((a,b)=>a.localeCompare(b));},
   async add(fileId,tag){await this.applyMany([fileId],tag);},
   async remove(fileId,tag){await this.removeMany([fileId],tag);},
-  async applyMany(fileIds,tag){const tags=this.split(tag).map(t=>this.normalize(t)).filter(Boolean);if(!tags.length)return;fileIds.forEach(id=>{const f=st.intel?.files?.[id];if(!f)return;const cur=this.normalizeList(f.tags||[]);tags.forEach(t=>{if(!cur.includes(t))cur.push(t);});f.tags=cur;});Intel.rollup(st.intel);if(st.providerType==='googledrive')await Promise.allSettled(fileIds.map(id=>{const f=st.intel?.files?.[id];return f&&st.provider.updateAppProperties(id,{slideboxTags:(f.tags||[]).join(',')});}).filter(Boolean));await Intel.save();},
-  async removeMany(fileIds,tag){const t=this.normalize(tag);if(!t)return;fileIds.forEach(id=>{const f=st.intel?.files?.[id];if(f)f.tags=this.normalizeList(f.tags||[]).filter(x=>x!==t);});Intel.rollup(st.intel);if(st.providerType==='googledrive')await Promise.allSettled(fileIds.map(id=>{const f=st.intel?.files?.[id];return f&&st.provider.updateAppProperties(id,{slideboxTags:(f.tags||[]).join(',')});}).filter(Boolean));await Intel.save();}
+  async applyMany(fileIds,tag){const tags=this.split(tag).map(t=>this.normalize(t)).filter(Boolean);if(!tags.length)return;fileIds.forEach(id=>{const f=st.intel?.files?.[id];if(!f)return;const cur=this.normalizeList(f.tags||[]);tags.forEach(t=>{if(!cur.includes(t))cur.push(t);});f.tags=cur;});Intel.rollup(st.intel);Intel.saveLocal();toast(`Tagged ${fileIds.length} item(s)`,'t-ok',1400);if(st.providerType==='googledrive')Promise.allSettled(fileIds.map(id=>{const f=st.intel?.files?.[id];return f&&st.provider.updateAppProperties(id,{slideboxTags:(f.tags||[]).join(',')});}).filter(Boolean)).then(()=>Intel.saveDebounced());else Intel.saveDebounced();},
+  async removeMany(fileIds,tag){const t=this.normalize(tag);if(!t)return;fileIds.forEach(id=>{const f=st.intel?.files?.[id];if(f)f.tags=this.normalizeList(f.tags||[]).filter(x=>x!==t);});Intel.rollup(st.intel);Intel.saveLocal();toast(`Updated ${fileIds.length} item(s)`,'t-ok',1400);if(st.providerType==='googledrive')Promise.allSettled(fileIds.map(id=>{const f=st.intel?.files?.[id];return f&&st.provider.updateAppProperties(id,{slideboxTags:(f.tags||[]).join(',')});}).filter(Boolean)).then(()=>Intel.saveDebounced());else Intel.saveDebounced();}
 };
 class TagEditorInstance{
   constructor(fileIds){this.fileIds=[...fileIds];this.el=document.createElement('div');this.el.className='tag-editor';this.render();}
@@ -611,7 +629,7 @@ const TagEditor={create(fileIds){return new TagEditorInstance(fileIds);}};
 function createNotesEditorElement(){const el=document.createElement('div');el.className='notes-editor';el.innerHTML='<textarea class="inp" placeholder="Notes…"></textarea><div class="rating-row"><span>Quality</span><input data-rate="qualityRating" type="range" min="0" max="5" value="0"><span class="mono">0</span></div><div class="rating-row"><span>Content</span><input data-rate="contentRating" type="range" min="0" max="5" value="0"><span class="mono">0</span></div>';el.querySelectorAll('input[type=range]').forEach(r=>{const v=r.nextElementSibling;r.addEventListener('input',()=>v.textContent=r.value);});return el;}
 class NotesEditorInstance{
   constructor(fileIds,{deferred=false}={}){this.fileIds=[...fileIds];this.deferred=deferred;this.el=createNotesEditorElement();const files=this.fileIds.map(id=>st.intel?.files?.[id]).filter(Boolean),same=k=>files.length&&files.every(f=>(f[k]||0)===(files[0][k]||0));const sameNotes=files.length&&files.every(f=>(f.notes||'')===(files[0].notes||''));this.el.querySelector('textarea').value=sameNotes?(files[0].notes||''):'';['qualityRating','contentRating'].forEach(k=>{const r=this.el.querySelector(`[data-rate="${k}"]`),val=same(k)?(files[0][k]||0):0;r.value=val;r.nextElementSibling.textContent=String(val);});if(!deferred){this.el.querySelector('textarea').addEventListener('blur',()=>this.commit());this.el.querySelectorAll('input[type=range]').forEach(r=>r.addEventListener('change',()=>this.commit()));}}
-  async commit(){const notes=this.el.querySelector('textarea').value;const qualityRating=parseInt(this.el.querySelector('[data-rate="qualityRating"]').value)||0;const contentRating=parseInt(this.el.querySelector('[data-rate="contentRating"]').value)||0;for(const id of this.fileIds){const f=st.intel?.files?.[id];if(f){f.notes=notes;f.qualityRating=qualityRating;f.contentRating=contentRating;}}Intel.rollup(st.intel);if(st.providerType==='googledrive')await Promise.allSettled(this.fileIds.map(id=>st.provider.updateAppProperties(id,{notes,qualityRating:String(qualityRating),contentRating:String(contentRating)})));await Intel.save();}
+  async commit(){const notes=this.el.querySelector('textarea').value;const qualityRating=parseInt(this.el.querySelector('[data-rate="qualityRating"]').value)||0;const contentRating=parseInt(this.el.querySelector('[data-rate="contentRating"]').value)||0;for(const id of this.fileIds){const f=st.intel?.files?.[id];if(f){f.notes=notes;f.qualityRating=qualityRating;f.contentRating=contentRating;}}Intel.rollup(st.intel);Intel.saveLocal();toast(`Updated ${this.fileIds.length} item(s)`,'t-ok',1400);if(st.providerType==='googledrive')Promise.allSettled(this.fileIds.map(id=>st.provider.updateAppProperties(id,{notes,qualityRating:String(qualityRating),contentRating:String(contentRating)}))).then(()=>Intel.saveDebounced());else Intel.saveDebounced();}
 }
 const NotesEditor={create(fileIds,opts){return new NotesEditorInstance(fileIds,opts);}};
 function showBulkPanel(type){
@@ -858,10 +876,11 @@ const Intel={
     if(onStep)onStep(rec?'Intelligence record loaded':'No existing record found',3);
     return rec;
   },
+  saveLocal(){if(!st.intel)return;st.intel.lastUpdated=Date.now();try{localStorage.setItem(LS_INTEL,JSON.stringify(st.intel));}catch(e){}},
+  saveDebounced(){clearTimeout(this._saveTimer);this._saveTimer=setTimeout(async()=>{try{if(st.intel)await st.provider.saveIntelligenceFile(st.intel);}catch(e){toast('Saved locally — cloud sync pending','t-err');}},450);},
   async save(){
     if(!st.intel)return;
-    st.intel.lastUpdated=Date.now();
-    try{localStorage.setItem(LS_INTEL,JSON.stringify(st.intel));}catch(e){}
+    this.saveLocal();
     try{await st.provider.saveIntelligenceFile(st.intel);}
     catch(e){toast('Saved locally — cloud write failed','t-err');}
   },
@@ -893,7 +912,7 @@ const Intel={
         }catch(e){}
       }
       const fname=rec.folders[fid].name;
-      onProg({folder:fname,fc:fScanned,ic:iCount});onLog(`▸ ${fname}`);
+      onProg({folder:fname,fc:fScanned,ic:iCount,done:[...visited].filter(id=>id!==fid).map(id=>rec.folders[id]?.name||id)});onLog(`▸ Indexing ${fname}`);
       let subs=[];try{subs=await p.getSubfolders(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
       subs.forEach(sf=>{
         if(!rec.folders[fid].children.includes(sf.id))rec.folders[fid].children.push(sf.id);
@@ -913,7 +932,7 @@ const Intel={
         iCount++;
       });
       folder.hash=simpleHash(hp.sort().join('|'));fScanned++;
-      onProg({folder:fname,fc:fScanned,ic:iCount});await sleep(0);
+      onProg({folder:fname,fc:fScanned,ic:iCount,done:[...visited].map(id=>rec.folders[id]?.name||id)});onLog(`✓ Done ${fname}`);await sleep(0);
     }
     this.computeDepths(rec);this.rollup(rec);st.intel=rec;return rec;
   },
@@ -1029,7 +1048,7 @@ const Timeline={
   dateOf(file){const d=new Date(file.effectiveDate||file.modifiedTime||file.createdTime||file.createdDateTime||file.lastModifiedDateTime);return isNaN(d)?null:d;},
   baseFiles(){if(!st.intel||!st.selFolderId||!st.selFolderEnrolled)return[];let files=Intel.getDescendantFiles(st.selFolderId);if(st.ui.search){const t=st.ui.search.toLowerCase();files=files.filter(f=>f.name.toLowerCase().includes(t));}if(st.ui.classFilter)files=files.filter(f=>f.class===st.ui.classFilter);if(st.ui.stackFilter)files=files.filter(f=>f.stack===st.ui.stackFilter);return files;},
   rangeFor(level,d){const y=d.getFullYear(),m=d.getMonth(),day=d.getDate();let a,b,label,next;if(level==='year'){a=new Date(y,0,1);b=new Date(y+1,0,1);label=String(y);next='month';}else if(level==='month'){a=new Date(y,m,1);b=new Date(y,m+1,1);label=a.toLocaleString(undefined,{month:'short',year:'numeric'});next='day';}else{a=new Date(y,m,day);b=new Date(y,m,day+1);label=String(day);next=null;}return{start:a.toISOString(),end:b.toISOString(),label,next};},
-  buckets(files){const level=st.ui.timelineLevel||'year',map=new Map();files.forEach(f=>{const d=this.dateOf(f);if(!d)return;const r=this.rangeFor(level,d),key=r.start,b=map.get(key)||{...r,count:0};b.count++;map.set(key,b);});return[...map.values()].sort((a,b)=>a.start.localeCompare(b.start));},
+  buckets(files){const level=st.ui.timelineLevel||'year',map=new Map();files.forEach(f=>{const d=this.dateOf(f);if(!d)return;const r=this.rangeFor(level,d),key=r.start,b=map.get(key)||{...r,count:0};b.count++;map.set(key,b);});return[...map.values()].sort((a,b)=>new Date(a.start)-new Date(b.start));},
   applyRange(files){const r=st.ui.timelineRange;if(!r)return files;return files.filter(f=>{const d=this.dateOf(f);return d&&d>=new Date(r.start)&&d<new Date(r.end);});},
   clear(){st.ui.timelineRange=null;st.ui.timelineLevel='year';st.ui.timelineBreadcrumbs=[];},
   render(){const box=$id('rp-timeline'),body=$id('timeline-body'),axis=$id('timeline-axis'),crumbs=$id('timeline-crumbs'),sum=$id('timeline-summary'),chev=$id('timeline-chevron');if(!box||!body||!axis||!crumbs)return;const base=this.baseFiles();box.classList.toggle('hidden',!base.length);body.classList.toggle('hidden',!st.ui.timelineOpen);if(chev)chev.textContent=st.ui.timelineOpen?'▼':'▶';if(sum)sum.textContent=st.ui.timelineRange?st.ui.timelineRange.label:`${base.length} dated`;crumbs.innerHTML='';axis.innerHTML='';const root=document.createElement('button');root.textContent='All';root.addEventListener('click',()=>{this.clear();RightPane.render();});crumbs.appendChild(root);(st.ui.timelineBreadcrumbs||[]).forEach((c,i)=>{const b=document.createElement('button');b.textContent=c.label;b.addEventListener('click',()=>{st.ui.timelineRange=c.range;st.ui.timelineLevel=c.next||'year';st.ui.timelineBreadcrumbs=st.ui.timelineBreadcrumbs.slice(0,i+1);RightPane.render();});crumbs.appendChild(b);});const buckets=this.buckets(base),max=Math.max(1,...buckets.map(b=>b.count));buckets.forEach(b=>{const btn=document.createElement('button');btn.className='timeline-bucket'+(st.ui.timelineRange?.start===b.start?' active':'');btn.title=`${b.label}: ${b.count}`;btn.innerHTML=`<span class="timeline-bar" style="height:${Math.max(8,Math.round((b.count/max)*38))}px"></span><span class="timeline-label">${esc(b.label)}</span>`;btn.addEventListener('click',()=>{st.ui.timelineRange={start:b.start,end:b.end,label:b.label};if(b.next){st.ui.timelineBreadcrumbs=[...(st.ui.timelineBreadcrumbs||[]),{label:b.label,range:st.ui.timelineRange,next:b.next}];st.ui.timelineLevel=b.next;}RightPane.render();});axis.appendChild(btn);});if(!buckets.length)axis.innerHTML='<div class="timeline-legend">No dates in current filters.</div>';}
@@ -1110,6 +1129,22 @@ const RightPane={
   },
 };
 
+
+// ── Item workspace window ─────────────────────────────────
+const ItemWindow={
+  open(fileId){
+    const file=st.intel?.files?.[fileId];if(!file)return;
+    document.querySelectorAll('.item-win').forEach(w=>w.remove());
+    const win=document.createElement('div');win.className='item-win';win.dataset.fid=fileId;
+    win.innerHTML=`<div class="item-titlebar"><strong>${esc(file.name)}</strong><button class="item-win-btn" data-win="min" title="Minimize">—</button><button class="item-win-btn" data-win="max" title="Maximize">□</button><button class="item-win-btn" data-win="close" title="Close">×</button></div><div class="item-ribbon"><button class="btn btn-ghost btn-sm" data-rib="details">Details</button><button class="btn btn-ghost btn-sm" data-rib="notes">Update Notes</button><button class="btn btn-ghost btn-sm" data-rib="tag">Tag</button><button class="btn btn-ghost btn-sm" data-rib="move">Move</button><button class="btn btn-danger btn-sm" data-rib="delete">Delete</button><button class="btn btn-ghost btn-sm ${file.favorite?'fav-on':''}" data-rib="favorite">${file.favorite?'★ Favorite':'☆ Favorite'}</button></div><div class="item-body"><div class="item-media"><div class="preview-no">Loading preview…</div></div><div class="item-side" data-side="details">${this.detailsHtml(file)}</div></div>`;
+    document.body.appendChild(win);this.wireWindow(win);this.wireRibbon(win,fileId);this.loadPreview(win,file);
+  },
+  detailsHtml(file){const rows=[['Name',file.name],['Type',(CLASS_DEF[file.class]||CLASS_DEF.other).label],['Size',fmtSizeMB(file.size)],['Date',fmtDate(file.effectiveDate)],['Stack',STACK_LABEL[file.stack]||'Inbox'],['Tags',(file.tags||[]).join(', ')||'—'],['Notes',file.notes||'—']];return rows.map(([k,v])=>`<div class="item-detail"><span>${esc(k)}</span><span>${esc(v)}</span></div>`).join('');},
+  wireWindow(win){const bar=win.querySelector('.item-titlebar');let drag=null;bar.addEventListener('pointerdown',e=>{if(e.target.closest('button'))return;const r=win.getBoundingClientRect();drag={dx:e.clientX-r.left,dy:e.clientY-r.top};win.style.transform='none';bar.setPointerCapture(e.pointerId);});bar.addEventListener('pointermove',e=>{if(!drag)return;win.style.left=Math.max(0,Math.min(window.innerWidth-80,e.clientX-drag.dx))+'px';win.style.top=Math.max(0,Math.min(window.innerHeight-44,e.clientY-drag.dy))+'px';});bar.addEventListener('pointerup',()=>drag=null);win.querySelector('[data-win="close"]').addEventListener('click',()=>win.remove());win.querySelector('[data-win="min"]').addEventListener('click',()=>win.classList.toggle('minimized'));win.querySelector('[data-win="max"]').addEventListener('click',()=>win.classList.toggle('maximized'));},
+  wireRibbon(win,fileId){const side=win.querySelector('[data-side]');win.querySelector('[data-rib="details"]').addEventListener('click',()=>{side.innerHTML=this.detailsHtml(st.intel.files[fileId]);});win.querySelector('[data-rib="tag"]').addEventListener('click',()=>{const ed=TagEditor.create([fileId]);side.innerHTML='';side.appendChild(ed.el);});win.querySelector('[data-rib="notes"]').addEventListener('click',()=>{const ed=NotesEditor.create([fileId],{deferred:true});side.innerHTML='';side.appendChild(ed.el);const b=document.createElement('button');b.className='btn btn-pri btn-sm';b.textContent='Save Notes';b.addEventListener('click',async()=>{await ed.commit();side.innerHTML=this.detailsHtml(st.intel.files[fileId]);RightPane.renderContent();});side.appendChild(b);});win.querySelector('[data-rib="move"]').addEventListener('click',()=>{side.innerHTML='<div class="bulk-stack-row"></div>';const row=side.querySelector('.bulk-stack-row');[['inbox','Inbox'],['keep','Keep'],['maybe','Maybe'],['trash','Recycle']].forEach(([stack,lbl])=>{const b=document.createElement('button');b.className='btn btn-ghost btn-sm';b.textContent=lbl;b.addEventListener('click',async()=>{await App.setStack(fileId,stack);RightPane.renderContent();side.innerHTML=this.detailsHtml(st.intel.files[fileId]);});row.appendChild(b);});});win.querySelector('[data-rib="delete"]').addEventListener('click',async()=>{await App.softDelete(fileId);win.remove();});win.querySelector('[data-rib="favorite"]').addEventListener('click',async e=>{await App.toggleFavorite(fileId);e.currentTarget.classList.toggle('fav-on',!!st.intel.files[fileId].favorite);e.currentTarget.textContent=st.intel.files[fileId].favorite?'★ Favorite':'☆ Favorite';RightPane.renderContent();});},
+  async loadPreview(win,file){const slot=win.querySelector('.item-media');const node=await App.fetchPreview(file,{large:true});if(!win.isConnected)return;slot.innerHTML='';if(node)slot.appendChild(node);else slot.innerHTML='<div class="preview-no">No preview available</div>';}
+};
+
 // ── List view ─────────────────────────────────────────────
 const ListView={
   render(files){
@@ -1168,7 +1203,7 @@ const ListView={
       }
       tr.appendChild(td);
     });
-    tr.addEventListener('click',e=>{if(e.target.closest('input'))return;this.toggleDrawer(file.id);});
+    tr.addEventListener('click',e=>{if(e.target.closest('input'))return;ItemWindow.open(file.id);});
     tbody.appendChild(tr);
   },
 
@@ -1231,21 +1266,23 @@ const PortalView={
     btnDel.draggable=false;btnDel.addEventListener('click',async e=>{e.stopPropagation();await App.softDelete(file.id);});
     acts.appendChild(btnDel);bar.appendChild(nameEl);bar.appendChild(acts);
     // Content
+    const fav=document.createElement('button');fav.className='ptl-fav-icon'+(file.favorite?' on':'');fav.textContent=file.favorite?'★':'☆';fav.title='Toggle favorite';fav.addEventListener('click',async e=>{e.stopPropagation();await App.toggleFavorite(file.id);RightPane.renderContent();});
     const contentEl=document.createElement('div');contentEl.className='ptl-content';contentEl.style.height=cardH+'px';
     if(file.thumbnailUrl){const img=document.createElement('img');img.src=file.thumbnailUrl;contentEl.appendChild(img);}
+    else if(file.class==='video'){const vid=document.createElement('video');App.getStreamUrl(file).then(url=>{if(url)vid.src=url;}).catch(()=>{});vid.muted=true;vid.playsInline=true;vid.preload='metadata';contentEl.appendChild(vid);}
     else{const ph=document.createElement('div');ph.className='ptl-content-placeholder';ph.innerHTML=`<div style="font-size:${cols<=2?38:22}px;margin-bottom:4px">${this.classIcon(file.class)}</div><div style="font-size:10px;color:var(--tm)">${def.label}</div>`;contentEl.appendChild(ph);}
     if(cols<=2){
       bar.style.cursor='grab';
       nameEl.style.whiteSpace='normal';nameEl.style.textOverflow='clip';nameEl.style.overflow='visible';
-      card.appendChild(cardCb);card.appendChild(contentEl);card.appendChild(bar);
+      card.appendChild(cardCb);card.appendChild(fav);card.appendChild(contentEl);card.appendChild(bar);
     }else if(cols>=7){
       bar.style.display='none';
-      card.appendChild(cardCb);card.appendChild(contentEl);
-      card.addEventListener('click',e=>{if(e.target.closest('input,button'))return;const oldTip=card.querySelector('.ptl-tooltip');if(oldTip)oldTip.remove();const tip=document.createElement('div');tip.className='ptl-tooltip';tip.textContent=file.name;card.appendChild(tip);setTimeout(()=>tip.remove(),1500);});
+      card.appendChild(cardCb);card.appendChild(fav);card.appendChild(contentEl);
     }else{
       nameEl.style.whiteSpace='nowrap';nameEl.style.overflow='hidden';nameEl.style.textOverflow='ellipsis';
-      card.appendChild(cardCb);card.appendChild(bar);card.appendChild(contentEl);
+      card.appendChild(cardCb);card.appendChild(fav);card.appendChild(bar);card.appendChild(contentEl);
     }
+    card.addEventListener('click',e=>{if(e.target.closest('input,button'))return;ItemWindow.open(file.id);});
     return card;
   },
   classIcon(cls){return{image:'🖼',video:'🎬',audio:'🎵',document:'📄',office:'📊',web:'🌐',text:'📝',code:'💻',archive:'📦',other:'📎'}[cls]||'📎';},
@@ -1360,11 +1397,11 @@ const App={
     showIndexingModal();
     st.acq={running:true,cancelled:false,paused:false,t0:Date.now(),tick:null,folderId};
     st.acqJobs[folderId]={...(activeJob||{}),running:true,cancelled:false,paused:false,lastFolder:folderName};
-    $id('acq-log').innerHTML='';$id('acq-pb').style.width='0%';$id('acq-fc').textContent='0';$id('acq-ic').textContent='0';$id('acq-el').textContent='0s';
+    $id('acq-log').innerHTML='';$id('acq-pb').style.width='0%';$id('acq-fc').textContent='0';$id('acq-ic').textContent='0';$id('acq-el').textContent='0s';$id('acq-current').textContent='—';$id('acq-done').textContent='—';
     st.acq.tick=setInterval(()=>{const el=$id('acq-el');if(el)el.textContent=Math.round((Date.now()-st.acq.t0)/1000)+'s';updateIntelSummary();},1000);
-    const onProg=({folder,fc,ic})=>{
-      const fn=$id('acq-folder'),fc2=$id('acq-fc'),ic2=$id('acq-ic'),pb=$id('acq-pb');
-      if(fn)fn.textContent=folder||'…';if(fc2)fc2.textContent=fc;if(ic2)ic2.textContent=ic;
+    const onProg=({folder,fc,ic,done=[]})=>{
+      const fn=$id('acq-folder'),fc2=$id('acq-fc'),ic2=$id('acq-ic'),pb=$id('acq-pb'),cur=$id('acq-current'),doneEl=$id('acq-done');
+      if(fn)fn.textContent=folder||'…';if(cur)cur.textContent=folder||'…';if(doneEl)doneEl.textContent=done.length?done.slice(-3).join(' → '):'—';if(fc2)fc2.textContent=fc;if(ic2)ic2.textContent=ic;
       if(pb)pb.style.width=Math.min(99,Math.round(ic/Math.max(1,ic+1)*50+fc*2))+'%';
       const thinBar=$id('intel-progress-bar-thin');if(thinBar&&pb)thinBar.style.width=pb.style.width;
       updateIntelSummary();
@@ -1408,9 +1445,8 @@ const App={
 
   async setStackMany(fileIds,stack){
     fileIds.forEach(id=>{if(st.intel?.files?.[id])st.intel.files[id].stack=stack;});
-    Intel.rollup(st.intel);
-    if(st.providerType==='googledrive')await Promise.allSettled(fileIds.map(id=>st.provider.updateAppProperties(id,{slideboxStack:STACK_TO_AP[stack]||'in'})));
-    await Intel.save();toast(`Moved ${fileIds.length} to ${STACK_LABEL[stack]}`);
+    Intel.rollup(st.intel);Intel.saveLocal();toast(`Moved ${fileIds.length} to ${STACK_LABEL[stack]}`,'t-ok',1400);
+    if(st.providerType==='googledrive')Promise.allSettled(fileIds.map(id=>st.provider.updateAppProperties(id,{slideboxStack:STACK_TO_AP[stack]||'in'}))).then(()=>Intel.saveDebounced());else Intel.saveDebounced();
   },
 
   async toggleFavorite(fileId){
@@ -1433,14 +1469,14 @@ const App={
     RightPane.render();toast('File deleted permanently');
   },
 
-  async fetchPreview(file){
+  async fetchPreview(file,{large=false}={}){
     try{
       const cls=file.class;
       if(cls==='image'){
-        const url=await this.fetchBlobUrl(file);const img=document.createElement('img');img.src=url;img.style.maxWidth='280px';img.style.maxHeight='220px';img.style.objectFit='contain';return img;
+        const url=await this.fetchBlobUrl(file);const img=document.createElement('img');img.src=url;img.style.maxWidth=large?'100%':'280px';img.style.maxHeight=large?'100%':'220px';img.style.objectFit='contain';return img;
       }else if(cls==='video'){
         const url=await this.getStreamUrl(file)||await this.fetchBlobUrl(file);
-        const vid=document.createElement('video');vid.src=url;vid.controls=true;vid.style.maxWidth='280px';vid.style.maxHeight='220px';return vid;
+        const vid=document.createElement('video');vid.src=url;vid.controls=true;vid.style.maxWidth=large?'100%':'280px';vid.style.maxHeight=large?'100%':'220px';vid.style.objectFit='contain';return vid;
       }else if(cls==='audio'){
         const url=await this.getStreamUrl(file)||await this.fetchBlobUrl(file);
         const aud=document.createElement('audio');aud.src=url;aud.controls=true;aud.style.width='240px';return aud;


### PR DESCRIPTION
### Motivation
- Make bulk operations feel immediate and discoverable by adding a selected-count chip with a one-click clear control and optimizing bulk updates.  
- Replace the inconsistent slide-out preview with a chromeless, resizable item window that supports details, notes, tagging, moving, deleting and favorite toggling.  
- Stabilize tile (portal) previews for video/image content and add an inline favorite toggle.  
- Improve indexing feedback and timeline ordering so users can see which subfolder is being indexed and see buckets sorted by real dates.

### Description
- UI: added a styled selected-count chip (`#bulk-count`) with an inline `×` button to deselect all and updated `updateBulkBar()` to render and wire the control.  
- Bulk ops: made `TagService.applyMany`/`removeMany`, `NotesEditor.commit`, and `App.setStackMany` optimistic by saving locally first (`Intel.saveLocal()`), showing a short toast, and deferring cloud sync via `Intel.saveDebounced()`; introduced `Intel.saveLocal()` and `Intel.saveDebounced()`.  
- Item workspace: replaced in-list slide drawer activation with a new `ItemWindow` (chromeless, draggable, resizable, minimize/maximize) that exposes a ribbon of controls (Details, Notes, Tag, Move, Delete, Favorite) and loads a large preview; list and portal card clicks open this window.  
- Portal tiles: enforced square media areas (`aspect-ratio:1/1`), added video preview handling on cards, and added a favorite icon (`ptl-fav-icon`) toggle on tiles.  
- Indexing modal: expanded the indexing modal to show `Current` (active subfolder) and `Done` (recently completed folders) and updated the indexing progress callbacks to pass `done` lists so the modal displays live subfolder progress.  
- Timeline: fixed bucket sorting by parsing the bucket start dates into `Date` objects instead of string comparison.  
- Preview API: `App.fetchPreview` accepts a `{large}` flag to produce larger previews for the item window.  
- Misc: various CSS tweaks (wrapping, paddings, media containment) and wiring changes so clicks/double-clicks open the item window consistently.

### Testing
- Ran a JS sanity check by extracting and evaluating the inline `<script>` with `node` (executed `new Function(js)`), and it returned `js ok`. — succeeded.  
- Ran `git diff --check` to verify no obvious whitespace/merge problems — succeeded.  
- Attempted UI screenshot / end-to-end capture but Playwright/browser binaries were not available in the environment, so visual verification was not performed. — not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24336b2320832d81c82728dce7143c)