### PR TITLE
Close external QR script tag and move S2/S13 initializer; update master plan (5.8.pre-ship.6)

### DIFF
--- a/bridge-turn08-pre-ship.html
+++ b/bridge-turn08-pre-ship.html
@@ -501,7 +501,8 @@ input::placeholder,textarea::placeholder{color:var(--ink-dim);opacity:.7;}
 </div>
 
 <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>
 // S2 datetime display
 (function(){
   function updateDT(){

--- a/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
+++ b/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
@@ -81,7 +81,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <div>Plan: v6.2.0 · Inventory: v1.3.0 (Part 3) · Executor: Codex (Claude retired from code; Claude remains plan/graveyard custodian)</div>
 <div>Golden floor: <b>bridge-turn07-post-ship.html</b> (checksums Part 5)</div>
 <div>Best current base: <b>bridge-turn08-base.html</b> — boots to start screen, shell + bridge merged, chat works; PB incomplete; retired panel buttons still present</div>
-<div>Deployed pre-ship (5.8.pre-ship.5, UNGATED): turn08-base + P2 changes (blank square long-press → 3-button modal, date/time, retired buttons removed) · sha256 f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</div>
+<div>Deployed pre-ship (5.8.pre-ship.6, READY FOR P2 DEVICE GATE): <code>bridge-turn08-pre-ship.html</code> · sha256 <code>b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1</code> · fixes executable S2 datetime and S13 long-press initializer by closing the external QR script tag before the inline initializer.</div>
 <div>Failed approach (do not repeat): injecting bridge into test.html shell — bridge always wakes on load. Build FROM turn08-base instead.</div>
 <div>Next: Codex reads Parts 2–3 (what to build), Part 7 (sequence + acceptance), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
 </div>
@@ -93,7 +93,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><th>Artifact</th><th>Purpose</th><th>Status</th><th>Checksum / note</th><th>Allowed to build from?</th><th>Why</th></tr>
 <tr><td><code>bridge-turn07-post-ship.html</code></td><td>Bridge golden floor</td><td>Golden input</td><td>Part 5 SHA</td><td>No, except for verified extraction</td><td>Supplies known-good bridge organs; not the surviving app shell.</td></tr>
 <tr><td><code>bridge-turn08-base.html</code></td><td>Current container base</td><td>Best current base</td><td>Boots to start; chat works; PB incomplete</td><td>Yes</td><td>Surviving surface after failed test.html injection path.</td></tr>
-<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>UNGATED</td><td><code>f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</code></td><td>No, unless first re-banked</td><td>Device-deployed but not a passed baseline.</td></tr>
+<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>Ready for P2 device gate</td><td><code>b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1</code></td><td>No, unless P2 device gate passes and owner re-banks it</td><td>Not the next build baseline until the P2 device gate passes and the owner re-banks it.</td></tr>
 <tr><td><code>test.html</code></td><td>Shell lineage</td><td>Golden input / lineage</td><td>Part 5 SHA</td><td>No direct build</td><td>Do not repeat runtime injection into this shell.</td></tr>
 <tr><td><code>2vid.html</code></td><td>Call presentation reference</td><td>Golden input / visual reference</td><td>Part 5 SHA</td><td>No direct build</td><td>Reference only; call must mount inside S4.</td></tr>
 <tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless updated by this plan</td><td>May point to older plan versions</td><td>No, unless reconciled first</td><td>Cannot override v6.2.0 authority.</td></tr>
@@ -871,5 +871,11 @@ All P2 criteria met including keys button tap path. P2 done.
 
 ### GATE · 5.8.pre-ship.4 · P3 · FAIL · Jul 5 2026 19:35 PT
 Call surface appeared on boot — bridge woke at load, not on room entry. Rollback to P2 972eca6 ordered.
+### 5.8.pre-ship.6 · P2 stabilization / execution prep · 2026-07-06
+- Scope limited to executable S2 datetime / S13 long-press script wiring in `bridge-turn08-pre-ship.html`.
+- No P3 bridge-organ integration; no phrasebook, call, Deepgram, WebRTC, relay, or notification changes.
+- Output checksum: b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1.
+- Device gate required before treating this as a banked P2 baseline.
+
 </pre>
 </body></html>


### PR DESCRIPTION
### Motivation
- Fix an HTML wiring bug where the external QR library `<script src="...">` tag contained inline initializer code so the S2 datetime and S13 long-press logic did not execute as a standalone inline script.
- Record the state change for Turn 08 in the canonical master plan by marking `bridge-turn08-pre-ship.html` as the current pre-ship candidate for `5.8.pre-ship.6` with the requested status, purpose, and checksum text.

### Description
- In `bridge-turn08-pre-ship.html` the external QR script tag is now closed (`<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>`) and the original S2 datetime / S13 long-press initializer was moved verbatim into a separate inline `<script>` block immediately after it.
- In `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` the CODEX handoff current state line was updated to reference `5.8.pre-ship.6` and the requested SHA/summary/purpose text was added, the `bridge-turn08-pre-ship.html` row in the baseline truth table was updated to reflect "Ready for P2 device gate" and the new SHA text, and a concise `5.8.pre-ship.6` entry was appended to the Turn 08 build log describing the narrow scope.
- The changes were intentionally minimal and limited to only the two target files and preserved the initializer logic exactly when moved into the inline script.

### Testing
- Verified no `<script src="...">` tag contains inline JavaScript using a small regex scan, and the check returned `PASS` for the modified file.
- Verified the S2 datetime / S13 long-press initializer is present in a separate inline `<script>` block by matching the initializer comments and code, and this check returned `PASS`.
- Verified the diff touches only `bridge-turn08-pre-ship.html` and `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` with `git diff --name-only`, and this check returned `PASS`.
- Attempted SHA-256 verification for `bridge-turn08-pre-ship.html` against `b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1` using `sha256sum`, but the actual checksum was `4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb`, so the SHA check `FAIL`ed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b41f0ed1c832dae0eadb2d8130e17)