### PR TITLE
TALKBRIDGE: bump master plan to v6.2.0 and add gating, ownership, and pre-build contracts

### DIFF
--- a/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
+++ b/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
@@ -86,10 +86,23 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <div>Next: Codex reads Parts 2–3 (what to build), Part 7 (sequence + acceptance), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
 </div>
 
+<div class="rule"><b>Authority & lineage.</b> This file, <code>TALKBRIDGE-MASTER-PLAN-v6.html v6.2.0</code>, is the only active product and build authority. Older files (<code>TALKBRIDGE-MASTER-PLAN.md</code>, <code>TALKBRIDGE-UI-INVENTORY.md</code>, <code>TALKBRIDGE-BUILD-MAP.md</code>, <code>TALKBRIDGE-BUILD-LOG.md</code>, generated prior HTML builds, and <code>talkbridge/build/*</code>) are lineage/context unless this plan explicitly imports a rule from them. If lineage conflicts with v6.2.0, v6.2.0 wins. The graveyard remains active only as the forbidden-approach registry.</div>
+
+<h3>Current baseline truth table</h3>
+<table>
+<tr><th>Artifact</th><th>Purpose</th><th>Status</th><th>Checksum / note</th><th>Allowed to build from?</th><th>Why</th></tr>
+<tr><td><code>bridge-turn07-post-ship.html</code></td><td>Bridge golden floor</td><td>Golden input</td><td>Part 5 SHA</td><td>No, except for verified extraction</td><td>Supplies known-good bridge organs; not the surviving app shell.</td></tr>
+<tr><td><code>bridge-turn08-base.html</code></td><td>Current container base</td><td>Best current base</td><td>Boots to start; chat works; PB incomplete</td><td>Yes</td><td>Surviving surface after failed test.html injection path.</td></tr>
+<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>UNGATED</td><td><code>f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</code></td><td>No, unless first re-banked</td><td>Device-deployed but not a passed baseline.</td></tr>
+<tr><td><code>test.html</code></td><td>Shell lineage</td><td>Golden input / lineage</td><td>Part 5 SHA</td><td>No direct build</td><td>Do not repeat runtime injection into this shell.</td></tr>
+<tr><td><code>2vid.html</code></td><td>Call presentation reference</td><td>Golden input / visual reference</td><td>Part 5 SHA</td><td>No direct build</td><td>Reference only; call must mount inside S4.</td></tr>
+<tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless updated by this plan</td><td>May point to older plan versions</td><td>No, unless reconciled first</td><td>Cannot override v6.2.0 authority.</td></tr>
+</table>
+
 <div class="tocbox">
 <a href="#p1">Part 1 · Vision &amp; intent</a>
 <a href="#p2">Part 2 · UX walkthrough by role (with mockups)</a>
-<a href="#p3">Part 3 · Surface &amp; element inventory v1.2.0</a>
+<a href="#p3">Part 3 · Surface &amp; element inventory v1.3.0</a>
 <a href="#p4">Part 4 · Configuration spec</a>
 <a href="#p5">Part 5 · Architecture: lift / refactor / build</a>
 <a href="#p6">Part 6 · Module map &amp; contracts</a>
@@ -143,7 +156,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
     <div style="position:absolute;bottom:16px;right:13px;width:46px;height:46px;border-radius:50%;background:var(--teal);display:flex;align-items:center;justify-content:center;box-shadow:0 4px 14px rgba(46,139,139,.35);"><span style="color:#fff;font-size:22px;font-weight:600;">+</span></div>
   </div>
 </div>
-<div class="mockcap"><div class="idx">S2 · Left panel</div><div class="beh">Top row: a blank borderless square — long-press opens S13 (keys · about · privacy); a plain tap does nothing. Beside it, current date and time. Room cards: editable title · pair + how long ago last accessed (as test.html shows) · unread badge (slashed bell when muted) · transcript icon · soft-delete. Share icon removed from the card — partner invite lives in the room (S4a) and device-linking lives in the room ⋯ drawer (S4b). Recycle bin below the list. Floating + → S3. Close by tapping the scrim.</div></div>
+<div class="mockcap"><div class="idx">S2 · Left panel</div><div class="beh">Top row: a blank borderless square — long-press opens S13 (keys · about · privacy); a plain tap does nothing. Beside it, current date and time. Room cards: editable title · pair + how long ago last accessed (as test.html shows) · unread badge (slashed bell when muted) · transcript icon · soft-delete. Share icon removed from the card — partner invite lives in the room invite card (S4a) before join, and owner device-linking lives in the room ⋯ drawer (S4b) as Link a device. Recycle bin below the list. Floating + → S3. Close by tapping the scrim.</div></div>
 </div>
 
 <div class="mockrow">
@@ -361,11 +374,11 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><th>ID</th><th>Surface</th><th>Elements &amp; behavior</th></tr>
 <tr><td><b>S0</b></td><td>First run</td><td>Flag-motif card: title ask · name input (40) · Continue · inline error. Once only.</td></tr>
 <tr><td><b>S1</b></td><td>Start screen</td><td>Ribbon: ☰ · auto-read speaker (slash = off). Flag-motif welcome + instruction text. Always the boot state; never auto-opens a room.</td></tr>
-<tr><td><b>S2</b></td><td>Left panel</td><td>Gear (→S13). Room cards: editable title · pair+activity subtitle · unread badge · mute state (slashed bell replaces badge) · share (3-node icon, reopens invite S4a) · transcript/diagnostics · soft-delete. Recycle bin section (soft-deleted rooms, restorable) below the list. Floating + FAB → S3. Close = tap scrim (no button).</td></tr>
+<tr><td><b>S2</b></td><td>Left panel</td><td>Gear (→S13). Room cards: editable title · pair+activity subtitle · unread badge · mute state (slashed bell replaces badge) · transcript/diagnostics · soft-delete. No room-card share icon; owner device-linking moved to S4b as Link a device. Recycle bin section (soft-deleted rooms, restorable) below the list. Floating + FAB → S3. Close = tap scrim (no button).</td></tr>
 <tr><td><b>S3</b></td><td>Create room</td><td>Flag band "Start new chat" · Your language ▾ (flag+name) · Partner language ▾ · Auto-read toggle (default on) · Cancel · OK → enter room. No name, no room-name fields.</td></tr>
 <tr><td><b>S4</b></td><td>Room / one transcript</td><td>Header: ☰ · partner name + presence · video + call icons CENTERED (always active, solo allowed; grayed while a PiP lives) · ⋯ FAR RIGHT (opens/closes S4b). Compose placeholder: "Type or /search". Send = paper-airplane icon (same icon as S5), always visible, hideable via S4b toggle. Bubbles per S4-B below. System pills: call ended+duration · missed call · date. Scroll-down indicator. Compose: 📎 · field "Message or / to search phrases" (auto-grow; × in search mode) · Go (always visible, dim when empty; Enter=Go; "/" prefix routes to search on both).</td></tr>
-<tr><td><b>S4b</b></td><td>Room drawer</td><td>Opened/closed by header ⋯. All room-scoped settings: YOUR NAME for this room (shown on your meta line to the partner — personalization: "Bob", emoji, anything; changes apply forward only, old bubbles keep the old name, and a system pill lands in the transcript: "Mike is now Bob") · auto-read · mute (kills ring + message-waiting; slashed bell on S2 card) · Go-button show/hide · meta line placement dropdown: Top (default) / Bottom / Off · APPEARANCE, exactly test.html's Me/Partner table, per room, NO reset button, persists across the owner's linked devices (carried in link-device payload + local storage; relay optional later) · export transcript (document icon) · LINK A DEVICE: hands off THIS ROOM ONLY to your other device; both synced, call active on one at a time · debug (modal with copy + download).</td></tr>
-<tr><td><b>S4a</b></td><td>Invite card</td><td>Top of transcript until partner joins: "Invite {name}" · QR · link (tap copies) · Copy · Share (system sheet). Vanishes on join; reopenable from S2 share icon.</td></tr>
+<tr><td><b>S4b</b></td><td>Room drawer</td><td>Opened/closed by header ⋯. All room-scoped settings: YOUR NAME for this room (shown on your meta line to the partner — personalization: "Bob", emoji, anything; changes apply forward only, old bubbles keep the old name, and a system pill lands in the transcript: "Mike is now Bob") · auto-read · mute (kills ring + message-waiting; slashed bell on S2 card) · Go-button show/hide · meta line placement dropdown: Top (default) / Bottom / Off · APPEARANCE, exactly test.html's Me/Partner table, per room, NO reset button, persists across the owner's linked devices (carried in link-device payload + local storage; relay optional later) · export transcript (document icon) · LINK A DEVICE: hands off THIS ROOM ONLY to your other device; both synced, call active on one at a time · debug (modal with copy + download) · Link a device replaces the old room-card share action and links this room to the owner's other device only.</td></tr>
+<tr><td><b>S4a</b></td><td>Invite card</td><td>Top of transcript until partner joins: "Invite {name}" · QR · link (tap copies) · Copy · Share (system sheet). Vanishes on join; not reopened from S2. Device linking is separate and lives in S4b as Link a device.</td></tr>
 <tr><td><b>S4-B</b></td><td>Bubble (canonical)</td><td>Mine right / theirs left, corner-tucked. Body: my-language col | divider | partner-language col — both always shown; each viewer's own language left. Meta line (placement per S4b): origin mark (🎤 spoken, none typed) · time · receipts own-only as dots (1 small black sent · 2 delivered · larger blue read; tap = status detail). Tap column = TTS. Long-press = Save / Delete(confirm) / Clarify. Attachment chip or image inline. "⚠ not translated" badge on failure. Appearance per S13.</td></tr>
 <tr><td><b>S5</b></td><td>Phrase search sheet</td><td>Trigger: "/" or ".." in compose; live filter; -word excludes; newest first. Header: 📖 (→S7) · pair flags · "n of total" count. Result rows: source | target; each side has speaker (TTS) + › — tapping › or the text loads that side into compose. Compose keeps 📎, gains × (cancel search), send stays visible. Close: ×, Esc, or send. Identical in-call.</td></tr>
 <tr><td><b>S6</b></td><td>PB card</td><td>Header: "Created {by} · {date time} — Modified {by} · {date time}". Side-by-side editable columns (Enter commits) · Use + speaker per side (Use loads compose + counts). Footer grid: × to-trash (Restore + Delete-Forever when trashed) · # tags · 💬 clarify. Panels: tags (pills+×, add input, suggestions, Enter adds+refocuses) · clarify (note, Enter commits+refocuses) · back-translation always visible (italic result · ✓ Sounds Good / ⚑ Flag radios; verdict resets only on source change). Long-press = quick-ring. Duplicate save → "Already saved" toast.</td></tr>
@@ -425,6 +438,20 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <li>Output file checksum recorded in the plan per attempt; deployed file byte-verified at the exact commit SHA (never at main).</li>
 </ol>
 
+<h4>Pre-build entry checklist (hard gate)</h4>
+<table>
+<tr><th>#</th><th>Required before coding</th><th>Pass condition</th></tr>
+<tr><td>1</td><td>Active source of truth</td><td>Builder states: v6.2.0 only; lineage read only for context.</td></tr>
+<tr><td>2</td><td>Baseline</td><td>Path + checksum recorded; allowed-to-build-from table says Yes.</td></tr>
+<tr><td>3</td><td>Target piece</td><td>One named piece/stage only; exact surfaces/modules touched and not touched listed.</td></tr>
+<tr><td>4</td><td>Graveyard scan</td><td>No forbidden signature match; any match stops work.</td></tr>
+<tr><td>5</td><td>Acceptance copied first</td><td>Deterministic criteria + device script written before edits.</td></tr>
+<tr><td>6</td><td>Rollback</td><td>Rollback file/checksum/procedure named before edits.</td></tr>
+</table>
+
+<h4>Gate sizing law</h4>
+<div class="rule">One gate may touch only one ownership boundary: shell boot/panel, room drawer, transcript, compose/search, phrasebook, call layer, joiner routing, or notifications. If a change needs two ownership boundaries, split it. Each gate states exact DOM/state before/after and a must-remain-unchanged list. Transcript and compose are not both replaced in separate visible states; bridge organs may be staged internally only while hidden/dormant.</div>
+
 <h2 id="p6">Part 6 · Module map &amp; contracts</h2>
 <p class="small">Every UI function belongs to exactly one module. Modules are black boxes: defined inputs → predictable outputs. Contracts are the only crossings. Gaps, overlaps, collisions = none, by inspection of this table. Technical appendix (function-level signatures) is manager/doer territory and rides in the repo next to the plan.</p>
 <table>
@@ -436,7 +463,24 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><td><b>M5 Keys/Transport</b></td><td>S11 · relay · TURN · Deepgram auth · GH API</td><td>credentials to M2 M3 M4 on demand</td><td>key entry ← S13</td></tr>
 <tr><td><b>M6 PWA/Notify</b></td><td>S14 · manifest · service worker · ring · badge · mute</td><td>accept/decline → M3 · badgeCount → M1 · open(room) → M1</td><td>notify ← M2 · incomingCall ← M3 · muteState ← M1</td></tr>
 </table>
-<div class="rule warn">Collision guards: one global namespace only (module IIFEs) · M2/M3/M4 share the sealed bridge bundle and speak to shell only via the contracts above · no module reaches into another's DOM.</div>
+
+<h4>Single-owner surface / module table</h4>
+<table>
+<tr><th>Responsibility</th><th>Owner</th><th>Forbidden duplicate owner</th><th>Activation trigger</th><th>Acceptance signal</th></tr>
+<tr><td>Boot/start</td><td>M1 Shell</td><td>Bridge lobby/call boot</td><td>App load</td><td>S1, panel closed, no room/call.</td></tr>
+<tr><td>Room list/panel/create</td><td>M1 Shell</td><td>Bridge room picker</td><td>☰ / +</td><td>S2/S3 only.</td></tr>
+<tr><td>Invite card</td><td>M2 Bridge-Conversation</td><td>S2 share card action</td><td>Room before partner join</td><td>S4a top card; gone after join.</td></tr>
+<tr><td>Room drawer/settings</td><td>M1 shell chassis + M2 room config contract</td><td>Global settings drawer</td><td>S4 ⋯</td><td>S4b owns name, appearance, Link a device, export, debug.</td></tr>
+<tr><td>Transcript / bubbles</td><td>M2 Bridge-Conversation</td><td>Shell stacked bubbles</td><td>Explicit room entry</td><td>Side-by-side canonical bubbles.</td></tr>
+<tr><td>Compose / send / search predicate</td><td>M2 Bridge-Conversation</td><td>Shell composer</td><td>Explicit room entry</td><td>One compose strip; / and .. route to S5.</td></tr>
+<tr><td>Phrasebook</td><td>M4 Phrasebook</td><td>Shell catalog/PB</td><td>📖, save, call write-back</td><td>Pair-scoped S6/S7/S8 only.</td></tr>
+<tr><td>Relay/presence/receipts</td><td>M5 transport + M2 contract</td><td>Independent second relay UI owner</td><td>Room entry</td><td>Presence/meta/receipts update without duplicate surfaces.</td></tr>
+<tr><td>Translation/TTS</td><td>M2/M4 on demand</td><td>Parallel shell translation path</td><td>Send/search/card action</td><td>One translated output path.</td></tr>
+<tr><td>Call signaling/UI/STT</td><td>M3 Bridge-Call</td><td>2vid floating window or boot-time call app</td><td>User taps call/video or accepts S14</td><td>S9 mounts over S4 only.</td></tr>
+<tr><td>Notifications</td><td>M6 PWA/Notify</td><td>In-room notification surface while open</td><td>Background incoming event</td><td>S14 OS notification; mute suppresses.</td></tr>
+<tr><td>Device linking</td><td>S4b Link a device</td><td>S2 room-card share</td><td>S4 ⋯ → Link a device</td><td>QR/link for owner device only.</td></tr>
+</table>
+<div class="rule warn">A build fails if two modules own the same row. Collision guards: one global namespace only (module IIFEs) · M2/M3/M4 share the sealed bridge bundle and speak to shell only via the contracts above · no module reaches into another's DOM.</div>
 
 <h2 id="p7">Part 7 · Build sequence &amp; deterministic acceptance</h2>
 <p class="small">Versioning: <code>series.turn.stage.attempt</code> — series 5, turn 8; stages pre-ship → ship → post-ship. Each piece gets: deterministic acceptance (answerable before any device test) + a device script (the gift, after certification). No piece starts before the previous piece's device gate passes and plan+graveyard are updated.</p>
@@ -450,6 +494,30 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><td><b>P5</b> Polish + defects</td><td>meta-line placement live (top/bottom/off) · S8 stacking defect · receipts detail popup · PB refresh on entry</td><td>each defect has a reproduce-step that now returns the specified result in scripted DOM test · inventory diff = zero</td><td>toggle meta placements, dots move/hide · open + twice, one card · reopen room, PB fresh</td></tr>
 <tr><td><b>P6</b> PWA (M6)</td><td>manifest · service worker · install · ring w/ Accept-Decline · message-waiting · per-room mute</td><td>Lighthouse installable pass · notification payloads validate against S14 spec · mute state provably suppresses (unit trace)</td><td>install to home screen · lock phone, partner calls → rings, Accept lands in call, Decline leaves missed pill · message → waiting notification · muted room: silence</td></tr>
 </table>
+
+<h4>Mandatory inert-on-boot acceptance</h4>
+<ul>
+<li>Applies to any gate importing bridge, phrasebook, relay, speech, or call code.</li>
+<li>Cold boot lands on S1; no room auto-opens; no bridge lobby; no call surface; no microphone/camera permission prompt.</li>
+<li>No relay/call/Deepgram connection starts before explicit room entry or call start.</li>
+<li>Console/log checkpoints prove zero bridge/call initialization before the intended trigger.</li>
+<li>Must be checked in a real browser/device path, not jsdom/static checks alone.</li>
+</ul>
+
+<h4>Device-test scripts (minimum tap paths)</h4>
+<table>
+<tr><th>Surface</th><th>Start</th><th>Do</th><th>Pass</th></tr>
+<tr><td>S0/S1</td><td>Fresh or cleared name</td><td>Enter name, reload</td><td>Name asks once; subsequent boot shows S1 only.</td></tr>
+<tr><td>S2/S3</td><td>S1</td><td>☰, long-press square, +, Cancel/OK</td><td>Panel/date/time/S13/Create work; no share icon.</td></tr>
+<tr><td>S4/S4b</td><td>Existing room</td><td>Tap room, open ⋯, edit settings, Link a device</td><td>Room opens only by tap; drawer owns room settings and device link.</td></tr>
+<tr><td>S5</td><td>S4 compose</td><td>Type / and .., filter, send/cancel</td><td>Search overlays transcript; no / text sent accidentally.</td></tr>
+<tr><td>S7/S8</td><td>S4</td><td>Open 📖, + twice, edit source, Enter</td><td>One empty card focused; translation/back-translation inline.</td></tr>
+<tr><td>S9</td><td>S4</td><td>Start call, BACK, expand, ×/hang up</td><td>S9 over S4; PiP works; transcript persists spoken lines.</td></tr>
+<tr><td>S10</td><td>Invite URL</td><td>Open as joiner, enter localized name, Join</td><td>Only that room; no panel/create.</td></tr>
+<tr><td>S13/S11</td><td>S2</td><td>Long-press square, tap all three buttons, save keys</td><td>Keys/About/Privacy all live; no appearance/data controls.</td></tr>
+<tr><td>S14</td><td>PWA background</td><td>Incoming call/message, mute room, retry</td><td>Accept/Decline/message-waiting per spec; mute suppresses.</td></tr>
+</table>
+
 <div class="rule">Ship gate = all P1–P6 device-passed on real phones (initiator + joiner) with zero do-not-touch regressions (Part 9). Post-ship = observation window, graveyard/process review, then out-of-scope items unfreeze (language rollout, PB scale, category redesign).</div>
 
 <h2 id="p8">Part 8 · Methodology</h2>
@@ -472,6 +540,35 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <li>After each confirmed ship: owner-provided process/self assessment → improvements enshrined here and in the graveyard, same turn.</li>
 <li>Token discipline: no play-by-play; report started/completed/blocked only.</li>
 </ul>
+
+<h4>Implementation staging vs product shipping</h4>
+<div class="rule">Bridge organs (transcript, compose/search, phrasebook) may be integrated behind internal gates only when incomplete states are hidden or dormant. No final/pilot build may expose transcript without compose/search/phrasebook, or compose/search/phrasebook without transcript. Temporary scaffolding is allowed only when acceptance proves it has no visible behavior.</div>
+
+<h4>Mandatory stop conditions</h4>
+<ul>
+<li>Stop if cold boot shows any room/call/bridge surface, or any permission prompt appears before user intent.</li>
+<li>Stop if a prior fixed issue reappears, a touched surface passes but an adjacent surface breaks, or deployed bytes do not match verified checksum.</li>
+<li>Stop if a device-only failure appears that deterministic checks missed, or a second patch is proposed for the same failed gate.</li>
+<li>Required response: rollback, record signature, compare graveyard, update acceptance criteria, restart from last banked baseline. Do not patch forward.</li>
+</ul>
+
+<h4>Rollback metadata (mandatory per attempt)</h4>
+<table>
+<tr><th>Field</th><th>Required value</th></tr>
+<tr><td>Start</td><td>Artifact path + checksum</td></tr>
+<tr><td>Output</td><td>Artifact path + checksum + commit SHA byte-verify</td></tr>
+<tr><td>Rollback</td><td>Artifact path + checksum + exact restore procedure</td></tr>
+<tr><td>Status</td><td>Whether rollback has been byte-verified</td></tr>
+</table>
+
+<h4>Coding-agent implementation contract</h4>
+<ol>
+<li>Restate target gate, exact files to touch, exact files not to touch, and that v6.2.0 is the only active plan.</li>
+<li>Confirm graveyard scan and pre-build checklist before editing.</li>
+<li>Produce the minimal diff only; never improvise beyond the named target.</li>
+<li>Never runtime-inject an independently booting app; modules must be inert until their trigger.</li>
+<li>Record deterministic checks, device script status, rollback metadata, and any blockers. If ambiguous, stop rather than guess.</li>
+</ol>
 
 <h2 id="p9">Part 9 · Registries</h2>
 <h4>Do-not-touch (regression tripwires — retested at every device gate)</h4>


### PR DESCRIPTION
### Motivation
- Update the canonical product/build plan `TALKBRIDGE-MASTER-PLAN-v6.html` to v6.2.0 and make the plan the single active source of truth with explicit authority and lineage rules.
- Clarify inventory and UX rulings (surface v1.3.0) and remove ambiguity around where room-invite and device-linking actions live.
- Enshrine deterministic pre-build gates, module ownership, inert-on-boot acceptance, and rollback metadata to prevent previous runtime-injection/startup race failures.

### Description
- Updated `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` header and version to v6.2.0 and bumped Part 3 inventory to `v1.3.0` with related copy edits to S2, S4a, and S4b behaviors.
- Added an explicit `Authority & lineage` paragraph and a `Current baseline truth table` that documents allowed sources and checksums for builds.
- Introduced a `Pre-build entry checklist`, `Gate sizing law`, `Single-owner surface / module table`, and extended module/ownership contracts in Part 6 to prevent duplicate owners and DOM intrusions.
- Expanded Part 7 with `Mandatory inert-on-boot acceptance`, device-test scripts, and deterministic acceptance criteria, and added staging/stop/rollback metadata and a `Coding-agent implementation contract` in Part 8. 

### Testing
- No automated tests were run for this change because it is a documentation/spec HTML update only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b19aa3a8c832d8d0e892062a76385)