### PR TITLE
Rollback failed P2/pre-ship.6: restore bridge-turn08-pre-ship and revert master plan

### DIFF
--- a/bridge-turn08-pre-ship.html
+++ b/bridge-turn08-pre-ship.html
@@ -501,8 +501,7 @@ input::placeholder,textarea::placeholder{color:var(--ink-dim);opacity:.7;}
 </div>
 
 <style>@keyframes spin{to{transform:rotate(360deg)}}</style>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-<script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js">
 // S2 datetime display
 (function(){
   function updateDT(){

--- a/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
+++ b/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
@@ -81,7 +81,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <div>Plan: v6.2.0 · Inventory: v1.3.0 (Part 3) · Executor: Codex (Claude retired from code; Claude remains plan/graveyard custodian)</div>
 <div>Golden floor: <b>bridge-turn07-post-ship.html</b> (checksums Part 5)</div>
 <div>Best current base: <b>bridge-turn08-base.html</b> — boots to start screen, shell + bridge merged, chat works; PB incomplete; retired panel buttons still present</div>
-<div>Deployed pre-ship (5.8.pre-ship.6, READY FOR P2 DEVICE GATE): <code>bridge-turn08-pre-ship.html</code> · sha256 <code>4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb</code> · fixes executable S2 datetime and S13 long-press initializer by closing the external QR script tag before the inline initializer.</div>
+<div>Deployed pre-ship (5.8.pre-ship.5, UNGATED): turn08-base + P2 changes (blank square long-press → 3-button modal, date/time, retired buttons removed) · sha256 f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</div>
 <div>Failed approach (do not repeat): injecting bridge into test.html shell — bridge always wakes on load. Build FROM turn08-base instead.</div>
 <div>Next: Codex reads Parts 2–3 (what to build), Part 7 (sequence + acceptance), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
 </div>
@@ -93,7 +93,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><th>Artifact</th><th>Purpose</th><th>Status</th><th>Checksum / note</th><th>Allowed to build from?</th><th>Why</th></tr>
 <tr><td><code>bridge-turn07-post-ship.html</code></td><td>Bridge golden floor</td><td>Golden input</td><td>Part 5 SHA</td><td>No, except for verified extraction</td><td>Supplies known-good bridge organs; not the surviving app shell.</td></tr>
 <tr><td><code>bridge-turn08-base.html</code></td><td>Current container base</td><td>Best current base</td><td>Boots to start; chat works; PB incomplete</td><td>Yes</td><td>Surviving surface after failed test.html injection path.</td></tr>
-<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>Ready for P2 device gate</td><td><code>4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb</code></td><td>No, unless P2 device gate passes and owner re-banks it</td><td>Not the next build baseline until the P2 device gate passes and the owner re-banks it.</td></tr>
+<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>UNGATED</td><td><code>f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</code></td><td>No, unless first re-banked</td><td>Device-deployed but not a passed baseline.</td></tr>
 <tr><td><code>test.html</code></td><td>Shell lineage</td><td>Golden input / lineage</td><td>Part 5 SHA</td><td>No direct build</td><td>Do not repeat runtime injection into this shell.</td></tr>
 <tr><td><code>2vid.html</code></td><td>Call presentation reference</td><td>Golden input / visual reference</td><td>Part 5 SHA</td><td>No direct build</td><td>Reference only; call must mount inside S4.</td></tr>
 <tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless updated by this plan</td><td>May point to older plan versions</td><td>No, unless reconciled first</td><td>Cannot override v6.2.0 authority.</td></tr>
@@ -871,11 +871,8 @@ All P2 criteria met including keys button tap path. P2 done.
 
 ### GATE · 5.8.pre-ship.4 · P3 · FAIL · Jul 5 2026 19:35 PT
 Call surface appeared on boot — bridge woke at load, not on room entry. Rollback to P2 972eca6 ordered.
-### 5.8.pre-ship.6 · P2 stabilization / execution prep · 2026-07-06
-- Scope limited to executable S2 datetime / S13 long-press script wiring in `bridge-turn08-pre-ship.html`.
-- No P3 bridge-organ integration; no phrasebook, call, Deepgram, WebRTC, relay, or notification changes.
-- Output checksum: 4769bd2f952961f6a6d347ed4a16d58287e3f0084428d457f87695dc7ff8a3bb.
-- Device gate required before treating this as a banked P2 baseline.
+### GATE · 5.8.pre-ship.6 · P2 · FAIL · 2026-07-06
+Owner device test: FAIL — Frankenstein / too many regressions to classify. Manager ruling: do not patch forward; rollback to last known good baseline before this attempt.
 
 </pre>
 </body></html>


### PR DESCRIPTION
### Motivation
- Restore the repository to the last known good state before the failed `5.8.pre-ship.6` device gate attempt which introduced QR/S2/S13 wiring regressions. 
- Ensure the failed `5.8.pre-ship.6` artifact is not presented as banked/ready and record the device-test failure per manager ruling.

### Description
- Restored `bridge-turn08-pre-ship.html` from the known-good source `3e01500:bridge-turn08-pre-ship.html`, returning the file to SHA-256 `f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3` and removing the QR/S2/S13 wiring changes. 
- Reverted `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` metadata that presented `5.8.pre-ship.6` as ready by replacing that block with the prior `5.8.pre-ship.5, UNGATED` entry and updating the baseline-truth-table row checksum/status accordingly. 
- Replaced the `5.8.pre-ship.6` preparatory text with a short failure note: `### GATE · 5.8.pre-ship.6 · P2 · FAIL · 2026-07-06` followed by the owner/manager failure ruling. 
- Ensured the sidecar `talkbridge/TALKBRIDGE-P2-TEST-HANDOFF.md` is not present (no-op in this rollout). 
- No other files, product fixes, or new artifacts were created or modified.

### Testing
- Ran `git diff --name-only` and confirmed only `bridge-turn08-pre-ship.html` and `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` were changed, and the check passed. 
- Verified `talkbridge/TALKBRIDGE-P2-TEST-HANDOFF.md` absence with `test ! -e talkbridge/TALKBRIDGE-P2-TEST-HANDOFF.md` and the test passed. 
- Confirmed the failed `5.8.pre-ship.6` ready/checksum strings are not present using ripgrep and the check passed. 
- Confirmed the failure note is present in `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` using ripgrep and the check passed. 
- Computed `sha256sum bridge-turn08-pre-ship.html` and verified it equals `f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3`, and `git diff --check` reported no whitespace/errors; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b64958e3c832da3fdbdd598643d0c)