### PR TITLE
Fix timeline sorting, auto-indexing, popup workspace, previews, and favorites in folder.html

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -257,7 +257,8 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .ptl-btn:hover{background:var(--hover);color:var(--ts)}
 .ptl-btn.danger:hover{color:var(--red)}
 .ptl-content{flex:1 1 auto;display:flex;align-items:center;justify-content:center;background:var(--bg);overflow:hidden;min-height:80px;aspect-ratio:1/1}
-.ptl-content img,.ptl-content video{width:100%;height:100%;max-width:100%;max-height:100%;object-fit:contain;background:var(--bg)}
+.ptl-content img,.ptl-content video,.ptl-content iframe{width:100%;height:100%;max-width:100%;max-height:100%;object-fit:contain;background:var(--bg)}
+.ptl-content iframe{border:0;pointer-events:none}
 .ptl-content-placeholder{text-align:center;padding:10px;color:var(--tm);font-size:11px}
 .ptl-foot{display:flex;align-items:center;gap:4px;padding:5px 8px;border-top:1px solid var(--border);background:var(--raised)}
 .ptl-stk{font-family:var(--mono);font-size:10px;flex:1}
@@ -273,13 +274,13 @@ html,body{height:100%;overflow:hidden;background:var(--bg);color:var(--tp);font-
 .item-titlebar strong{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;color:var(--tp)}
 .item-win-btn{background:transparent;border:1px solid var(--border);color:var(--ts);border-radius:5px;width:26px;height:24px;cursor:pointer}
 .item-win-btn:hover{background:var(--hover);color:var(--tp)}
-.item-ribbon{display:flex;align-items:center;gap:6px;flex-wrap:wrap;padding:8px 10px;background:var(--surface);border-bottom:1px solid var(--border)}
-.item-ribbon .fav-on{background:var(--yel-d);border-color:var(--yel);color:var(--yel)}
-.item-body{display:grid;grid-template-columns:minmax(220px,1fr) 300px;gap:12px;padding:12px;min-height:0;overflow:auto}
-.item-media{display:flex;align-items:center;justify-content:center;background:var(--bg);border:1px solid var(--border);border-radius:var(--r);min-height:240px;overflow:hidden}
-.item-media img,.item-media video{max-width:100%;max-height:100%;object-fit:contain}.item-media audio{width:90%}.item-media iframe{width:100%;height:100%;min-height:360px;border:0}.item-media pre{max-height:100%;overflow:auto;padding:12px;white-space:pre-wrap;word-break:break-word;font:11px var(--mono);color:var(--ts)}
-.item-side{display:flex;flex-direction:column;gap:10px;min-width:0}.item-detail{display:flex;justify-content:space-between;gap:8px;font-size:11px}.item-detail span:first-child{color:var(--ts)}.item-detail span:last-child{font-family:var(--mono);text-align:right;word-break:break-all}
-.ptl-fav-icon{position:absolute;top:8px;right:8px;z-index:3;background:rgba(0,0,0,.55);border:1px solid var(--bmd);border-radius:999px;color:var(--tm);width:26px;height:26px;cursor:pointer}.ptl-fav-icon.on{color:var(--yel);background:var(--yel-d);border-color:var(--yel)}
+.item-ribbon{display:flex;flex-direction:column;gap:8px;padding:8px 10px;background:var(--surface);border-bottom:1px solid var(--border)}
+.item-ribbon-top{display:flex;align-items:center;gap:6px;flex-wrap:wrap}.item-ribbon-panel{max-height:190px;overflow:auto;border-top:1px solid var(--border);padding-top:8px}.item-win.panel-collapsed .item-ribbon-panel{display:none}.item-tab.active,.item-fav.on{background:var(--acc-d);border-color:var(--bacc);color:var(--acc)}
+.item-body{display:flex;padding:12px;min-height:0;overflow:hidden}
+.item-media{flex:1;display:flex;align-items:center;justify-content:center;background:var(--bg);border:1px solid var(--border);border-radius:var(--r);min-height:0;overflow:hidden}
+.item-media img,.item-media video{width:100%;height:100%;max-width:100%;max-height:100%;object-fit:contain}.item-media audio{width:90%}.item-media iframe{width:100%;height:100%;min-height:0;border:0}.item-media pre{max-height:100%;overflow:auto;padding:12px;white-space:pre-wrap;word-break:break-word;font:11px var(--mono);color:var(--ts)}
+.item-side{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;min-width:0}.item-detail{display:flex;justify-content:space-between;gap:8px;font-size:11px}.item-detail span:first-child{color:var(--ts)}.item-detail span:last-child{font-family:var(--mono);text-align:right;word-break:break-all}
+.ptl-fav-icon{position:absolute;top:8px;right:8px;z-index:3;background:rgba(0,0,0,.55);border:1px solid var(--bmd);border-radius:999px;color:var(--tm);height:24px;padding:0 8px;cursor:pointer;font:10px var(--mono)}.ptl-fav-icon.on{color:var(--acc);background:var(--acc-d);border-color:var(--bacc)}
 
 /* Empty state */
 .empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;color:var(--tm);font-size:13px;gap:8px;padding:32px}
@@ -1047,8 +1048,8 @@ const Tree={
 const Timeline={
   dateOf(file){const d=new Date(file.effectiveDate||file.modifiedTime||file.createdTime||file.createdDateTime||file.lastModifiedDateTime);return isNaN(d)?null:d;},
   baseFiles(){if(!st.intel||!st.selFolderId||!st.selFolderEnrolled)return[];let files=Intel.getDescendantFiles(st.selFolderId);if(st.ui.search){const t=st.ui.search.toLowerCase();files=files.filter(f=>f.name.toLowerCase().includes(t));}if(st.ui.classFilter)files=files.filter(f=>f.class===st.ui.classFilter);if(st.ui.stackFilter)files=files.filter(f=>f.stack===st.ui.stackFilter);return files;},
-  rangeFor(level,d){const y=d.getFullYear(),m=d.getMonth(),day=d.getDate();let a,b,label,next;if(level==='year'){a=new Date(y,0,1);b=new Date(y+1,0,1);label=String(y);next='month';}else if(level==='month'){a=new Date(y,m,1);b=new Date(y,m+1,1);label=a.toLocaleString(undefined,{month:'short',year:'numeric'});next='day';}else{a=new Date(y,m,day);b=new Date(y,m,day+1);label=String(day);next=null;}return{start:a.toISOString(),end:b.toISOString(),label,next};},
-  buckets(files){const level=st.ui.timelineLevel||'year',map=new Map();files.forEach(f=>{const d=this.dateOf(f);if(!d)return;const r=this.rangeFor(level,d),key=r.start,b=map.get(key)||{...r,count:0};b.count++;map.set(key,b);});return[...map.values()].sort((a,b)=>new Date(a.start)-new Date(b.start));},
+  rangeFor(level,d){const y=d.getFullYear(),m=d.getMonth(),day=d.getDate();let a,b,label,next,sortKey;if(level==='year'){a=new Date(y,0,1);b=new Date(y+1,0,1);label=String(y);next='month';sortKey=y;}else if(level==='month'){a=new Date(y,m,1);b=new Date(y,m+1,1);label=a.toLocaleString(undefined,{month:'short',year:'numeric'});next='day';sortKey=y*100+(m+1);}else{a=new Date(y,m,day);b=new Date(y,m,day+1);label=String(day);next=null;sortKey=y*10000+(m+1)*100+day;}return{start:a.toISOString(),end:b.toISOString(),label,next,sortKey};},
+  buckets(files){const level=st.ui.timelineLevel||'year',map=new Map();files.forEach(f=>{const d=this.dateOf(f);if(!d)return;const r=this.rangeFor(level,d),key=r.start,b=map.get(key)||{...r,count:0};b.count++;map.set(key,b);});return[...map.values()].sort((a,b)=>a.sortKey-b.sortKey);},
   applyRange(files){const r=st.ui.timelineRange;if(!r)return files;return files.filter(f=>{const d=this.dateOf(f);return d&&d>=new Date(r.start)&&d<new Date(r.end);});},
   clear(){st.ui.timelineRange=null;st.ui.timelineLevel='year';st.ui.timelineBreadcrumbs=[];},
   render(){const box=$id('rp-timeline'),body=$id('timeline-body'),axis=$id('timeline-axis'),crumbs=$id('timeline-crumbs'),sum=$id('timeline-summary'),chev=$id('timeline-chevron');if(!box||!body||!axis||!crumbs)return;const base=this.baseFiles();box.classList.toggle('hidden',!base.length);body.classList.toggle('hidden',!st.ui.timelineOpen);if(chev)chev.textContent=st.ui.timelineOpen?'▼':'▶';if(sum)sum.textContent=st.ui.timelineRange?st.ui.timelineRange.label:`${base.length} dated`;crumbs.innerHTML='';axis.innerHTML='';const root=document.createElement('button');root.textContent='All';root.addEventListener('click',()=>{this.clear();RightPane.render();});crumbs.appendChild(root);(st.ui.timelineBreadcrumbs||[]).forEach((c,i)=>{const b=document.createElement('button');b.textContent=c.label;b.addEventListener('click',()=>{st.ui.timelineRange=c.range;st.ui.timelineLevel=c.next||'year';st.ui.timelineBreadcrumbs=st.ui.timelineBreadcrumbs.slice(0,i+1);RightPane.render();});crumbs.appendChild(b);});const buckets=this.buckets(base),max=Math.max(1,...buckets.map(b=>b.count));buckets.forEach(b=>{const btn=document.createElement('button');btn.className='timeline-bucket'+(st.ui.timelineRange?.start===b.start?' active':'');btn.title=`${b.label}: ${b.count}`;btn.innerHTML=`<span class="timeline-bar" style="height:${Math.max(8,Math.round((b.count/max)*38))}px"></span><span class="timeline-label">${esc(b.label)}</span>`;btn.addEventListener('click',()=>{st.ui.timelineRange={start:b.start,end:b.end,label:b.label};if(b.next){st.ui.timelineBreadcrumbs=[...(st.ui.timelineBreadcrumbs||[]),{label:b.label,range:st.ui.timelineRange,next:b.next}];st.ui.timelineLevel=b.next;}RightPane.render();});axis.appendChild(btn);});if(!buckets.length)axis.innerHTML='<div class="timeline-legend">No dates in current filters.</div>';}
@@ -1136,12 +1137,19 @@ const ItemWindow={
     const file=st.intel?.files?.[fileId];if(!file)return;
     document.querySelectorAll('.item-win').forEach(w=>w.remove());
     const win=document.createElement('div');win.className='item-win';win.dataset.fid=fileId;
-    win.innerHTML=`<div class="item-titlebar"><strong>${esc(file.name)}</strong><button class="item-win-btn" data-win="min" title="Minimize">—</button><button class="item-win-btn" data-win="max" title="Maximize">□</button><button class="item-win-btn" data-win="close" title="Close">×</button></div><div class="item-ribbon"><button class="btn btn-ghost btn-sm" data-rib="details">Details</button><button class="btn btn-ghost btn-sm" data-rib="notes">Update Notes</button><button class="btn btn-ghost btn-sm" data-rib="tag">Tag</button><button class="btn btn-ghost btn-sm" data-rib="move">Move</button><button class="btn btn-danger btn-sm" data-rib="delete">Delete</button><button class="btn btn-ghost btn-sm ${file.favorite?'fav-on':''}" data-rib="favorite">${file.favorite?'★ Favorite':'☆ Favorite'}</button></div><div class="item-body"><div class="item-media"><div class="preview-no">Loading preview…</div></div><div class="item-side" data-side="details">${this.detailsHtml(file)}</div></div>`;
-    document.body.appendChild(win);this.wireWindow(win);this.wireRibbon(win,fileId);this.loadPreview(win,file);
+    win.innerHTML=`<div class="item-titlebar"><strong>${esc(file.name)}</strong><button class="item-win-btn" data-win="min" title="Minimize">—</button><button class="item-win-btn" data-win="max" title="Maximize">□</button><button class="item-win-btn" data-win="close" title="Close">×</button></div><div class="item-ribbon"><div class="item-ribbon-top"><button class="btn btn-ghost btn-sm" data-panel-toggle aria-expanded="true">⌄</button><button class="btn btn-ghost btn-sm item-tab active" data-tab="info">Info</button><button class="btn btn-ghost btn-sm item-tab" data-tab="notes">Notes</button><button class="btn btn-ghost btn-sm item-tab" data-tab="tags">Tags</button><button class="btn btn-ghost btn-sm item-tab" data-tab="metadata">Metadata</button><button class="btn btn-ghost btn-sm item-fav ${file.favorite?'on':''}" data-rib="favorite">Favorite: ${file.favorite?'On':'Off'}</button><button class="btn btn-danger btn-sm" data-rib="delete">Delete</button></div><div class="item-ribbon-panel"><div class="item-side" data-side></div></div></div><div class="item-body"><div class="item-media"><div class="preview-no">Loading preview…</div></div></div>`;
+    document.body.appendChild(win);this.wireWindow(win);this.wireRibbon(win,fileId);this.showTab(win,fileId,'info');this.loadPreview(win,file);
   },
-  detailsHtml(file){const rows=[['Name',file.name],['Type',(CLASS_DEF[file.class]||CLASS_DEF.other).label],['Size',fmtSizeMB(file.size)],['Date',fmtDate(file.effectiveDate)],['Stack',STACK_LABEL[file.stack]||'Inbox'],['Tags',(file.tags||[]).join(', ')||'—'],['Notes',file.notes||'—']];return rows.map(([k,v])=>`<div class="item-detail"><span>${esc(k)}</span><span>${esc(v)}</span></div>`).join('');},
+  displayValue(v){return v===false?'false':v===0?'0':(v?String(v):'—');},
+  collectRows(file,mode='info'){
+    const rows=[['Name',file.name],['Type',(CLASS_DEF[file.class]||CLASS_DEF.other).label],['Mime',file.mimeType||file.type],['Size',fmtSizeMB(file.size)],['Date',fmtDate(file.effectiveDate)],['Created',fmtDate(file.createdTime||file.createdDateTime)],['Modified',fmtDate(file.modifiedTime||file.lastModifiedDateTime)],['Dimensions',file.meta?.width&&file.meta?.height?`${file.meta.width}×${file.meta.height}`:''],['Duration',file.meta?.duration?`${file.meta.duration}s`:''],['Camera Make',file.meta?.cameraMake],['Camera Model',file.meta?.cameraModel],['Aperture',file.meta?.aperture],['Exposure',file.meta?.exposure],['ISO',file.meta?.iso],['Focal Length',file.meta?.focalLength],['GPS',file.meta?.gpsLat&&file.meta?.gpsLng?`${file.meta.gpsLat}, ${file.meta.gpsLng}`:''],['Stack',STACK_LABEL[file.stack]||'Inbox'],['Favorite',file.favorite?'On':'Off'],['Tags',(file.tags||[]).join(', ')],['Notes',file.notes],['Quality Rating',file.qualityRating],['Content Rating',file.contentRating]];
+    if(mode==='metadata'&&file.meta)Object.entries(file.meta).forEach(([k,v])=>{if(!rows.some(([rk])=>rk.toLowerCase().replaceAll(' ','')===k.toLowerCase()))rows.push([k,v]);});
+    return rows.filter(([,v])=>mode==='metadata'||this.displayValue(v)!=='—');
+  },
+  detailsHtml(file,mode='info'){return this.collectRows(file,mode).map(([k,v])=>`<div class="item-detail"><span>${esc(k)}</span><span>${esc(this.displayValue(v))}</span></div>`).join('')||'<div class="preview-no">No metadata available</div>';},
+  showTab(win,fileId,tab){const side=win.querySelector('[data-side]'),file=st.intel?.files?.[fileId];if(!side||!file)return;win.querySelectorAll('.item-tab').forEach(b=>b.classList.toggle('active',b.dataset.tab===tab));side.innerHTML='';if(tab==='tags'){const ed=TagEditor.create([fileId]);side.appendChild(ed.el);return;}if(tab==='notes'){const ed=NotesEditor.create([fileId]);side.appendChild(ed.el);ed.el.addEventListener('focusout',()=>RightPane.renderContent());ed.el.addEventListener('change',()=>RightPane.renderContent());return;}side.innerHTML=this.detailsHtml(file,tab==='metadata'?'metadata':'info');},
   wireWindow(win){const bar=win.querySelector('.item-titlebar');let drag=null;bar.addEventListener('pointerdown',e=>{if(e.target.closest('button'))return;const r=win.getBoundingClientRect();drag={dx:e.clientX-r.left,dy:e.clientY-r.top};win.style.transform='none';bar.setPointerCapture(e.pointerId);});bar.addEventListener('pointermove',e=>{if(!drag)return;win.style.left=Math.max(0,Math.min(window.innerWidth-80,e.clientX-drag.dx))+'px';win.style.top=Math.max(0,Math.min(window.innerHeight-44,e.clientY-drag.dy))+'px';});bar.addEventListener('pointerup',()=>drag=null);win.querySelector('[data-win="close"]').addEventListener('click',()=>win.remove());win.querySelector('[data-win="min"]').addEventListener('click',()=>win.classList.toggle('minimized'));win.querySelector('[data-win="max"]').addEventListener('click',()=>win.classList.toggle('maximized'));},
-  wireRibbon(win,fileId){const side=win.querySelector('[data-side]');win.querySelector('[data-rib="details"]').addEventListener('click',()=>{side.innerHTML=this.detailsHtml(st.intel.files[fileId]);});win.querySelector('[data-rib="tag"]').addEventListener('click',()=>{const ed=TagEditor.create([fileId]);side.innerHTML='';side.appendChild(ed.el);});win.querySelector('[data-rib="notes"]').addEventListener('click',()=>{const ed=NotesEditor.create([fileId],{deferred:true});side.innerHTML='';side.appendChild(ed.el);const b=document.createElement('button');b.className='btn btn-pri btn-sm';b.textContent='Save Notes';b.addEventListener('click',async()=>{await ed.commit();side.innerHTML=this.detailsHtml(st.intel.files[fileId]);RightPane.renderContent();});side.appendChild(b);});win.querySelector('[data-rib="move"]').addEventListener('click',()=>{side.innerHTML='<div class="bulk-stack-row"></div>';const row=side.querySelector('.bulk-stack-row');[['inbox','Inbox'],['keep','Keep'],['maybe','Maybe'],['trash','Recycle']].forEach(([stack,lbl])=>{const b=document.createElement('button');b.className='btn btn-ghost btn-sm';b.textContent=lbl;b.addEventListener('click',async()=>{await App.setStack(fileId,stack);RightPane.renderContent();side.innerHTML=this.detailsHtml(st.intel.files[fileId]);});row.appendChild(b);});});win.querySelector('[data-rib="delete"]').addEventListener('click',async()=>{await App.softDelete(fileId);win.remove();});win.querySelector('[data-rib="favorite"]').addEventListener('click',async e=>{await App.toggleFavorite(fileId);e.currentTarget.classList.toggle('fav-on',!!st.intel.files[fileId].favorite);e.currentTarget.textContent=st.intel.files[fileId].favorite?'★ Favorite':'☆ Favorite';RightPane.renderContent();});},
+  wireRibbon(win,fileId){win.querySelector('[data-panel-toggle]').addEventListener('click',e=>{const collapsed=win.classList.toggle('panel-collapsed');e.currentTarget.textContent=collapsed?'›':'⌄';e.currentTarget.setAttribute('aria-expanded',collapsed?'false':'true');});win.querySelectorAll('.item-tab').forEach(btn=>btn.addEventListener('click',()=>this.showTab(win,fileId,btn.dataset.tab)));win.querySelector('[data-rib="delete"]').addEventListener('click',async()=>{await App.softDelete(fileId);win.remove();});win.querySelector('[data-rib="favorite"]').addEventListener('click',async e=>{await App.toggleFavorite(fileId);const on=!!st.intel.files[fileId].favorite;e.currentTarget.classList.toggle('on',on);e.currentTarget.textContent=`Favorite: ${on?'On':'Off'}`;this.showTab(win,fileId,win.querySelector('.item-tab.active')?.dataset.tab||'info');RightPane.renderContent();});},
   async loadPreview(win,file){const slot=win.querySelector('.item-media');const node=await App.fetchPreview(file,{large:true});if(!win.isConnected)return;slot.innerHTML='';if(node)slot.appendChild(node);else slot.innerHTML='<div class="preview-no">No preview available</div>';}
 };
 
@@ -1266,11 +1274,12 @@ const PortalView={
     btnDel.draggable=false;btnDel.addEventListener('click',async e=>{e.stopPropagation();await App.softDelete(file.id);});
     acts.appendChild(btnDel);bar.appendChild(nameEl);bar.appendChild(acts);
     // Content
-    const fav=document.createElement('button');fav.className='ptl-fav-icon'+(file.favorite?' on':'');fav.textContent=file.favorite?'★':'☆';fav.title='Toggle favorite';fav.addEventListener('click',async e=>{e.stopPropagation();await App.toggleFavorite(file.id);RightPane.renderContent();});
+    const fav=document.createElement('button');fav.className='ptl-fav-icon'+(file.favorite?' on':'');fav.textContent=file.favorite?'On':'Off';fav.title='Toggle favorite';fav.addEventListener('click',async e=>{e.stopPropagation();await App.toggleFavorite(file.id);fav.classList.toggle('on',!!st.intel.files[file.id].favorite);fav.textContent=st.intel.files[file.id].favorite?'On':'Off';RightPane.renderContent();});
     const contentEl=document.createElement('div');contentEl.className='ptl-content';contentEl.style.height=cardH+'px';
-    if(file.thumbnailUrl){const img=document.createElement('img');img.src=file.thumbnailUrl;contentEl.appendChild(img);}
+    if(file.class==='web'){App.fetchPreview(file).then(node=>{contentEl.innerHTML='';if(node)contentEl.appendChild(node);else this.appendPlaceholder(contentEl,file,cols,def);});this.appendPlaceholder(contentEl,file,cols,def);}
+    else if(file.thumbnailUrl){const img=document.createElement('img');img.src=file.thumbnailUrl;contentEl.appendChild(img);}
     else if(file.class==='video'){const vid=document.createElement('video');App.getStreamUrl(file).then(url=>{if(url)vid.src=url;}).catch(()=>{});vid.muted=true;vid.playsInline=true;vid.preload='metadata';contentEl.appendChild(vid);}
-    else{const ph=document.createElement('div');ph.className='ptl-content-placeholder';ph.innerHTML=`<div style="font-size:${cols<=2?38:22}px;margin-bottom:4px">${this.classIcon(file.class)}</div><div style="font-size:10px;color:var(--tm)">${def.label}</div>`;contentEl.appendChild(ph);}
+    else this.appendPlaceholder(contentEl,file,cols,def);
     if(cols<=2){
       bar.style.cursor='grab';
       nameEl.style.whiteSpace='normal';nameEl.style.textOverflow='clip';nameEl.style.overflow='visible';
@@ -1285,6 +1294,7 @@ const PortalView={
     card.addEventListener('click',e=>{if(e.target.closest('input,button'))return;ItemWindow.open(file.id);});
     return card;
   },
+  appendPlaceholder(contentEl,file,cols,def){const ph=document.createElement('div');ph.className='ptl-content-placeholder';ph.innerHTML=`<div style="font-size:${cols<=2?38:22}px;margin-bottom:4px">${this.classIcon(file.class)}</div><div style="font-size:10px;color:var(--tm)">${def.label}</div>`;contentEl.appendChild(ph);},
   classIcon(cls){return{image:'🖼',video:'🎬',audio:'🎵',document:'📄',office:'📊',web:'🌐',text:'📝',code:'💻',archive:'📦',other:'📎'}[cls]||'📎';},
   reorder(fromId,toId){
     const files=this.ordered(RightPane.getFilteredFiles()),ids=files.map(f=>f.id),fi=ids.indexOf(fromId),ti=ids.indexOf(toId);if(fi<0||ti<0)return;
@@ -1365,13 +1375,14 @@ const App={
     const banner=$id('rp-enroll');
     const job=st.acqJobs[folderId];
     if(st.selFolderEnrolled&&job&&!job.running)delete st.acqJobs[folderId];
-    if(banner)banner.classList.toggle('hidden',st.selFolderEnrolled||job?.running||st.acq.running);
+    if(banner)banner.classList.toggle('hidden',true);
     if(!st.selFolderEnrolled&&!job?.running){
       const txt=$id('enroll-txt');if(txt)txt.textContent=`"${folderName}" hasn't been indexed yet.`;
       const sub=$id('enroll-sub');if(sub)sub.textContent='Index it once to enable search, filtering, and curation.';
     }
     // Render right pane
     RightPane.render();
+    if(!st.selFolderEnrolled&&!job?.running)setTimeout(()=>{if(st.selFolderId===folderId)App.startIndexing(folderId,folderName);},0);
     // Quick non-recursive refresh check only for selected level-1 folders
     if(st.selFolderEnrolled&&this.shouldQuickRefresh(folderId)){
       const folderRec=st.intel?.folders?.[folderId];
@@ -1452,8 +1463,8 @@ const App={
   async toggleFavorite(fileId){
     if(!st.intel?.files?.[fileId])return;
     const file=st.intel.files[fileId];file.favorite=!file.favorite;
-    try{if(st.providerType==='googledrive')await st.provider.updateAppProperties(fileId,{favorite:String(file.favorite)});}catch(e){}
-    await Intel.save();toast(file.favorite?'Added to favorites':'Removed from favorites');
+    Intel.saveLocal();toast(file.favorite?'Favorite on':'Favorite off');
+    if(st.providerType==='googledrive')Promise.resolve().then(()=>st.provider.updateAppProperties(fileId,{favorite:String(file.favorite)})).then(()=>Intel.saveDebounced()).catch(()=>Intel.saveDebounced());else Intel.saveDebounced();
   },
 
   async softDelete(fileId){
@@ -1476,13 +1487,15 @@ const App={
         const url=await this.fetchBlobUrl(file);const img=document.createElement('img');img.src=url;img.style.maxWidth=large?'100%':'280px';img.style.maxHeight=large?'100%':'220px';img.style.objectFit='contain';return img;
       }else if(cls==='video'){
         const url=await this.getStreamUrl(file)||await this.fetchBlobUrl(file);
-        const vid=document.createElement('video');vid.src=url;vid.controls=true;vid.style.maxWidth=large?'100%':'280px';vid.style.maxHeight=large?'100%':'220px';vid.style.objectFit='contain';return vid;
+        const vid=document.createElement('video');vid.src=url;vid.controls=true;vid.style.width=large?'100%':'280px';vid.style.height=large?'100%':'220px';vid.style.maxWidth='100%';vid.style.maxHeight='100%';vid.style.objectFit='contain';return vid;
       }else if(cls==='audio'){
         const url=await this.getStreamUrl(file)||await this.fetchBlobUrl(file);
         const aud=document.createElement('audio');aud.src=url;aud.controls=true;aud.style.width='240px';return aud;
       }else if(cls==='document'){
-        const url=await this.fetchBlobUrl(file);const iframe=document.createElement('iframe');iframe.src=url;iframe.style.width='280px';iframe.style.height='220px';iframe.style.border='none';return iframe;
-      }else if(cls==='text'||cls==='code'||cls==='web'){
+        const url=await this.fetchBlobUrl(file);const iframe=document.createElement('iframe');iframe.src=url;iframe.sandbox='';iframe.style.width=large?'100%':'280px';iframe.style.height=large?'100%':'220px';iframe.style.border='none';return iframe;
+      }else if(cls==='web'){
+        const url=await this.fetchBlobUrl(file);const iframe=document.createElement('iframe');iframe.src=url;iframe.sandbox='';iframe.style.width=large?'100%':'280px';iframe.style.height=large?'100%':'220px';iframe.style.border='none';return iframe;
+      }else if(cls==='text'||cls==='code'){
         const url=await this.fetchBlobUrl(file);const r=await fetch(url);const text=await r.text();
         const pre=document.createElement('pre');pre.textContent=text.slice(0,3000);return pre;
       }
@@ -1607,7 +1620,6 @@ function initEvents(){
   $id('btn-index-now').addEventListener('click',()=>{
     if(!st.selFolderId)return;
     const folder=st.levelOneFolders.find(f=>f.id===st.selFolderId)||(st.intel?.folders?.[st.selFolderId]||{name:st.selFolderId});
-    if(!confirm(`Index "${folder.name||st.selFolderId}" now?`))return;
     App.startIndexing(st.selFolderId,folder.name||st.selFolderId);
   });
   $id('timeline-toggle')?.addEventListener('click',()=>{st.ui.timelineOpen=!st.ui.timelineOpen;Timeline.render();});


### PR DESCRIPTION
### Motivation
- Timeline buckets and breadcrumb drill-down must sort by numeric date (year/month/day) rather than localized label text to guarantee chronological order. 
- Enrollment drawer must not duplicate status text or require a user confirmation for first-time indexing and should auto-start indexing while respecting the 5-worker cap. 
- Item popup/workspace, tile rendering, preview scaling, web/html previews, metadata display, and favorite toggles needed refinement to match the app reference behavior while minimizing scope.

### Description
- Timeline: add numeric `sortKey` to `rangeFor` and sort bucket arrays by `sortKey` so year/month/day buckets order Jan→Dec and days numerically. (changes limited to timeline bucket/range code in `folder.html`).
- Enrollment/indexing: stop showing duplicate enrollment/status copy in the chevron/drawer, hide the enroll banner when selected, and auto-start indexing for a non-indexed folder immediately on first selection; preserve up to 5 concurrent worker slots and existing "slot not available" feedback. The `Index Now` confirmation was removed so first-time indexing begins automatically; the manual button still triggers indexing when present.
- Item popup/workspace: replace the single static side panel with a small ribbon that has a chevron control and tabs for Info, Notes, Tags, and Metadata, plus a collapsible ribbon panel; when collapsed the media preview expands to use available space. Metadata extraction and display were added to include dimensions, duration, camera/photo fields, created/modified dates, size, mime/type, stack, tags, notes, ratings, favorite status, and any `file.meta` fields present; reuse existing `TagEditor`/`NotesEditor` and save/debounce paths.
- Tile rendering & previews: add an iframe preview path for web/html files in portal tiles and change portal card rendering to attempt a fetched preview then fall back to a placeholder; added `appendPlaceholder` helper for tiles. Iframes are created with sandbox attributes and sized to fill available media area. Video elements now scale using `width/height` and `object-fit: contain` so they expand with popup/tile sizes.
- Favorites UI & persistence: replace red heart/star visuals with a neutral on/off toggle label ("On"/"Off") in both tile and workspace UI, update UI immediately on toggle, write local intel immediately (`saveLocal`) and persist to backend via the existing debounced save path (`saveDebounced`).
- CSS tweaks: allow iframe previews to size like images/videos in portal cards and popup media areas; update item-workspace styles so the media area can expand when the ribbon panel is collapsed.
- Scope: all edits are limited to `folder.html` and reuse existing helper components and save/update paths.

### Testing
- Inline script syntax sanity check: extracted inline scripts and evaluated with `new Function(js)` in Node and the script executed without syntax errors (success).
- Git check: ran `git diff --check` and resolved whitespace/format issues; no check errors remained (success).
- Basic smoke: confirmed that timeline bucket generation and bucket sorting path run through successfully in the environment when exercising `Timeline.rangeFor`/`buckets` (no runtime syntax errors).

Note: no browser-based screenshot capture was performed because a browser rendering harness is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2448018a64832daa9d9d08b1e4d782)