### PR TITLE
Fix recursive folder indexed status

### DIFF
--- a/folder-v1.html
+++ b/folder-v1.html
@@ -622,6 +622,13 @@ function makeIndexMarker(rec,rootId){
   ensureContractShape(rec,rootId);const folder=rec?.folders?.[rootId]||{};
   return{schemaVersion:CONTRACT_VERSION,artifactType:CONTRACT_ARTIFACTS.marker,provider:rec?.provider||st.providerType,accountKey:rec?.accountKey||st.providerType,rootFolderId:rootId,rootFolderName:folder.name||st.selFolderName||rootId,folderVersion:rec?.folderVersion||0,indexArtifactRef:INTEL_FILE,indexArtifactETag:null,indexArtifactModifiedTime:rec?.updatedAt||null,directHash:folder.hash||folder.directHash||null,recursiveHash:rec?.freshness?.recursiveHash||null,entryCount:rec?.freshness?.entryCount||0,folderCount:rec?.freshness?.folderCount||0,pngEntryCount:Object.values(rec?.files||{}).filter(f=>f.mimeType==='image/png').length,pngReuseGroupCount:Object.keys(rec?.pngReuse?.groups||{}).length,updatedAt:rec?.updatedAt||null,lastWriter:rec?.lastWriter||makeLastWriter()};
 }
+function hasIndexedFolderState(rec,folderId,enrolled=false){
+  const folderRec=rec?.folders?.[folderId];
+  const stats=folderRec?.stats,agg=folderRec?.aggStats;
+  const hasStats=s=>!!s&&(s.totalFiles>0||s.totalSize>0||s.newestFile||s.oldestFile);
+  const hasVerifiedStats=!!(folderRec&&(folderRec.lastVerified||folderRec.firstIndexed)&&(stats||agg));
+  return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||folderRec?.isIndexed===true||folderRec?.indexed===true||hasVerifiedStats||hasStats(agg)||hasStats(stats));
+}
 
 function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
 function $id(id){return document.getElementById(id);}
@@ -1122,12 +1129,14 @@ const Intel={
       while(st.acq.paused&&!st.acq.cancelled){await sleep(120);}
       const fid=queue.shift();if(visited.has(fid))continue;visited.add(fid);
       if(!rec.folders[fid]){
-        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,
+        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,isIndexed:true,indexed:true,
           firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],
           stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},
           curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
       }else{
+        rec.folders[fid].firstIndexed=rec.folders[fid].firstIndexed||Date.now();
         rec.folders[fid].lastVerified=Date.now();
+        rec.folders[fid].isIndexed=true;rec.folders[fid].indexed=true;rec.folders[fid].status='current';
         rec.folders[fid].stats={totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null};
         rec.folders[fid].curation={inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0};
         rec.folders[fid].children=[];
@@ -1143,7 +1152,7 @@ const Intel={
       let subs=[];try{subs=await p.getSubfolders(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
       subs.forEach(sf=>{
         if(!rec.folders[fid].children.includes(sf.id))rec.folders[fid].children.push(sf.id);
-        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
+        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,isIndexed:false,indexed:false,firstIndexed:null,lastVerified:null,hash:'',status:'discovered',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
         queue.push(sf.id);
       });
       let allFiles=[];try{allFiles=await p.getAllFiles(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
@@ -1158,7 +1167,7 @@ const Intel={
         if(fr.tags.length)folder.curation.tagged++;if(fr.notes)folder.curation.noted++;if(fr.qualityRating||fr.contentRating)folder.curation.rated++;if(fr.favorite)folder.curation.favorited++;
         iCount++;
       });
-      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.lastVerified=Date.now();fScanned++;
+      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.firstIndexed=folder.firstIndexed||Date.now();folder.lastVerified=Date.now();folder.isIndexed=true;folder.indexed=true;folder.status='current';fScanned++;
       if(fScanned%5===0)idbPut('intel',rec).catch(()=>{});
       onProg({folder:fname,fc:fScanned,ic:iCount,done:[...visited].map(id=>rec.folders[id]?.name||id)});onLog(`✓ Done ${fname}`);await sleep(0);
     }
@@ -1225,7 +1234,7 @@ const Tree={
   },
   renderNode(container,fid,fname,depth,parentId,knownChildren){
     const rec=st.intel;
-    const enrolled=rec?.enrolledRoots?.includes(fid)||false;
+    const enrolled=hasIndexedFolderState(rec,fid,rec?.enrolledRoots?.includes(fid)||false);
     const folderRec=rec?.folders?.[fid];
     const agg=folderRec?(folderRec.aggStats||folderRec.stats):null;
     const children=knownChildren||(folderRec?.children?.map(c=>({id:c,name:rec?.folders?.[c]?.name||c}))||null);
@@ -1634,7 +1643,7 @@ const App={
     return(Date.now()-lastCheck)>120000;
   },
 
-  isFolderIndexed(folderId,enrolled=false){const rec=st.intel,folderRec=rec?.folders?.[folderId],agg=folderRec?.aggStats||folderRec?.stats;return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||agg&&(agg.totalFiles>0||agg.totalSize>0||agg.newestFile||agg.oldestFile));},
+  isFolderIndexed(folderId,enrolled=false){return hasIndexedFolderState(st.intel,folderId,enrolled);},
 
   selectFolder(folderId,folderName,enrolled){
     // Clear context

--- a/folder-v2.html
+++ b/folder-v2.html
@@ -658,6 +658,13 @@ function makeIndexMarker(rec,rootId){
   ensureContractShape(rec,rootId);const folder=rec?.folders?.[rootId]||{};
   return{schemaVersion:CONTRACT_VERSION,artifactType:CONTRACT_ARTIFACTS.marker,provider:rec?.provider||st.providerType,accountKey:rec?.accountKey||st.providerType,rootFolderId:rootId,rootFolderName:folder.name||st.selFolderName||rootId,folderVersion:rec?.folderVersion||0,indexArtifactRef:INTEL_FILE,indexArtifactETag:null,indexArtifactModifiedTime:rec?.updatedAt||null,directHash:folder.hash||folder.directHash||null,recursiveHash:rec?.freshness?.recursiveHash||null,entryCount:rec?.freshness?.entryCount||0,folderCount:rec?.freshness?.folderCount||0,pngEntryCount:Object.values(rec?.files||{}).filter(f=>f.mimeType==='image/png').length,pngReuseGroupCount:Object.keys(rec?.pngReuse?.groups||{}).length,updatedAt:rec?.updatedAt||null,lastWriter:rec?.lastWriter||makeLastWriter()};
 }
+function hasIndexedFolderState(rec,folderId,enrolled=false){
+  const folderRec=rec?.folders?.[folderId];
+  const stats=folderRec?.stats,agg=folderRec?.aggStats;
+  const hasStats=s=>!!s&&(s.totalFiles>0||s.totalSize>0||s.newestFile||s.oldestFile);
+  const hasVerifiedStats=!!(folderRec&&(folderRec.lastVerified||folderRec.firstIndexed)&&(stats||agg));
+  return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||folderRec?.isIndexed===true||folderRec?.indexed===true||hasVerifiedStats||hasStats(agg)||hasStats(stats));
+}
 
 function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
 function $id(id){return document.getElementById(id);}
@@ -1158,12 +1165,14 @@ const Intel={
       while(st.acq.paused&&!st.acq.cancelled){await sleep(120);}
       const fid=queue.shift();if(visited.has(fid))continue;visited.add(fid);
       if(!rec.folders[fid]){
-        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,
+        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,isIndexed:true,indexed:true,
           firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],
           stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},
           curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
       }else{
+        rec.folders[fid].firstIndexed=rec.folders[fid].firstIndexed||Date.now();
         rec.folders[fid].lastVerified=Date.now();
+        rec.folders[fid].isIndexed=true;rec.folders[fid].indexed=true;rec.folders[fid].status='current';
         rec.folders[fid].stats={totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null};
         rec.folders[fid].curation={inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0};
         rec.folders[fid].children=[];
@@ -1179,7 +1188,7 @@ const Intel={
       let subs=[];try{subs=await p.getSubfolders(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
       subs.forEach(sf=>{
         if(!rec.folders[fid].children.includes(sf.id))rec.folders[fid].children.push(sf.id);
-        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
+        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,isIndexed:false,indexed:false,firstIndexed:null,lastVerified:null,hash:'',status:'discovered',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
         queue.push(sf.id);
       });
       let allFiles=[];try{allFiles=await p.getAllFiles(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
@@ -1194,7 +1203,7 @@ const Intel={
         if(fr.tags.length)folder.curation.tagged++;if(fr.notes)folder.curation.noted++;if(fr.qualityRating||fr.contentRating)folder.curation.rated++;if(fr.favorite)folder.curation.favorited++;
         iCount++;
       });
-      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.lastVerified=Date.now();fScanned++;
+      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.firstIndexed=folder.firstIndexed||Date.now();folder.lastVerified=Date.now();folder.isIndexed=true;folder.indexed=true;folder.status='current';fScanned++;
       if(fScanned%5===0)idbPut('intel',rec).catch(()=>{});
       onProg({folder:fname,fc:fScanned,ic:iCount,done:[...visited].map(id=>rec.folders[id]?.name||id)});onLog(`✓ Done ${fname}`);await sleep(0);
     }
@@ -1261,7 +1270,7 @@ const Tree={
   },
   renderNode(container,fid,fname,depth,parentId,knownChildren){
     const rec=st.intel;
-    const enrolled=rec?.enrolledRoots?.includes(fid)||false;
+    const enrolled=hasIndexedFolderState(rec,fid,rec?.enrolledRoots?.includes(fid)||false);
     const folderRec=rec?.folders?.[fid];
     const agg=folderRec?(folderRec.aggStats||folderRec.stats):null;
     const children=knownChildren||(folderRec?.children?.map(c=>({id:c,name:rec?.folders?.[c]?.name||c}))||null);
@@ -1724,7 +1733,7 @@ const App={
     return(Date.now()-lastCheck)>120000;
   },
 
-  isFolderIndexed(folderId,enrolled=false){const rec=st.intel,folderRec=rec?.folders?.[folderId],agg=folderRec?.aggStats||folderRec?.stats;return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||agg&&(agg.totalFiles>0||agg.totalSize>0||agg.newestFile||agg.oldestFile));},
+  isFolderIndexed(folderId,enrolled=false){return hasIndexedFolderState(st.intel,folderId,enrolled);},
 
   selectFolder(folderId,folderName,enrolled){
     // Clear context

--- a/folder.html
+++ b/folder.html
@@ -602,6 +602,13 @@ function makeIndexMarker(rec,rootId){
   ensureContractShape(rec,rootId);const folder=rec?.folders?.[rootId]||{};
   return{schemaVersion:CONTRACT_VERSION,artifactType:CONTRACT_ARTIFACTS.marker,provider:rec?.provider||st.providerType,accountKey:rec?.accountKey||st.providerType,rootFolderId:rootId,rootFolderName:folder.name||st.selFolderName||rootId,folderVersion:rec?.folderVersion||0,indexArtifactRef:INTEL_FILE,indexArtifactETag:null,indexArtifactModifiedTime:rec?.updatedAt||null,directHash:folder.hash||folder.directHash||null,recursiveHash:rec?.freshness?.recursiveHash||null,entryCount:rec?.freshness?.entryCount||0,folderCount:rec?.freshness?.folderCount||0,pngEntryCount:Object.values(rec?.files||{}).filter(f=>f.mimeType==='image/png').length,pngReuseGroupCount:Object.keys(rec?.pngReuse?.groups||{}).length,updatedAt:rec?.updatedAt||null,lastWriter:rec?.lastWriter||makeLastWriter()};
 }
+function hasIndexedFolderState(rec,folderId,enrolled=false){
+  const folderRec=rec?.folders?.[folderId];
+  const stats=folderRec?.stats,agg=folderRec?.aggStats;
+  const hasStats=s=>!!s&&(s.totalFiles>0||s.totalSize>0||s.newestFile||s.oldestFile);
+  const hasVerifiedStats=!!(folderRec&&(folderRec.lastVerified||folderRec.firstIndexed)&&(stats||agg));
+  return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||folderRec?.isIndexed===true||folderRec?.indexed===true||hasVerifiedStats||hasStats(agg)||hasStats(stats));
+}
 
 function sleep(ms){return new Promise(r=>setTimeout(r,ms));}
 function $id(id){return document.getElementById(id);}
@@ -1090,12 +1097,14 @@ const Intel={
       while(st.acq.paused&&!st.acq.cancelled){await sleep(120);}
       const fid=queue.shift();if(visited.has(fid))continue;visited.add(fid);
       if(!rec.folders[fid]){
-        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,
+        rec.folders[fid]={id:fid,name:fid,parentId:null,depth:0,isEnrolled:fid===folderId,isIndexed:true,indexed:true,
           firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],
           stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},
           curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
       }else{
+        rec.folders[fid].firstIndexed=rec.folders[fid].firstIndexed||Date.now();
         rec.folders[fid].lastVerified=Date.now();
+        rec.folders[fid].isIndexed=true;rec.folders[fid].indexed=true;rec.folders[fid].status='current';
         rec.folders[fid].stats={totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null};
         rec.folders[fid].curation={inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0};
         rec.folders[fid].children=[];
@@ -1111,7 +1120,7 @@ const Intel={
       let subs=[];try{subs=await p.getSubfolders(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
       subs.forEach(sf=>{
         if(!rec.folders[fid].children.includes(sf.id))rec.folders[fid].children.push(sf.id);
-        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,firstIndexed:Date.now(),lastVerified:Date.now(),hash:'',status:'current',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
+        if(!rec.folders[sf.id])rec.folders[sf.id]={id:sf.id,name:sf.name,parentId:fid,depth:0,isEnrolled:false,isIndexed:false,indexed:false,firstIndexed:null,lastVerified:null,hash:'',status:'discovered',children:[],stats:{totalFiles:0,byClass:Object.fromEntries(CLASS_KEYS.map(k=>[k,0])),totalSize:0,newestFile:null,oldestFile:null},curation:{inbox:0,maybe:0,keep:0,trash:0,tagged:0,noted:0,rated:0,favorited:0}};
         queue.push(sf.id);
       });
       let allFiles=[];try{allFiles=await p.getAllFiles(fid);}catch(e){onLog(`  ⚠ ${e.message}`);}
@@ -1126,7 +1135,7 @@ const Intel={
         if(fr.tags.length)folder.curation.tagged++;if(fr.notes)folder.curation.noted++;if(fr.qualityRating||fr.contentRating)folder.curation.rated++;if(fr.favorite)folder.curation.favorited++;
         iCount++;
       });
-      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.lastVerified=Date.now();fScanned++;
+      folder.hash=simpleHash(hp.sort().join('|'));folder.directHash=folder.hash;folder.firstIndexed=folder.firstIndexed||Date.now();folder.lastVerified=Date.now();folder.isIndexed=true;folder.indexed=true;folder.status='current';fScanned++;
       if(fScanned%5===0)idbPut('intel',rec).catch(()=>{});
       onProg({folder:fname,fc:fScanned,ic:iCount,done:[...visited].map(id=>rec.folders[id]?.name||id)});onLog(`✓ Done ${fname}`);await sleep(0);
     }
@@ -1193,7 +1202,7 @@ const Tree={
   },
   renderNode(container,fid,fname,depth,parentId,knownChildren){
     const rec=st.intel;
-    const enrolled=rec?.enrolledRoots?.includes(fid)||false;
+    const enrolled=hasIndexedFolderState(rec,fid,rec?.enrolledRoots?.includes(fid)||false);
     const folderRec=rec?.folders?.[fid];
     const agg=folderRec?(folderRec.aggStats||folderRec.stats):null;
     const children=knownChildren||(folderRec?.children?.map(c=>({id:c,name:rec?.folders?.[c]?.name||c}))||null);
@@ -1601,7 +1610,7 @@ const App={
     return(Date.now()-lastCheck)>120000;
   },
 
-  isFolderIndexed(folderId,enrolled=false){const rec=st.intel,folderRec=rec?.folders?.[folderId],agg=folderRec?.aggStats||folderRec?.stats;return !!(enrolled||rec?.enrolledRoots?.includes(folderId)||folderRec?.isEnrolled||agg&&(agg.totalFiles>0||agg.totalSize>0||agg.newestFile||agg.oldestFile));},
+  isFolderIndexed(folderId,enrolled=false){return hasIndexedFolderState(st.intel,folderId,enrolled);},
 
   selectFolder(folderId,folderName,enrolled){
     // Clear context


### PR DESCRIPTION
### Motivation
- After adding Contract v1 scaffolding, recursively indexed child and descendant folders were not flagged as indexed in the UI, causing only the root to appear indexed in the tree.
- The change must be minimal and preserve existing Contract v1 helpers and artifact markers while correcting indexed/enrolled semantics for visited folders.

### Description
- Add a centralized helper `hasIndexedFolderState(rec,folderId,enrolled=false)` to determine indexed status from enrollment, `isIndexed`/`indexed` flags, verification timestamps, and stats, and use it in tree rendering and folder selection.
- When `Intel.acquire()` visits a folder mark the visited folder with `isIndexed:true`, `indexed:true`, set `firstIndexed` when missing, update `lastVerified` and `status:'current'`, and keep `isEnrolled` only for explicitly enrolled roots.
- Create newly discovered-but-not-yet-visited child folder records with `isIndexed:false`/`indexed:false`, `firstIndexed:null`, `lastVerified:null`, and `status:'discovered'` so they are not shown as indexed until visited.
- Wire `Tree.renderNode(...)` and `App.isFolderIndexed(...)` to use the new helper so descendant folders visited during recursion show indexed state and aggregate counts without requiring `isEnrolled`.

### Testing
- Ran `node --check` on extracted inline scripts for each file with `node --check /tmp/folder-check/folder.html.js`, `node --check /tmp/folder-check/folder-v1.html.js`, and `node --check /tmp/folder-check/folder-v2.html.js`, and all checks passed.
- Ran `git diff --check` to ensure no whitespace issues and it passed.
- Executed a local Node smoke check that exercised `hasIndexedFolderState` against a mock record with root, child, grandchild (visited/indexed) and a discovered-but-unvisited folder, and it validated the intended behavior (indexed folders true, discovered folder false).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b5bd21e0832daa4e3e19f1fb1304)