### PR TITLE
Reconcile pre-ship checksum in master plan

### DIFF
--- a/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
+++ b/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
@@ -81,7 +81,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <div>Plan: v6.2.0 · Inventory: v1.3.0 (Part 3) · Executor: Codex (Claude retired from code; Claude remains plan/graveyard custodian)</div>
 <div>Golden floor: <b>bridge-turn07-post-ship.html</b> (checksums Part 5)</div>
 <div>Best current base: <b>bridge-turn08-base.html</b> — boots to start screen, shell + bridge merged, chat works; PB incomplete; retired panel buttons still present</div>
-<div>Deployed pre-ship (5.8.pre-ship.6, READY FOR P2 DEVICE GATE): <code>bridge-turn08-pre-ship.html</code> · sha256 <code>b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1</code> · fixes executable S2 datetime and S13 long-press initializer by closing the external QR script tag before the inline initializer.</div>
+<div>Deployed pre-ship (5.8.pre-ship.6, READY FOR P2 DEVICE GATE): <code>bridge-turn08-pre-ship.html</code> · sha256 <code>4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb</code> · fixes executable S2 datetime and S13 long-press initializer by closing the external QR script tag before the inline initializer.</div>
 <div>Failed approach (do not repeat): injecting bridge into test.html shell — bridge always wakes on load. Build FROM turn08-base instead.</div>
 <div>Next: Codex reads Parts 2–3 (what to build), Part 7 (sequence + acceptance), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
 </div>
@@ -93,7 +93,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><th>Artifact</th><th>Purpose</th><th>Status</th><th>Checksum / note</th><th>Allowed to build from?</th><th>Why</th></tr>
 <tr><td><code>bridge-turn07-post-ship.html</code></td><td>Bridge golden floor</td><td>Golden input</td><td>Part 5 SHA</td><td>No, except for verified extraction</td><td>Supplies known-good bridge organs; not the surviving app shell.</td></tr>
 <tr><td><code>bridge-turn08-base.html</code></td><td>Current container base</td><td>Best current base</td><td>Boots to start; chat works; PB incomplete</td><td>Yes</td><td>Surviving surface after failed test.html injection path.</td></tr>
-<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>Ready for P2 device gate</td><td><code>b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1</code></td><td>No, unless P2 device gate passes and owner re-banks it</td><td>Not the next build baseline until the P2 device gate passes and the owner re-banks it.</td></tr>
+<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>Ready for P2 device gate</td><td><code>4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb</code></td><td>No, unless P2 device gate passes and owner re-banks it</td><td>Not the next build baseline until the P2 device gate passes and the owner re-banks it.</td></tr>
 <tr><td><code>test.html</code></td><td>Shell lineage</td><td>Golden input / lineage</td><td>Part 5 SHA</td><td>No direct build</td><td>Do not repeat runtime injection into this shell.</td></tr>
 <tr><td><code>2vid.html</code></td><td>Call presentation reference</td><td>Golden input / visual reference</td><td>Part 5 SHA</td><td>No direct build</td><td>Reference only; call must mount inside S4.</td></tr>
 <tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless updated by this plan</td><td>May point to older plan versions</td><td>No, unless reconciled first</td><td>Cannot override v6.2.0 authority.</td></tr>
@@ -874,7 +874,7 @@ Call surface appeared on boot — bridge woke at load, not on room entry. Rollba
 ### 5.8.pre-ship.6 · P2 stabilization / execution prep · 2026-07-06
 - Scope limited to executable S2 datetime / S13 long-press script wiring in `bridge-turn08-pre-ship.html`.
 - No P3 bridge-organ integration; no phrasebook, call, Deepgram, WebRTC, relay, or notification changes.
-- Output checksum: b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1.
+- Output checksum: 4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb.
 - Device gate required before treating this as a banked P2 baseline.
 
 </pre>


### PR DESCRIPTION
### Motivation
- Align the canonical master plan with the actual committed artifact so owner testing proceeds without checksum mismatch for `5.8.pre-ship.6` / `bridge-turn08-pre-ship.html`.

### Description
- Replace the prior expected SHA `b55681410552a0bb101607bbf6689eadedabc4fa87be7991834c1e0bb63769e1` with the actual committed artifact SHA `4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb` in `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` (deployed pre-ship summary, baseline truth table, and `5.8.pre-ship.6` output checksum), and do not otherwise modify plan language or versioning.

### Testing
- Run the provided inline script structure check (`python3 - <<'PY' ... PY`): PASS.
- Verify artifact checksum with `sha256sum bridge-turn08-pre-ship.html`: PASS (matches `4769bd2f9...a3bb`).
- Confirm old SHA is removed and new SHA is present in `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` using ripgrep: PASS.
- Confirm only `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` changed and `git diff --check` produced no issues: PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b49fadd40832d93df6a144ab44e69)