### PR TITLE
Auto-detect and render HTML / Markdown / plain text in z.html

### DIFF
--- a/z.html
+++ b/z.html
@@ -12,6 +12,11 @@
   tr:nth-child(even) {background:#f0f8ff;}
   #inputArea {width:100%; height:8rem; margin-bottom:1rem; font-family:monospace;}
   #loadBtn {padding:0.5rem 1rem; background:#007aff; color:#fff; border:none; border-radius:4px; cursor:pointer;}
+  #renderMode {display:inline-block; margin-left:0.75rem; color:#555; font-size:0.9rem;}
+  .rendered-output {background:#fff; border:1px solid #ddd; border-radius:6px; padding:1rem; overflow:auto;}
+  .rendered-output pre {white-space:pre-wrap; margin:0;}
+  .rendered-output blockquote {border-left:4px solid #ddd; color:#555; margin-left:0; padding-left:1rem;}
+  .html-frame {width:100%; min-height:20rem; border:1px solid #ddd; border-radius:6px; background:#fff;}
   #sessionToggle {display:flex; align-items:center; gap:0.5rem; padding:0.5rem 0; cursor:pointer; user-select:none;}
   #sessionChevron {display:inline-block; transition:transform 0.15s ease;}
   #sessionToggle[aria-expanded="true"] #sessionChevron {transform:rotate(90deg);}
@@ -31,7 +36,7 @@
   </div>
   <div id="sessionPanel" aria-hidden="true"></div>
   <textarea id="inputArea" placeholder="Paste the raw OpenClaw text here…"></textarea><br>
-  <button id="loadBtn">Render Table</button>
+  <button id="loadBtn">Render</button><span id="renderMode" aria-live="polite"></span>
   <div id="tableWrapper" style="margin-top:1rem;"></div>
 </div>
 
@@ -106,23 +111,122 @@ function toggleSessions() {
   panel.classList.toggle('open', !isOpen);
 }
 
-function parseToTable(text) {
-  // Split into lines, ignore empty lines
-  const lines = text.split(/\r?\n/).filter(l => l.trim() !== '');
-  // Guess separator – most OpenClaw tables use two+ spaces or a tab
-  const sep = / {2,}|\t/;
-  const rows = lines.map(l => l.split(sep).map(c => c.trim()));
-  // Build HTML
-  let html = '<table><thead><tr>';
-  rows[0].forEach(col => html += `<th>${escapeHtml(col)}</th>`);
-  html += '</tr></thead><tbody>';
-  for (let i = 1; i < rows.length; i++) {
-    html += '<tr>';
-    rows[i].forEach(col => html += `<td>${escapeHtml(col)}</td>`);
-    html += '</tr>';
+function looksLikeHtml(text) {
+  const trimmed = text.trim();
+  return /<(?:!doctype\s+html|html|head|body|div|section|article|main|p|br|h[1-6]|ul|ol|li|table|thead|tbody|tr|td|th|pre|code|blockquote|script|style|span|strong|em|a|img)\b[\s\S]*>/i.test(trimmed);
+}
+
+function looksLikeMarkdown(text) {
+  return /(^|\n)\s{0,3}(#{1,6}\s+|[-*+]\s+|\d+\.\s+|>\s+|```|---\s*$|\|.+\|)|\[[^\]]+\]\([^)]+\)|\*\*[^*]+\*\*|__[^_]+__|`[^`]+`/.test(text);
+}
+
+function renderInlineMarkdown(text) {
+  return escapeHtml(text)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+    .replace(/_([^_]+)_/g, '<em>$1</em>')
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+}
+
+function renderMarkdown(text) {
+  const lines = text.split(/\r?\n/);
+  let html = '';
+  let inList = false;
+  let inCode = false;
+  let paragraph = [];
+
+  function flushParagraph() {
+    if (!paragraph.length) return;
+    html += `<p>${renderInlineMarkdown(paragraph.join(' '))}</p>`;
+    paragraph = [];
   }
-  html += '</tbody></table>';
-  return html;
+
+  function closeList() {
+    if (!inList) return;
+    html += '</ul>';
+    inList = false;
+  }
+
+  lines.forEach(line => {
+    if (/^```/.test(line.trim())) {
+      flushParagraph();
+      closeList();
+      html += inCode ? '</code></pre>' : '<pre><code>';
+      inCode = !inCode;
+      return;
+    }
+
+    if (inCode) {
+      html += `${escapeHtml(line)}\n`;
+      return;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      closeList();
+      return;
+    }
+
+    const heading = line.match(/^\s{0,3}(#{1,6})\s+(.+)$/);
+    if (heading) {
+      flushParagraph();
+      closeList();
+      const level = heading[1].length;
+      html += `<h${level}>${renderInlineMarkdown(heading[2])}</h${level}>`;
+      return;
+    }
+
+    const listItem = line.match(/^\s{0,3}[-*+]\s+(.+)$/);
+    if (listItem) {
+      flushParagraph();
+      if (!inList) {
+        html += '<ul>';
+        inList = true;
+      }
+      html += `<li>${renderInlineMarkdown(listItem[1])}</li>`;
+      return;
+    }
+
+    const quote = line.match(/^\s{0,3}>\s?(.*)$/);
+    if (quote) {
+      flushParagraph();
+      closeList();
+      html += `<blockquote>${renderInlineMarkdown(quote[1])}</blockquote>`;
+      return;
+    }
+
+    paragraph.push(line.trim());
+  });
+
+  flushParagraph();
+  closeList();
+  if (inCode) html += '</code></pre>';
+  return `<div class="rendered-output">${html}</div>`;
+}
+
+function renderPlainText(text) {
+  return `<div class="rendered-output"><pre>${escapeHtml(text)}</pre></div>`;
+}
+
+function renderHtml(text) {
+  return `<iframe class="html-frame" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox" srcdoc="${escapeHtml(text)}"></iframe>`;
+}
+
+function detectMode(text) {
+  if (looksLikeHtml(text)) return 'html';
+  if (looksLikeMarkdown(text)) return 'markdown';
+  return 'plain text';
+}
+
+function renderContent(text) {
+  const mode = detectMode(text);
+  document.getElementById('renderMode').textContent = `Detected: ${mode}`;
+
+  if (mode === 'html') return renderHtml(text);
+  if (mode === 'markdown') return renderMarkdown(text);
+  return renderPlainText(text);
 }
 
 document.getElementById('sessionToggle').addEventListener('click', toggleSessions);
@@ -142,7 +246,7 @@ document.getElementById('sessionPanel').addEventListener('click', event => {
     const session = sessions.find(item => item.id === id);
     if (!session) return;
     document.getElementById('inputArea').value = session.content;
-    document.getElementById('tableWrapper').innerHTML = parseToTable(session.content);
+    document.getElementById('tableWrapper').innerHTML = renderContent(session.content);
   }
 
   if (event.target.classList.contains('remove-session')) {
@@ -155,7 +259,7 @@ document.getElementById('loadBtn').addEventListener('click', () => {
   const txt = document.getElementById('inputArea').value;
   if (!txt.trim()) { alert('Paste some text first'); return; }
   saveSession(txt);
-  document.getElementById('tableWrapper').innerHTML = parseToTable(txt);
+  document.getElementById('tableWrapper').innerHTML = renderContent(txt);
 });
 
 renderSessions();


### PR DESCRIPTION
### Motivation

- Provide a more flexible viewer by auto-detecting pasted content (HTML, Markdown, or plain text) instead of only parsing tables. 
- Make rendered output clearer to users by showing the detected mode and using safer sandboxed HTML previews. 
- Reuse saved-session flows with a single rendering pipeline to simplify code paths.

### Description

- Added content detection helpers `looksLikeHtml`, `looksLikeMarkdown`, and `detectMode`, and a single renderer `renderContent` that dispatches to HTML, Markdown, or plain-text renderers. 
- Implemented `renderHtml` using a sandboxed `<iframe>`, a small `renderMarkdown` renderer with inline formatting, and `renderPlainText` that preserves whitespace. 
- Replaced the old table-only parser usage with calls to `renderContent` in the load and session-open flows, and changed the button label to `Render` with a `#renderMode` label showing the detected type. 
- Added CSS for `.rendered-output` and `.html-frame` and adjusted layout styles for the new rendering modes.

### Testing

- Ran `node --check /tmp/z-script.js` to validate the injected script syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b17c0900c832db3e6235427715704)