### PR TITLE
Add TALKBRIDGE logical design v1 and bump master plan to v6.3.0 (plan‑first final app)

### DIFF
--- a/talkbridge/TALKBRIDGE-LOGICAL-DESIGN-v1.md
+++ b/talkbridge/TALKBRIDGE-LOGICAL-DESIGN-v1.md
@@ -1,0 +1,720 @@
+# TALKBRIDGE Logical Design & Build Package v1
+
+Status: audit-before-build package for `TALKBRIDGE-MASTER-PLAN-v6.html v6.3.0`.
+
+Purpose: define the final TalkBridge app top-down before code is written. This document is the auditable logical design, inventory, schema, physical structure, interface contract, and build package for the first implementation. `bridge-turn08-base.html` and `test.html` are reference inputs only; they are not runtime bases.
+
+## 0. Non-negotiable product definition
+
+- TalkBridge is one final app, not a merge of prior apps.
+  - Plan surfaces and navigation are product authority.
+  - Old artifacts may answer implementation questions only.
+  - No old boot system, router, lobby, room manager, transcript owner, composer, phrasebook, call app, or hidden DOM may be imported.
+- First meaningful build must include planned navigation and working bilingual messaging.
+  - L1 and L2 are implemented as one coherent delivery package.
+  - A build that cannot create/join a room and exchange bilingual messages in planned S4 is not acceptable.
+- Every visible state must be a coherent product state.
+  - No partial exposed shell-only app.
+  - No transcript without composer.
+  - No composer/search without transcript.
+  - No duplicate owner for any surface or service.
+
+## 1. Logical outline inventory
+
+- App
+  - Boot
+    - Input: browser load, stored app state, URL route.
+    - Output: S0 name ask, S1 start, or S10 joiner landing.
+    - Rules:
+      - Never auto-open S4 on normal owner boot.
+      - Never request media permissions on boot.
+      - Never start call/STT on boot.
+      - Never mount any prior app surface.
+  - Identity
+    - S0 owner name ask.
+    - S10 joiner name ask.
+    - Local display name is required before room entry.
+  - Routing
+    - Owner routes: S0, S1, S2, S3, S4, S4a, S4b, S5, S6, S7, S8, S9, S11, S13, S14.
+    - Joiner routes: S10, S4, S4b limited, S5, S6/S7/S8 limited by room pair, S9, S14.
+    - Route guard blocks joiner from S2/S3.
+  - Persistence
+    - Local state persists identity, rooms, messages, settings, phrasebooks, pending outbound queue, invite cache.
+    - Transport sync may enrich state but must not own UI.
+
+- S0 First run
+  - Purpose: collect owner display name once.
+  - Inputs:
+    - text field `displayName`.
+    - Continue tap.
+  - Outputs:
+    - `setCurrentUser(displayName)`.
+    - route to S1.
+  - Errors:
+    - empty name: inline error.
+    - name over 40 chars: trim or inline error.
+  - Owner: M1 App shell/router.
+
+- S1 Start screen
+  - Purpose: neutral landing; no active room.
+  - Inputs:
+    - menu tap opens S2.
+    - global auto-read toggle.
+  - Outputs:
+    - `openPanel()`.
+    - `toggleGlobalAutoRead()`.
+  - Owner: M1 App shell/router.
+
+- S2 Left panel
+  - Purpose: room list, access to create, long-press settings.
+  - Inputs:
+    - room card tap.
+    - plus tap.
+    - card title edit.
+    - transcript/diagnostics tap.
+    - soft-delete tap.
+    - recycle restore.
+    - blank square long-press.
+    - scrim tap close.
+  - Outputs:
+    - `enterRoom(roomId)`.
+    - `openCreateRoom()`.
+    - `renameRoom(roomId,title)`.
+    - `softDeleteRoom(roomId)`.
+    - `restoreRoom(roomId)`.
+    - `openDeviceSettings()`.
+    - `closePanel()`.
+  - Forbidden:
+    - no room-card share icon.
+    - no phrasebook/global catalog buttons.
+  - Owner: M1 App shell/router.
+
+- S3 Create room
+  - Purpose: create one partner/language-pair room.
+  - Inputs:
+    - local language select.
+    - partner language select.
+    - auto-read toggle.
+    - Cancel.
+    - OK.
+  - Outputs:
+    - `createRoom(pair, autoRead)`.
+    - route to S4 with invite card visible.
+  - Owner: M1 App shell/router, transport adapter for room creation.
+
+- S4 Room transcript
+  - Purpose: one continuous typed/spoken bilingual conversation.
+  - Inputs:
+    - menu tap.
+    - call/video tap.
+    - overflow tap.
+    - attach tap.
+    - composer text input.
+    - send tap or Enter.
+    - slash/double-dot search predicate.
+    - bubble column tap for TTS.
+    - bubble long-press.
+  - Outputs:
+    - `openPanel()`.
+    - `startCall(roomId, kind)`.
+    - `openRoomDrawer(roomId)`.
+    - `updateDraft(roomId,text)`.
+    - `sendDraft(roomId)`.
+    - `openPhraseSearch(roomId,query)`.
+    - `speakMessageColumn(messageId, column)`.
+    - `openBubbleActions(messageId)`.
+  - Render rules:
+    - Each bubble has original and translated text side-by-side.
+    - Viewer's language is always left.
+    - Meta line supports top/bottom/off setting.
+    - Typed and spoken messages share the same stream.
+    - One composer only.
+  - Owner: M2 Conversation.
+
+- S4a Invite card
+  - Purpose: invite partner before join and expose invite/share actions from room context.
+  - Inputs:
+    - link tap.
+    - Copy tap.
+    - Share tap.
+  - Outputs:
+    - `copyInvite(roomId)`.
+    - `shareInvite(roomId)`.
+  - Rules:
+    - appears at top of S4 before partner joins.
+    - disappears after partner joins.
+    - invite/link access after join lives in S4b.
+  - Owner: M2 Conversation.
+
+- S4b Room drawer
+  - Purpose: room-scoped settings and tools.
+  - Inputs:
+    - room display name edit.
+    - meta placement select.
+    - send-button visibility toggle if retained.
+    - Link a device.
+    - invite/link.
+    - export.
+    - debug.
+  - Outputs:
+    - `updateRoomSettings(roomId, patch)`.
+    - `openDeviceLink(roomId)`.
+    - `copyInvite(roomId)`.
+    - `exportRoom(roomId)`.
+    - `openDebug(roomId)`.
+  - Owner: M4 Room drawer/settings.
+
+- S5 Phrase search overlay
+  - Purpose: search pair-scoped phrasebook from composer.
+  - Inputs:
+    - `/` or `..` predicate.
+    - query text.
+    - exclude token `-word`.
+    - result text tap.
+    - result arrow tap.
+    - TTS tap.
+    - close.
+    - send.
+  - Outputs:
+    - `searchPhrases(pairKey, query)`.
+    - `usePhrase(cardId, side)`.
+    - `speakPhrase(cardId, side)`.
+    - `closePhraseSearch()`.
+  - Owner: M3 Phrasebook.
+
+- S6 Phrase card
+  - Purpose: reusable phrase display.
+  - Inputs:
+    - source/target tap.
+    - use.
+    - edit.
+    - delete.
+    - TTS.
+  - Outputs:
+    - `usePhrase(cardId, side)`.
+    - `editPhrase(cardId, patch)`.
+    - `deletePhrase(cardId)`.
+    - `speakPhrase(cardId, side)`.
+  - Owner: M3 Phrasebook.
+
+- S7 Phrasebook list
+  - Purpose: full pair-scoped phrasebook.
+  - Inputs:
+    - open from S4/S5.
+    - search query.
+    - plus.
+    - card actions.
+  - Outputs:
+    - `openPhrasebook(pairKey)`.
+    - `searchPhrases(pairKey, query)`.
+    - `createPhraseDraft(pairKey)`.
+  - Owner: M3 Phrasebook.
+
+- S8 New/edit phrase inline card
+  - Purpose: add or edit phrase without separate sheet.
+  - Inputs:
+    - source text.
+    - Enter.
+    - target edit.
+    - save.
+    - cancel/delete.
+  - Outputs:
+    - `translatePhraseDraft(pairKey, sourceText)`.
+    - `savePhrase(card)`.
+    - `cancelPhraseDraft()`.
+  - Rules:
+    - plus while empty draft exists focuses existing draft.
+    - no stacked empty cards.
+  - Owner: M3 Phrasebook.
+
+- S9 Call band
+  - Purpose: call/video layer over S4, with STT lines into transcript.
+  - Inputs:
+    - call/video start.
+    - accept/decline.
+    - mute/camera controls.
+    - back.
+    - expand PiP.
+    - hang up.
+  - Outputs:
+    - `startCall(roomId, kind)`.
+    - `acceptCall(callId)`.
+    - `declineCall(callId)`.
+    - `setCallPip(true|false)`.
+    - `hangupCall(callId)`.
+    - `appendSpeechLine(roomId, text, lang, speakerId)`.
+  - Rules:
+    - no permission request before call action.
+    - no full-screen prior call app.
+    - call-ended pill persists in transcript.
+  - Owner: M5 Call/STT.
+
+- S10 Joiner landing
+  - Purpose: invite URL entry for partner.
+  - Inputs:
+    - invite token from URL.
+    - localized display name.
+    - Join tap.
+  - Outputs:
+    - `resolveInvite(token)`.
+    - `setJoinerName(name)`.
+    - `joinRoom(token, user)`.
+    - route to S4.
+  - Rules:
+    - joiner cannot access S2/S3.
+    - joiner sees only joined room.
+  - Owner: M1 App shell/router with transport adapter.
+
+- S11 Keys
+  - Purpose: credential entry for transport/translation/STT/GitHub as required.
+  - Inputs:
+    - key fields.
+    - save.
+    - validate.
+  - Outputs:
+    - `saveKeys(keys)`.
+    - `validateKeys(keys)`.
+  - Owner: M6 Keys/settings/about/privacy.
+
+- S13 Device settings/about/privacy
+  - Purpose: device-level settings only.
+  - Inputs:
+    - Keys.
+    - About.
+    - Privacy.
+  - Outputs:
+    - route to S11 or static panels.
+  - Forbidden:
+    - no global appearance controls.
+    - no reset/data-grid controls.
+  - Owner: M6 Keys/settings/about/privacy.
+
+- S14 Notifications
+  - Purpose: OS/PWA incoming call/message routing.
+  - Inputs:
+    - incoming message.
+    - incoming call.
+    - Accept.
+    - Decline.
+    - notification tap.
+    - mute state.
+  - Outputs:
+    - `showMessageWaiting(roomId)`.
+    - `showIncomingCall(roomId, callId)`.
+    - `notificationOpenRoom(roomId)`.
+    - `notificationAcceptCall(callId)`.
+    - `notificationDeclineCall(callId)`.
+  - Owner: M7 PWA/notifications.
+
+## 2. Physical structure
+
+- Recommended files
+  - `talkbridge-app/index.html`
+    - static root document.
+    - loads `styles.css` and `src/main.js`.
+  - `talkbridge-app/styles.css`
+    - design tokens.
+    - layout primitives.
+    - surface styles S0-S14.
+  - `talkbridge-app/src/main.js`
+    - app bootstrap.
+    - initializes store, router, services.
+    - mounts root render.
+  - `talkbridge-app/src/state.js`
+    - initial state.
+    - reducer/action handlers.
+    - selectors.
+  - `talkbridge-app/src/schema.js`
+    - schema comments/validators.
+    - id factories.
+    - pair key helpers.
+  - `talkbridge-app/src/router.js`
+    - route parsing.
+    - route guards.
+    - navigation helpers.
+  - `talkbridge-app/src/storage.js`
+    - local persistence.
+    - migration/version handling.
+  - `talkbridge-app/src/services/transport.js`
+    - create/join/send/subscribe interface.
+    - local two-tab fallback for first audit build.
+  - `talkbridge-app/src/services/translator.js`
+    - translation interface.
+    - configured real provider or deterministic fallback.
+  - `talkbridge-app/src/services/speech.js`
+    - TTS/STT interface.
+  - `talkbridge-app/src/services/phrasebook-store.js`
+    - phrase search/save/update/delete.
+  - `talkbridge-app/src/services/calls.js`
+    - call signaling/media interface.
+  - `talkbridge-app/src/services/pwa-notify.js`
+    - install/notification interface.
+  - `talkbridge-app/src/ui/render.js`
+    - root render dispatch.
+    - common DOM helpers.
+  - `talkbridge-app/src/ui/screens/*.js`
+    - one screen renderer per surface group.
+  - `talkbridge-app/src/ui/components/*.js`
+    - bubble, composer, panel card, invite card, phrase card, drawer, call band.
+  - `talkbridge-app/tests/smoke.mjs`
+    - deterministic DOM and state smoke checks.
+
+## 3. Schemas
+
+```js
+AppState = {
+  version: 'tb-app-v1',
+  currentUserId: string | null,
+  users: Record<UserId, User>,
+  route: Route,
+  activeRoomId: RoomId | null,
+  rooms: Record<RoomId, Room>,
+  roomOrder: RoomId[],
+  messages: Record<RoomId, Message[]>,
+  drafts: Record<RoomId, Draft>,
+  phrasebooks: Record<PairKey, PhraseBook>,
+  settings: Settings,
+  callState: CallState,
+  notificationState: NotificationState,
+  pendingOutbound: OutboundEvent[],
+  ui: UiState
+}
+```
+
+```js
+User = {
+  id: string,
+  displayName: string,
+  preferredLanguage: LangCode,
+  deviceId: string,
+  roleByRoom: Record<RoomId, 'owner' | 'joiner'>,
+  createdAt: ISODateString,
+  updatedAt: ISODateString
+}
+```
+
+```js
+Room = {
+  id: string,
+  role: 'owner' | 'joiner',
+  ownerUserId: string,
+  partnerUserId: string | null,
+  localTitle: string,
+  pair: LanguagePair,
+  autoRead: boolean,
+  muted: boolean,
+  invite: Invite,
+  joinedAt: ISODateString | null,
+  lastActivityAt: ISODateString,
+  unreadCount: number,
+  receiptWatermark: Record<UserId, MessageId>,
+  settings: RoomSettings,
+  deletedAt: ISODateString | null
+}
+```
+
+```js
+LanguagePair = {
+  localLang: LangCode,
+  partnerLang: LangCode,
+  localLabel: string,
+  partnerLabel: string,
+  localFlag: string,
+  partnerFlag: string,
+  pairKey: string
+}
+```
+
+```js
+Message = {
+  id: string,
+  roomId: string,
+  senderId: string,
+  kind: 'typed' | 'speech' | 'system',
+  sourceLang: LangCode,
+  targetLang: LangCode,
+  originalText: string,
+  translatedText: string,
+  translationStatus: 'pending' | 'complete' | 'error',
+  translationError: string | null,
+  createdAt: ISODateString,
+  updatedAt: ISODateString,
+  receipt: 'queued' | 'sent' | 'delivered' | 'read',
+  source: 'composer' | 'stt' | 'system' | 'phrase',
+  savedPhraseId: string | null
+}
+```
+
+```js
+Draft = {
+  text: string,
+  mode: 'compose' | 'phrase-search',
+  searchQuery: string,
+  updatedAt: ISODateString
+}
+```
+
+```js
+PhraseBook = {
+  pairKey: string,
+  cards: PhraseCard[],
+  syncStatus: 'local' | 'syncing' | 'synced' | 'error',
+  updatedAt: ISODateString
+}
+```
+
+```js
+PhraseCard = {
+  id: string,
+  pairKey: string,
+  sourceText: string,
+  targetText: string,
+  backTranslation: string | null,
+  notes: string | null,
+  createdBy: string,
+  createdAt: ISODateString,
+  updatedAt: ISODateString,
+  deletedAt: ISODateString | null
+}
+```
+
+```js
+Invite = {
+  token: string,
+  url: string,
+  qrPayload: string,
+  createdAt: ISODateString,
+  acceptedAt: ISODateString | null,
+  revokedAt: ISODateString | null
+}
+```
+
+```js
+Settings = {
+  globalAutoRead: boolean,
+  keys: Record<string, string>,
+  privacyAcceptedAt: ISODateString | null,
+  installPromptSeenAt: ISODateString | null
+}
+```
+
+```js
+RoomSettings = {
+  metaPlacement: 'top' | 'bottom' | 'off',
+  showSendButton: boolean,
+  appearance: 'light',
+  debugEnabled: boolean
+}
+```
+
+```js
+CallState = {
+  roomId: string | null,
+  callId: string | null,
+  status: 'idle' | 'ringing' | 'connecting' | 'active' | 'ended' | 'error',
+  kind: 'audio' | 'video' | null,
+  startedAt: ISODateString | null,
+  endedAt: ISODateString | null,
+  pip: boolean,
+  participants: Record<UserId, CallParticipant>
+}
+```
+
+```js
+NotificationState = {
+  permission: 'default' | 'granted' | 'denied',
+  pendingRoomId: string | null,
+  pendingCallId: string | null,
+  mutedRoomIds: string[]
+}
+```
+
+## 4. Function definitions and contracts
+
+- App lifecycle
+  - `bootApp(): void`
+    - Input: none.
+    - Reads: local storage, location URL.
+    - Output: initialized state and first render.
+  - `renderApp(state: AppState): void`
+    - Input: full state.
+    - Output: root DOM for current route.
+  - `dispatch(action: Action): void`
+    - Input: action object.
+    - Output: state mutation, persistence, render, optional service effect.
+
+- Routing
+  - `parseRoute(url: URL): Route`
+  - `navigate(route: Route): void`
+  - `guardRoute(route: Route, state: AppState): Route`
+  - `enterRoom(roomId: string): void`
+  - `leaveRoom(): void`
+
+- Identity
+  - `setCurrentUser(displayName: string, preferredLanguage?: LangCode): User`
+  - `setJoinerName(inviteToken: string, displayName: string): User`
+
+- Rooms
+  - `createRoom(pair: LanguagePair, options: { autoRead: boolean }): Promise<Room>`
+  - `joinRoom(inviteToken: string, user: User): Promise<Room>`
+  - `renameRoom(roomId: string, localTitle: string): void`
+  - `softDeleteRoom(roomId: string): void`
+  - `restoreRoom(roomId: string): void`
+  - `updateRoomSettings(roomId: string, patch: Partial<RoomSettings>): void`
+
+- Messaging
+  - `updateDraft(roomId: string, text: string): void`
+  - `sendDraft(roomId: string): Promise<Message>`
+    - validates non-empty draft.
+    - creates pending message.
+    - calls translator.
+    - calls transport send.
+    - updates receipt.
+  - `receiveMessage(roomId: string, message: Message): void`
+  - `appendSpeechLine(roomId: string, text: string, lang: LangCode, speakerId: string): Promise<Message>`
+  - `setReceipt(roomId: string, messageId: string, receipt: Message['receipt']): void`
+  - `deleteMessage(roomId: string, messageId: string): void`
+  - `clarifyMessage(roomId: string, messageId: string): Promise<void>`
+
+- Invite/link
+  - `buildInvite(roomId: string): Invite`
+  - `copyInvite(roomId: string): Promise<void>`
+  - `shareInvite(roomId: string): Promise<void>`
+  - `resolveInvite(token: string): Promise<InviteResolution>`
+
+- Phrasebook
+  - `openPhraseSearch(roomId: string, query: string): void`
+  - `searchPhrases(pairKey: string, query: string): PhraseCard[]`
+  - `usePhrase(cardId: string, side: 'source' | 'target'): void`
+  - `savePhraseFromMessage(roomId: string, messageId: string): Promise<PhraseCard>`
+  - `createPhraseDraft(pairKey: string): PhraseCard`
+  - `translatePhraseDraft(pairKey: string, sourceText: string): Promise<PhraseCard>`
+  - `savePhrase(card: PhraseCard): Promise<PhraseCard>`
+  - `editPhrase(cardId: string, patch: Partial<PhraseCard>): Promise<PhraseCard>`
+  - `deletePhrase(cardId: string): Promise<void>`
+
+- Speech
+  - `speakText(text: string, lang: LangCode): Promise<void>`
+  - `startStt(roomId: string, pair: LanguagePair): Promise<void>`
+  - `stopStt(): Promise<void>`
+
+- Calls
+  - `startCall(roomId: string, kind: 'audio' | 'video'): Promise<void>`
+  - `acceptCall(callId: string): Promise<void>`
+  - `declineCall(callId: string): Promise<void>`
+  - `setCallPip(pip: boolean): void`
+  - `hangupCall(callId: string): Promise<void>`
+
+- PWA/notifications
+  - `registerPwa(): Promise<void>`
+  - `requestNotificationPermission(): Promise<NotificationPermission>`
+  - `showIncomingCall(roomId: string, callId: string): Promise<void>`
+  - `showMessageWaiting(roomId: string, messageId: string): Promise<void>`
+  - `handleNotificationAction(action: NotificationAction): void`
+
+## 5. Service inputs and outputs
+
+- `transport.createRoom(room)`
+  - Input: Room draft.
+  - Output: persisted/synced Room with invite token.
+  - Errors: unavailable, conflict, invalid credentials.
+- `transport.joinRoom(token, user)`
+  - Input: invite token, user.
+  - Output: joined Room and initial transcript.
+  - Errors: expired invite, revoked invite, not found.
+- `transport.sendMessage(roomId, message)`
+  - Input: room id, message.
+  - Output: receipt status.
+  - Errors: offline queued, rejected, unauthorized.
+- `transport.subscribeRoom(roomId, onEvent)`
+  - Input: room id, event callback.
+  - Output: unsubscribe function.
+- `translator.translate(text, fromLang, toLang)`
+  - Input: text and language codes.
+  - Output: `{ text, provider, confidence? }`.
+  - Errors: unavailable, unsupported pair, quota.
+- `phrasebookStore.search(pairKey, query)`
+  - Input: pair key and query.
+  - Output: ranked cards.
+- `calls.start(roomId, kind)`
+  - Input: room id, call kind.
+  - Output: call id and media/session state.
+- `pwaNotify.showIncomingCall(payload)`
+  - Input: room/call payload.
+  - Output: displayed notification or fallback signal.
+
+## 6. L1 + L2 first implementation package
+
+- Must build
+  - App entry and layout.
+  - S0/S1/S2/S3/S10 routing.
+  - S4 planned conversation surface.
+  - S4a invite card.
+  - Room creation.
+  - Join via invite token.
+  - One composer.
+  - Message creation, translation, persistence, send/receive between two sessions.
+  - Receipt states at least queued/sent/read locally.
+  - Two-session deterministic harness.
+- May stub
+  - Real network relay, if local two-tab transport is explicitly named and swappable.
+  - Real translation provider, if deterministic fallback is explicitly named and UI still renders original+translated columns.
+  - QR visual encoding, if invite URL copy/share works and QR contract is isolated.
+- Must not fake
+  - Route guards.
+  - Room creation.
+  - Invite token resolution.
+  - Message persistence.
+  - The existence of original+translated message fields.
+  - The single S4 composer/transcript ownership.
+
+## 7. Acceptance harness
+
+- Static checks
+  - No import/reference to `bridge-turn08-base.html` or `test.html` from runtime files.
+  - No duplicate screen owner files for S4 transcript or composer.
+  - No media permission APIs called during boot.
+  - No route from joiner to S2/S3.
+- State checks
+  - `bootApp()` with empty storage routes to S0.
+  - `setCurrentUser()` routes to S1.
+  - `createRoom()` creates Room, Invite, empty Message list, and route S4.
+  - `joinRoom()` with token creates joiner state locked to room.
+  - `sendDraft()` appends Message with original and translated fields.
+  - reload restores room and transcript.
+- DOM checks
+  - S2 has no share icon.
+  - S4 has one transcript container.
+  - S4 has one composer.
+  - S4a appears before partner join and disappears after join.
+  - S5 opens only from phrase predicates or phrasebook action.
+- Two-session script
+  - Session A clear storage.
+  - A enters name.
+  - A opens S2 and creates EN↔TH room.
+  - A sees S4 with invite card.
+  - Session B opens invite URL.
+  - B enters name and joins.
+  - A sends message.
+  - B receives original+translated message.
+  - B replies.
+  - A receives original+translated reply.
+  - Both reload.
+  - Both retain room and transcript.
+
+## 8. Audit checklist before build
+
+- Product
+  - Every planned surface S0-S14 has an owner.
+  - Every navigation path has an action.
+  - Every action has state input/output.
+  - Every service has a boundary.
+- Safety
+  - Old apps are reference only.
+  - No hidden prior app can boot.
+  - No duplicate transcript/composer/call owner exists.
+  - No permission prompt before user intent.
+- Delivery
+  - L1+L2 are implemented together or in one branch with no shell-only release claim.
+  - First real build demonstrates two-person bilingual messaging.
+  - Later layers cannot proceed if L2 fails.

--- a/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
+++ b/talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>TALKBRIDGE MASTER PLAN v6.2.0 — Single Source of Truth</title>
+<title>TALKBRIDGE MASTER PLAN v6.3.0 — Single Source of Truth</title>
 
 <style>
 :root{--teal:#2E8B8B;--tl:#E6F4F4;--ink:#1A1714;--mid:#5A5552;--dim:#9A9592;--bd:#E2DDD8;--paper:#F5F1EC;--cream:#FDFAF7;--red:#C0392B;--green:#2E7D4F;--amber:#B8860B;}
@@ -74,29 +74,30 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 </style></head><body>
 
 <h1>TALKBRIDGE — MASTER PLAN</h1>
-<div class="small">v6.2.0 · 2026-07-05 · Single source of truth: vision, UX walkthrough by role, surface inventory, config spec, architecture, build sequence, methodology. Supersedes TALKBRIDGE-MASTER-PLAN.md v5.x. Graveyard remains a separate versioned document.</div>
+<div class="small">v6.3.0 · 2026-07-06 · Single source of truth: plan-first final-app strategy, UX walkthrough by role, surface inventory, config spec, architecture, build sequence, methodology. Supersedes TALKBRIDGE-MASTER-PLAN.md v5.x. Graveyard remains a separate versioned document.</div>
 
 <div class="state">
 <div><b>STATE — CODEX HANDOFF</b></div>
-<div>Plan: v6.2.0 · Inventory: v1.3.0 (Part 3) · Executor: Codex (Claude retired from code; Claude remains plan/graveyard custodian)</div>
-<div>Golden floor: <b>bridge-turn07-post-ship.html</b> (checksums Part 5)</div>
-<div>Best current base: <b>bridge-turn08-base.html</b> — boots to start screen, shell + bridge merged, chat works; PB incomplete; retired panel buttons still present</div>
-<div>Deployed pre-ship (5.8.pre-ship.5, UNGATED): turn08-base + P2 changes (blank square long-press → 3-button modal, date/time, retired buttons removed) · sha256 f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</div>
-<div>Failed approach (do not repeat): injecting bridge into test.html shell — bridge always wakes on load. Build FROM turn08-base instead.</div>
-<div>Next: Codex reads Parts 2–3 (what to build), Part 7 (sequence + acceptance), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
+<div>Plan: v6.3.0 · Inventory: v1.3.0 (Part 3) · Executor: Codex (Claude retired from code; Claude remains plan/graveyard custodian)</div>
+<div>Build strategy: <b>plan-first final app</b> — the plan surfaces, navigation paths, functional descriptions, schemas, contracts, and acceptance criteria are non-negotiable.</div>
+<div>Runtime base: <b>new clean TalkBridge app target</b> (for example <code>talkbridge-app.html</code> or <code>talkbridge/index.html</code>). No prior HTML file is the runtime foundation.</div>
+<div>Reference ingredients: <b>bridge-turn08-base.html</b> for working bilingual behavior patterns and <b>test.html</b> for visual/shell ideas. Both are reference only; neither defines final behavior.</div>
+<div>Failed approaches (do not repeat): shell-first bridge injection, hidden prior apps, dormant bridge organs, negative-only gates, and choosing old behavior over the planned app.</div>
+<div>Next: Codex reads Parts 2–3 (what to build), Parts 5–7 (schemas/contracts/build plan), <code>talkbridge/TALKBRIDGE-LOGICAL-DESIGN-v1.md</code> (auditable top-down design/build package), Part 8 (rules), Parts 10–11 (history). Every attempt logged in Part 11 format.</div>
 </div>
 
-<div class="rule"><b>Authority & lineage.</b> This file, <code>TALKBRIDGE-MASTER-PLAN-v6.html v6.2.0</code>, is the only active product and build authority. Older files (<code>TALKBRIDGE-MASTER-PLAN.md</code>, <code>TALKBRIDGE-UI-INVENTORY.md</code>, <code>TALKBRIDGE-BUILD-MAP.md</code>, <code>TALKBRIDGE-BUILD-LOG.md</code>, generated prior HTML builds, and <code>talkbridge/build/*</code>) are lineage/context unless this plan explicitly imports a rule from them. If lineage conflicts with v6.2.0, v6.2.0 wins. The graveyard remains active only as the forbidden-approach registry.</div>
+<div class="rule"><b>Authority & lineage.</b> This file, <code>TALKBRIDGE-MASTER-PLAN-v6.html v6.3.0</code>, is the only active product and build authority. Older files (<code>TALKBRIDGE-MASTER-PLAN.md</code>, <code>TALKBRIDGE-UI-INVENTORY.md</code>, <code>TALKBRIDGE-BUILD-MAP.md</code>, <code>TALKBRIDGE-BUILD-LOG.md</code>, generated prior HTML builds, and <code>talkbridge/build/*</code>) are lineage/context unless this plan explicitly imports a rule from them. If lineage conflicts with v6.3.0, v6.3.0 wins. The graveyard remains active only as the forbidden-approach registry.</div>
 
 <h3>Current baseline truth table</h3>
 <table>
 <tr><th>Artifact</th><th>Purpose</th><th>Status</th><th>Checksum / note</th><th>Allowed to build from?</th><th>Why</th></tr>
-<tr><td><code>bridge-turn07-post-ship.html</code></td><td>Bridge golden floor</td><td>Golden input</td><td>Part 5 SHA</td><td>No, except for verified extraction</td><td>Supplies known-good bridge organs; not the surviving app shell.</td></tr>
-<tr><td><code>bridge-turn08-base.html</code></td><td>Current container base</td><td>Best current base</td><td>Boots to start; chat works; PB incomplete</td><td>Yes</td><td>Surviving surface after failed test.html injection path.</td></tr>
-<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>UNGATED</td><td><code>f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</code></td><td>No, unless first re-banked</td><td>Device-deployed but not a passed baseline.</td></tr>
-<tr><td><code>test.html</code></td><td>Shell lineage</td><td>Golden input / lineage</td><td>Part 5 SHA</td><td>No direct build</td><td>Do not repeat runtime injection into this shell.</td></tr>
-<tr><td><code>2vid.html</code></td><td>Call presentation reference</td><td>Golden input / visual reference</td><td>Part 5 SHA</td><td>No direct build</td><td>Reference only; call must mount inside S4.</td></tr>
-<tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless updated by this plan</td><td>May point to older plan versions</td><td>No, unless reconciled first</td><td>Cannot override v6.2.0 authority.</td></tr>
+<tr><td><code>TALKBRIDGE-MASTER-PLAN-v6.html</code></td><td>Recipe/product authority</td><td>Active v6.3.0 authority</td><td>Updated in-repo per this revision</td><td>Yes — as requirements only</td><td>Defines the required surfaces, navigation, behavior, schemas, contracts, and acceptance. Plan beats all old artifacts.</td></tr>
+<tr><td><code>talkbridge/TALKBRIDGE-LOGICAL-DESIGN-v1.md</code></td><td>Auditable logical design/build package</td><td>L0 package</td><td>Created for v6.3.0</td><td>Yes — as implementation blueprint</td><td>Expands the plan into outline inventory, schemas, physical structure, functions, I/O contracts, and L1+L2 acceptance before app code.</td></tr>
+<tr><td><code>bridge-turn08-base.html</code></td><td>Working bilingual behavior reference</td><td>Reference ingredient</td><td><code>5adeccae796b086391a2efcc07f7ba0bf7eead780b1d8cf82aa09be0a9a3f83b</code> when last recorded</td><td>No</td><td>May answer implementation questions for translation/relay/phrase/call behavior, but must not become the runtime app or hidden module.</td></tr>
+<tr><td><code>test.html</code></td><td>Visual/shell reference</td><td>Reference ingredient</td><td><code>70b9b13e665e2408639389539a563f1bfd8545b64201c69eded34e9241c22bfa</code></td><td>No</td><td>May inspire warm UI, panel, cards, and settings patterns, but must not define routing, state, or final behavior.</td></tr>
+<tr><td><code>bridge-turn07-post-ship.html</code></td><td>Older bridge reference</td><td>Lineage only</td><td>Part 5 legacy SHA</td><td>No</td><td>Useful only for inspected, inert helper extraction.</td></tr>
+<tr><td><code>bridge-turn08-pre-ship.html</code></td><td>Deployed experiment</td><td>Failed/UNGATED lineage</td><td><code>f366ab1e674b4635feb7538346006d07ff31a1c67c3e5e3ed6aacec814d9e5b3</code></td><td>No</td><td>Not a passed baseline and not the desired plan behavior.</td></tr>
+<tr><td><code>talkbridge/build/*</code></td><td>Prior build tooling</td><td>Lineage unless rewritten for v6.3.0</td><td>May point to older plan versions</td><td>No</td><td>Cannot override the plan-first final-app architecture.</td></tr>
 </table>
 
 <div class="tocbox">
@@ -113,9 +114,9 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 
 <h2 id="p1">Part 1 · Vision &amp; intent</h2>
 <p><b>TalkBridge is a privacy-first WhatsApp-class experience for two people who don't share a language.</b> One room = one partner = one language pair = one shared phrasebook. Chat, voice, and video are one continuous conversation on one transcript surface — typed messages and spoken words land in the same stream, every line shown side-by-side in both languages, each person always reading their own language on the left. No accounts, no servers holding content, no tracking. Installable as a PWA so calls ring and messages wait like a real messenger.</p>
-<p><b>End product</b> = shell experience (test.html) + bridge conversation engine (bridge-turn07-post-ship.html) + call presentation direction (2vid.html) + PWA layer (install, ring, message-waiting, mute-room), assembled by build-time injection into one file, deployed on GitHub Pages.</p>
+<p><b>End product</b> = the planned TalkBridge app itself: one clean app state, one router, one room model, one message model, one phrasebook model, one call model, and one notification model, deployed as a PWA. Existing HTML artifacts are ingredient references only, not the pan, not the recipe, and not the finished layer.</p>
 <div class="rule"><b>Design law — addition by subtraction.</b> Fewer choices, fewer buttons, less friction. Elements must earn their place. No labels on auto-actions, no borders or badges without a job. Bridge look wins everywhere; one light theme everywhere.</div>
-<div class="rule"><b>Product laws (owner rulings, closed):</b> app always boots to start screen · all rooms are one type, any room can call · chat surface is text-typed, voice lives in the call layer, both write to the one transcript · joiner sees only their room · bridge organs (transcript, compose, phrasebook) ship together, never split.</div>
+<div class="rule"><b>Product laws (owner rulings, closed):</b> app always boots to start screen · all rooms are one type, any room can call · chat surface is text-typed, voice lives in the call layer, both write to the one transcript · joiner sees only their room · transcript, compose/search, and phrasebook are delivered as one working conversation product, not exposed as broken partial states.</div>
 
 <h2 id="p2">Part 2 · UX walkthrough by role</h2>
 <p class="small">Every screen indexed to the inventory (Part 3). Behavior rides with each image. Mockups are the build target: pixel intent, exact elements — nothing decorative, nothing missing.</p>
@@ -191,7 +192,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
   </div>
   <div class="cmp"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="1em" height="1em" style="vertical-align:-0.12em;font-size:17px;color:var(--dim)"><path d="M15 7l-6.5 6.5a2.1 2.1 0 0 0 3 3L18 10a4.2 4.2 0 1 0-6-6L5.5 10.5a6.4 6.4 0 0 0 9 9L21 13"/></svg><div class="f">Type or /search</div><div style="width:38px;height:38px;border-radius:50%;background:var(--teal);color:#fff;display:flex;align-items:center;justify-content:center;flex-shrink:0;"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="1em" height="1em" style="vertical-align:-0.12em;font-size:16px"><path d="M10 14 21 3"/><path d="M21 3l-7 18-4-7-7-4z"/></svg></div></div>
 </div>
-<div class="mockcap"><div class="idx">S4 first entry · Invite card</div><div class="beh">Every first entry into a room the partner hasn't joined shows the invite card at the top of the transcript: QR, link (tap copies), Copy, Share (system sheet). Card disappears permanently once the partner joins; reachable again from the room card's share icon (S2). Call/video icons sit centered but dim until she joins; ⋯ (S4b) live — solo calls allowed. Compose live immediately — messages queue.</div></div>
+<div class="mockcap"><div class="idx">S4 first entry · Invite card</div><div class="beh">Every first entry into a room the partner hasn't joined shows the invite card at the top of the transcript: QR, link (tap copies), Copy, Share (system sheet). Card disappears permanently once the partner joins; invite/link access then lives in the room ⋯ drawer (S4b), never as an S2 room-card share icon. Call/video icons sit centered but dim until she joins; ⋯ (S4b) live — solo calls allowed. Compose live immediately — messages queue.</div></div>
 </div>
 
 <div class="flow"><span class="n">A2</span><span class="a">daily use:</span><span class="n">S4 chat</span><span class="a">→ "/" →</span><span class="n">S5 search</span><span class="a">→ Use → Go · long-press bubble → save/delete/clarify · 📖 →</span><span class="n">S7 phrasebook</span><span class="a">→ + →</span><span class="n">S8 new card</span></div>
@@ -283,7 +284,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
     </div>
   </div>
 </div>
-<div class="mockcap"><div class="idx">S8 · New card (inline)</div><div class="beh">+ prepends an empty card at the top of the S7 list — not a separate sheet. Attribution strip stamps creator and time immediately; sync dot goes amber (unsaved). Cursor lands in the source column; Enter translates and fills the target and back-translation inline, keyboard stays put. Same footer and panels as every card. Tapping + again while an empty card exists must focus it, not stack another (defect, fixed in P5).</div></div>
+<div class="mockcap"><div class="idx">S8 · New card (inline)</div><div class="beh">+ prepends an empty card at the top of the S7 list — not a separate sheet. Attribution strip stamps creator and time immediately; sync dot goes amber (unsaved). Cursor lands in the source column; Enter translates and fills the target and back-translation inline, keyboard stays put. Same footer and panels as every card. Tapping + again while an empty card exists must focus it, not stack another (defect, fixed in L3).</div></div>
 </div>
 
 <div class="flow"><span class="n">A4</span><span class="a">configuration:</span><span class="n">S2 gear</span><span class="a">→</span><span class="n">S13 settings</span><span class="a">→ appearance / notifications / keys (S11)</span></div>
@@ -383,7 +384,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><td><b>S5</b></td><td>Phrase search sheet</td><td>Trigger: "/" or ".." in compose; live filter; -word excludes; newest first. Header: 📖 (→S7) · pair flags · "n of total" count. Result rows: source | target; each side has speaker (TTS) + › — tapping › or the text loads that side into compose. Compose keeps 📎, gains × (cancel search), send stays visible. Close: ×, Esc, or send. Identical in-call.</td></tr>
 <tr><td><b>S6</b></td><td>PB card</td><td>Header: "Created {by} · {date time} — Modified {by} · {date time}". Side-by-side editable columns (Enter commits) · Use + speaker per side (Use loads compose + counts). Footer grid: × to-trash (Restore + Delete-Forever when trashed) · # tags · 💬 clarify. Panels: tags (pills+×, add input, suggestions, Enter adds+refocuses) · clarify (note, Enter commits+refocuses) · back-translation always visible (italic result · ✓ Sounds Good / ⚑ Flag radios; verdict resets only on source change). Long-press = quick-ring. Duplicate save → "Already saved" toast.</td></tr>
 <tr><td><b>S7</b></td><td>PB manager</td><td>Header: pair label · + (→S8) · save-now · sync dot (grey pending / green synced / amber failed) · ×. Search "(-word to exclude)" + clear ×. "Recently Deleted (n)" boxed row (chevron left) appears only when trash holds cards; expands to Restore / Delete Forever per card. Card list (S6). SCOPE: the phrasebook is LANGUAGE-PAIR scoped, not room scoped — one shared, curated set per pair, source of truth in GitHub; every EN↔TH room reads and writes the same book. Writes back on call end, dirty close, save-now; retry on reconnect. No category strip, no footer status line.</td></tr>
-<tr><td><b>S8</b></td><td>New card</td><td>+ in S7 prepends an empty inline card (no separate sheet). Attribution strip stamps creator+time; sync dot amber until saved. Cursor in source; Enter translates, fills target + back-translation ("No result yet." until then). Same footer/panels as S6. + with an empty card present must focus it, not stack (P5).</td></tr>
+<tr><td><b>S8</b></td><td>New card</td><td>+ in S7 prepends an empty inline card (no separate sheet). Attribution strip stamps creator+time; sync dot amber until saved. Cursor in source; Enter translates, fills target + back-translation ("No result yet." until then). Same footer/panels as S6. + with an empty card present must focus it, not stack (L3).</td></tr>
 <tr><td><b>S9</b></td><td>Call, same surface</td><td>Video band mounts atop S4; transcript+compose unchanged. Band: remote video (👤 placeholder) · local thumb · name+duration+connection dot · mic toggle · camera toggle (red slash; off default = voice) · red end. Partner states: camera off · disconnected/reconnecting · speaking. Speech → live translated transcript lines, 🎤 mark, permanent. Solo: record alone; joiner joins in progress, reads all. Auto-recovery on drop; entry-heal for tab-closure. Hang up: band unmounts · call-ended pill · PB write-back. BACK button (not hang-up): call shrinks to a tall 9:16 draggable PiP over the chat — partner's live video + small self inlay; header video/call icons gray out; tap PiP → expand (restore full call) and × (end call, back to plain chat). From bridge; re-executed cleanly.</td></tr>
 <tr><td><b>S10</b></td><td>Joiner landing</td><td>Entirely localized to the joiner's language — every word. Flags reversed: joiner's language first (theirs → partner's). Language pill · localized invite line · name input (first visit) · Join · mic/camera note. Lands in that one room only — no panel/list/create, enforced in routing. Live call → joins in progress.</td></tr>
 <tr><td><b>S11</b></td><td>API keys</td><td>Inside S13: Deepgram key+status · TURN token ID · TURN API token+status · GitHub PAT (optional). Password fields, local-only, one-time.</td></tr>
@@ -410,98 +411,105 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 </table>
 <div class="rule">Room settings live in the room (⋯). Device has only keys + about + privacy. No global appearance, no reset buttons, no data grid. Config never adds chrome to the transcript.</div>
 
-<h2 id="p5">Part 5 · Architecture — lift, refactor, build</h2>
-<div class="rule"><b>Golden baseline.</b> Every doer session begins by fetching these at their pinned commit and verifying SHA-256. Mismatch = stop, report, no work.
-<br><code>bridge-turn07-post-ship.html · 5713b5b41eab6a6c3b8ef1beb069f7c08a8eda012326226f437b083826af20ff</code>
-<br><code>test.html · 70b9b13e665e2408639389539a563f1bfd8545b64201c69eded34e9241c22bfa</code>
-<br><code>2vid.html · 0c37ceac8f74d411451359a9b5785c42e4b273f536589eedd45ccf5644649b1f</code></div>
+<h2 id="p5">Part 5 · Architecture — plan-first final app</h2>
+<div class="rule"><b>Governing strategy.</b> Build the TalkBridge app described by this plan. The plan's surfaces, navigation paths, role definitions, functional descriptions, schemas, contracts, and acceptance criteria are non-negotiable. Existing HTML files are ingredient references only. The app must not be created by injecting one prior app into another, preserving an old shell, or adapting the plan to fit old DOM/code.</div>
+<div class="rule warn"><b>Hard reset from failed process.</b> No shell-first bridge injection. No hidden dormant prior app. No dummy DOM/getElementById overrides. No old boot/router/lobby/call owner. No negative-only milestones whose main proof is that nothing broke. Build the final product layers deliberately, but the first implementation target is the real app architecture, not a toy prototype.</div>
 
-<div class="rule"><b>Proven architecture (50+ failed attempts distilled):</b> the bridge conversation product is sealed as one inert build-time module (single IIFE, one namespace, kill switch), injected into the shell at build time — never at runtime. It wakes only on room entry. Every runtime-merge attempt died of startup races. Shell duplicates are deleted in the same release their bridge replacement lands.</div>
-
+<h3>New product target</h3>
 <table>
-<tr><th>#</th><th>Piece</th><th>Disposition</th><th>Source → target</th></tr>
-<tr><td>A1</td><td>ame: boot, S0 name, S1 start, S2 panel+cards, S3 create, routing, storage</td><td><span class="tag ls">LIFT</span></td><td>test.html as-is; remove panel PB/globe buttons, legacy catalog screen, shell bubble/composer</td></tr>
-<tr><td>A2</td><td>rgan: transcript+bubbles, compose, S5/S6/S7/S8 phrasebook, TTS, translation, receipts</td><td><span class="tag ls">LIFT</span> + <span class="tag rf">REFACTOR</span></td><td>bridge sealed module; refactor: meta-line dots + placement config, invite card, delete category strip remnants</td></tr>
-<tr><td>A3</td><td>ine: WebRTC, STT, live transcript lines, recovery (~sealed, dormant)</td><td><span class="tag ls">LIFT</span> + <span class="tag rf">REFACTOR</span></td><td>bridge engine; presentation refactored to integrated band per S9 (kill full-screen call surface, kill 2vid float)</td></tr>
-<tr><td>A4</td><td>outing + S10 landing (+ name ask)</td><td><span class="tag rf">REFACTOR</span></td><td>bridge joiner landing, restyled to flag-ask card, name field added, room-lock enforced in routing</td></tr>
-<tr><td>A5</td><td>ard S4a (QR+link in transcript)</td><td><span class="tag bn">BUILD</span></td><td>new; QR lib in-file; link = existing room URL scheme</td></tr>
-<tr><td>A6</td><td>e config (footer/header/off) + settings S13 consolidation</td><td><span class="tag bn">BUILD</span></td><td>new, on shell settings drawer chassis</td></tr>
-<tr><td>A7</td><td>ifest, service worker, install, ring, message-waiting, mute</td><td><span class="tag bn">BUILD</span></td><td>new layer; relay push hooks on existing signal channel</td></tr>
-<tr><td>A8</td><td>al (calls ended by tab closure) · receipts wiring · PB refresh on room entry</td><td><span class="tag bn">BUILD</span></td><td>ship-stage items carried from v5 plan</td></tr>
+<tr><th>Target</th><th>Required decision before coding</th><th>Rule</th></tr>
+<tr><td>App entry</td><td>Choose one clean output such as <code>talkbridge-app.html</code> or <code>talkbridge/index.html</code>.</td><td>It is the only runtime document. Prior HTML files may be opened for reference but not imported wholesale.</td></tr>
+<tr><td>App architecture</td><td>One state tree, one router, one persistence boundary, one service-adapter registry.</td><td>All surfaces render from state; actions update state; services attach through explicit adapters.</td></tr>
+<tr><td>Reference extraction</td><td>Any copied helper must be named, dependency-audited, and made inert.</td><td>Allowed: isolated translation, QR, relay, TTS/STT, phrase, or CSS snippets. Forbidden: full app, boot system, router, lobby, room manager, or call app.</td></tr>
 </table>
 
-<h4>Fingerprinting (mandatory every build)</h4>
-<ol>
-<li>Manager locks the module fingerprint (SHA-256 of the exact block to inject) in the plan before the build.</li>
-<li>Doer injects, recomputes fingerprint from what actually landed in the output file.</li>
-<li>Mismatch = build auto-rejected, no debugging forward — rollback.</li>
-<li>Output file checksum recorded in the plan per attempt; deployed file byte-verified at the exact commit SHA (never at main).</li>
-</ol>
-
-<h4>Pre-build entry checklist (hard gate)</h4>
+<h3>Core schemas</h3>
 <table>
-<tr><th>#</th><th>Required before coding</th><th>Pass condition</th></tr>
-<tr><td>1</td><td>Active source of truth</td><td>Builder states: v6.2.0 only; lineage read only for context.</td></tr>
-<tr><td>2</td><td>Baseline</td><td>Path + checksum recorded; allowed-to-build-from table says Yes.</td></tr>
-<tr><td>3</td><td>Target piece</td><td>One named piece/stage only; exact surfaces/modules touched and not touched listed.</td></tr>
-<tr><td>4</td><td>Graveyard scan</td><td>No forbidden signature match; any match stops work.</td></tr>
-<tr><td>5</td><td>Acceptance copied first</td><td>Deterministic criteria + device script written before edits.</td></tr>
-<tr><td>6</td><td>Rollback</td><td>Rollback file/checksum/procedure named before edits.</td></tr>
+<tr><th>Schema</th><th>Minimum fields</th><th>Invariant</th></tr>
+<tr><td><code>AppState</code></td><td><code>currentUserId</code>, <code>route</code>, <code>activeRoomId</code>, <code>rooms</code>, <code>messages</code>, <code>phrasebooks</code>, <code>settings</code>, <code>callState</code>, <code>notificationState</code></td><td>All UI is a pure rendering of this state plus transient input focus.</td></tr>
+<tr><td><code>User</code></td><td><code>id</code>, <code>displayName</code>, <code>preferredLanguage</code>, <code>deviceId</code></td><td>Name is captured at S0/S10 and reused; no account requirement.</td></tr>
+<tr><td><code>Room</code></td><td><code>id</code>, <code>role</code>, <code>ownerUserId</code>, <code>partnerUserId?</code>, <code>localTitle</code>, <code>pair</code>, <code>autoRead</code>, <code>muted</code>, <code>invite</code>, <code>lastActivityAt</code>, <code>deletedAt?</code></td><td>One room = one partner = one language pair = one shared phrasebook.</td></tr>
+<tr><td><code>LanguagePair</code></td><td><code>localLang</code>, <code>partnerLang</code>, <code>localLabel</code>, <code>partnerLabel</code>, <code>flags</code></td><td>Each participant reads their own language on the left.</td></tr>
+<tr><td><code>Message</code></td><td><code>id</code>, <code>roomId</code>, <code>senderId</code>, <code>kind</code>, <code>sourceLang</code>, <code>targetLang</code>, <code>originalText</code>, <code>translatedText</code>, <code>createdAt</code>, <code>receipt</code>, <code>source</code></td><td>Typed and spoken lines land in the same transcript.</td></tr>
+<tr><td><code>PhraseCard</code></td><td><code>id</code>, <code>pairKey</code>, <code>sourceText</code>, <code>targetText</code>, <code>notes?</code>, <code>updatedAt</code></td><td>Phrasebooks are scoped by language pair, not by room title.</td></tr>
+<tr><td><code>CallState</code></td><td><code>roomId?</code>, <code>status</code>, <code>kind</code>, <code>startedAt?</code>, <code>pip</code>, <code>participants</code></td><td>No media permission is requested until an explicit call/video tap or notification accept.</td></tr>
 </table>
 
-<h4>Gate sizing law</h4>
-<div class="rule">One gate may touch only one ownership boundary: shell boot/panel, room drawer, transcript, compose/search, phrasebook, call layer, joiner routing, or notifications. If a change needs two ownership boundaries, split it. Each gate states exact DOM/state before/after and a must-remain-unchanged list. Transcript and compose are not both replaced in separate visible states; bridge organs may be staged internally only while hidden/dormant.</div>
+<h3>Service adapter contracts</h3>
+<table>
+<tr><th>Adapter</th><th>Contract</th><th>UI ownership rule</th></tr>
+<tr><td><code>transport</code></td><td><code>createRoom</code>, <code>joinRoom</code>, <code>sendMessage</code>, <code>subscribeRoom</code>, <code>updatePresence</code>, <code>ackReceipt</code></td><td>May sync state only; never renders DOM.</td></tr>
+<tr><td><code>translator</code></td><td><code>translate(text, fromLang, toLang)</code></td><td>Returns result/error; S4 decides how to render pending/error.</td></tr>
+<tr><td><code>speech</code></td><td><code>speak(text, lang)</code>, <code>startSTT(room,pair)</code>, <code>stopSTT()</code></td><td>TTS by tap; STT only during S9 call.</td></tr>
+<tr><td><code>phrasebookStore</code></td><td><code>search(pair,q)</code>, <code>save(card)</code>, <code>update(card)</code>, <code>delete(id)</code></td><td>S5/S6/S7/S8 own all phrase UI.</td></tr>
+<tr><td><code>calls</code></td><td><code>start(room,kind)</code>, <code>accept(event)</code>, <code>decline(event)</code>, <code>hangup()</code></td><td>S9 owns call UI; service owns signaling/media only.</td></tr>
+<tr><td><code>pwaNotify</code></td><td><code>install</code>, <code>showIncomingCall</code>, <code>showMessageWaiting</code>, <code>handleAction</code></td><td>S14/OS notifications route back into app state.</td></tr>
+</table>
 
 <h2 id="p6">Part 6 · Module map &amp; contracts</h2>
-<p class="small">Every UI function belongs to exactly one module. Modules are black boxes: defined inputs → predictable outputs. Contracts are the only crossings. Gaps, overlaps, collisions = none, by inspection of this table. Technical appendix (function-level signatures) is manager/doer territory and rides in the repo next to the plan.</p>
+<p class="small">Every UI function belongs to exactly one module in the new final app. Modules communicate through state/actions/service adapters, not DOM reach-through and not hidden prior apps.</p>
 <table>
-<tr><th>Module</th><th>Owns (surfaces)</th><th>Contracts out</th><th>Contracts in</th></tr>
-<tr><td><b>M1 Shell</b></td><td>S0 S1 S2 S3 boot·routing·room store·settings store</td><td>enterRoom(roomId,role) → M2 · settingsChanged(cfg) → M2 M6 · muteState(room) → M6</td><td>roomMeta(unread,lastActivity) ← M2 · badgeCount ← M6</td></tr>
-<tr><td><b>M2 Bridge-Conversation</b> (sealed)</td><td>S4 S4a S4-B S5 · transcript store · translation · TTS · receipts</td><td>startCall(kind) → M3 · pbSearch(q)/pbOpen() → M4 · notify(msg) → M6 · roomMeta → M1</td><td>enterRoom ← M1 · liveLine(text,lang,speaker) ← M3 · useText(text) ← M4 · settingsChanged ← M1</td></tr>
-<tr><td><b>M3 Bridge-Call</b> (sealed, dormant until start)</td><td>S9 band · WebRTC · STT · recovery · entry-heal</td><td>liveLine → M2 · callEnded(duration) → M2 · pbWriteback() → M4 · incomingCall(peer) → M6</td><td>startCall ← M2 · accept/decline ← M6</td></tr>
-<tr><td><b>M4 Phrasebook</b> (sealed with M2)</td><td>S6 S7 S8 · card store keyed by LANGUAGE PAIR (GitHub = source of truth; all rooms of a pair share one book) · GH sync · back-translate</td><td>useText → M2 · syncState → S7 dot</td><td>pbSearch/pbOpen ← M2 · pbWriteback ← M3 · refreshOnEntry ← M1</td></tr>
-<tr><td><b>M5 Keys/Transport</b></td><td>S11 · relay · TURN · Deepgram auth · GH API</td><td>credentials to M2 M3 M4 on demand</td><td>key entry ← S13</td></tr>
-<tr><td><b>M6 PWA/Notify</b></td><td>S14 · manifest · service worker · ring · badge · mute</td><td>accept/decline → M3 · badgeCount → M1 · open(room) → M1</td><td>notify ← M2 · incomingCall ← M3 · muteState ← M1</td></tr>
+<tr><th>Module</th><th>Owns surfaces</th><th>Actions emitted</th><th>Consumes</th></tr>
+<tr><td><b>M1 App shell/router</b></td><td>S0 S1 S2 S3 route guard, role guard, persistence boot</td><td><code>setName</code>, <code>openPanel</code>, <code>createRoom</code>, <code>enterRoom</code>, <code>leaveRoom</code></td><td>AppState, transport room metadata</td></tr>
+<tr><td><b>M2 Conversation</b></td><td>S4 S4a transcript, invite card, compose, receipts, bilingual rendering</td><td><code>sendMessage</code>, <code>copyInvite</code>, <code>shareInvite</code>, <code>savePhraseFromMessage</code>, <code>startCall</code></td><td>Room, Message, translator, transport, speech TTS</td></tr>
+<tr><td><b>M3 Phrasebook</b></td><td>S5 S6 S7 S8 search, use, save, edit, delete</td><td><code>searchPhrase</code>, <code>usePhrase</code>, <code>savePhrase</code>, <code>editPhrase</code>, <code>deletePhrase</code></td><td>PhraseCard, phrasebookStore, active LanguagePair</td></tr>
+<tr><td><b>M4 Room drawer/settings</b></td><td>S4b room name/meta/link-device/export/debug toggles</td><td><code>updateRoomSettings</code>, <code>linkDevice</code>, <code>exportRoom</code></td><td>Room settings, AppState</td></tr>
+<tr><td><b>M5 Call/STT</b></td><td>S9 call band, PiP/back behavior, live spoken lines, call-ended pill</td><td><code>callStarted</code>, <code>liveLine</code>, <code>callEnded</code></td><td>calls adapter, speech STT, Conversation append-line action</td></tr>
+<tr><td><b>M6 Keys/settings/about/privacy</b></td><td>S11 S13 credentials/about/privacy and global auto-read</td><td><code>saveKeys</code>, <code>updateGlobalSettings</code></td><td>Settings store</td></tr>
+<tr><td><b>M7 PWA/notifications</b></td><td>S14 install, incoming call, message waiting, mute behavior</td><td><code>notificationOpenRoom</code>, <code>notificationAcceptCall</code>, <code>notificationDeclineCall</code></td><td>pwaNotify adapter, mute state, route guard</td></tr>
 </table>
 
 <h4>Single-owner surface / module table</h4>
 <table>
 <tr><th>Responsibility</th><th>Owner</th><th>Forbidden duplicate owner</th><th>Activation trigger</th><th>Acceptance signal</th></tr>
-<tr><td>Boot/start</td><td>M1 Shell</td><td>Bridge lobby/call boot</td><td>App load</td><td>S1, panel closed, no room/call.</td></tr>
-<tr><td>Room list/panel/create</td><td>M1 Shell</td><td>Bridge room picker</td><td>☰ / +</td><td>S2/S3 only.</td></tr>
-<tr><td>Invite card</td><td>M2 Bridge-Conversation</td><td>S2 share card action</td><td>Room before partner join</td><td>S4a top card; gone after join.</td></tr>
-<tr><td>Room drawer/settings</td><td>M1 shell chassis + M2 room config contract</td><td>Global settings drawer</td><td>S4 ⋯</td><td>S4b owns name, appearance, Link a device, export, debug.</td></tr>
-<tr><td>Transcript / bubbles</td><td>M2 Bridge-Conversation</td><td>Shell stacked bubbles</td><td>Explicit room entry</td><td>Side-by-side canonical bubbles.</td></tr>
-<tr><td>Compose / send / search predicate</td><td>M2 Bridge-Conversation</td><td>Shell composer</td><td>Explicit room entry</td><td>One compose strip; / and .. route to S5.</td></tr>
-<tr><td>Phrasebook</td><td>M4 Phrasebook</td><td>Shell catalog/PB</td><td>📖, save, call write-back</td><td>Pair-scoped S6/S7/S8 only.</td></tr>
-<tr><td>Relay/presence/receipts</td><td>M5 transport + M2 contract</td><td>Independent second relay UI owner</td><td>Room entry</td><td>Presence/meta/receipts update without duplicate surfaces.</td></tr>
-<tr><td>Translation/TTS</td><td>M2/M4 on demand</td><td>Parallel shell translation path</td><td>Send/search/card action</td><td>One translated output path.</td></tr>
-<tr><td>Call signaling/UI/STT</td><td>M3 Bridge-Call</td><td>2vid floating window or boot-time call app</td><td>User taps call/video or accepts S14</td><td>S9 mounts over S4 only.</td></tr>
-<tr><td>Notifications</td><td>M6 PWA/Notify</td><td>In-room notification surface while open</td><td>Background incoming event</td><td>S14 OS notification; mute suppresses.</td></tr>
-<tr><td>Device linking</td><td>S4b Link a device</td><td>S2 room-card share</td><td>S4 ⋯ → Link a device</td><td>QR/link for owner device only.</td></tr>
+<tr><td>Boot/start</td><td>M1 App shell/router</td><td>Any old bridge/test boot, lobby, room, or call owner</td><td>App load</td><td>S1 or S0 only; panel closed; no room/call/media.</td></tr>
+<tr><td>Room list/panel/create</td><td>M1 App shell/router</td><td>Bridge room picker or old shell router</td><td>☰ / +</td><td>S2/S3 match inventory.</td></tr>
+<tr><td>Invite card</td><td>M2 Conversation</td><td>S2 share card action</td><td>Room before partner join or S4b invite/link action</td><td>S4a top card; gone after join.</td></tr>
+<tr><td>Room drawer/settings</td><td>M4 Room drawer/settings</td><td>Global settings drawer</td><td>S4 ⋯</td><td>S4b owns name, appearance, Link a device, export, debug.</td></tr>
+<tr><td>Transcript / bubbles</td><td>M2 Conversation</td><td>Shell stacked bubbles or bridge hidden transcript</td><td>Explicit room entry</td><td>Side-by-side canonical bubbles.</td></tr>
+<tr><td>Compose / send / search predicate</td><td>M2 Conversation + M3 phrase overlay</td><td>Any second composer/send path</td><td>Explicit room entry</td><td>One compose strip; / and .. route to S5.</td></tr>
+<tr><td>Phrasebook</td><td>M3 Phrasebook</td><td>Shell catalog/PB or old bridge PB surface</td><td>📖, / search, save action</td><td>Pair-scoped S5/S6/S7/S8 only.</td></tr>
+<tr><td>Relay/presence/receipts</td><td>transport adapter + M2 state actions</td><td>Independent second relay UI owner</td><td>Room creation/join/entry</td><td>Presence/meta/receipts update without duplicate surfaces.</td></tr>
+<tr><td>Translation/TTS</td><td>translator/speech adapters on demand</td><td>Parallel shell translation path</td><td>Send/search/card/tap-to-hear action</td><td>One translated output path.</td></tr>
+<tr><td>Call signaling/UI/STT</td><td>M5 Call/STT</td><td>2vid floating window or boot-time call app</td><td>User taps call/video or accepts S14</td><td>S9 mounts over S4 only.</td></tr>
+<tr><td>Notifications</td><td>M7 PWA/notifications</td><td>In-room notification surface while open</td><td>Background incoming event</td><td>S14 OS notification; mute suppresses.</td></tr>
+<tr><td>Device linking</td><td>M4 S4b Link a device</td><td>S2 room-card share</td><td>S4 ⋯ → Link a device</td><td>QR/link for owner device only.</td></tr>
 </table>
-<div class="rule warn">A build fails if two modules own the same row. Collision guards: one global namespace only (module IIFEs) · M2/M3/M4 share the sealed bridge bundle and speak to shell only via the contracts above · no module reaches into another's DOM.</div>
+<div class="rule warn">A build fails if two modules own the same row, if an old app boots inside the new app, or if implementation changes planned behavior to match old code. The plan wins.</div>
 
 <h2 id="p7">Part 7 · Build sequence &amp; deterministic acceptance</h2>
-<p class="small">Versioning: <code>series.turn.stage.attempt</code> — series 5, turn 8; stages pre-ship → ship → post-ship. Each piece gets: deterministic acceptance (answerable before any device test) + a device script (the gift, after certification). No piece starts before the previous piece's device gate passes and plan+graveyard are updated.</p>
+<p class="small">This is not a toy-prototype sequence. These are the real layers of the final app: pan, cake body, filling, assembly, frosting. Each layer must leave a runnable app, but the architecture is designed up front so the first serious implementation can produce real bilingual messaging without detouring through throwaway fragments.</p>
 
+<h3>One-go build planning package required before code</h3>
 <table>
-<tr><th>Piece</th><th>Builds</th><th>Deterministic acceptance ("how do I know", pre-device)</th><th>Device script (see/do/pass)</th></tr>
-<tr><td><b>P1</b> Workspace + golden verify</td><td>build pipeline: sources pinned, module extraction, assembly script, fingerprints</td><td>golden checksums match table above · assembled output byte-identical on two consecutive runs · lint clean</td><td>open deployed P1 file: boots to S1, existing shell flows unchanged</td></tr>
-<tr><td><b>P2</b> Shell trim + S13</td><td>remove retired shell surfaces · settings consolidation · meta-line config plumbing (dormant)</td><td>retired element selectors return zero matches in output · every S1–S3 inventory element present by ID · fingerprint pass</td><td>boot→S1 · panel: gear only, cards with share/transcript/delete · create room per S3 · nothing retired visible</td></tr>
-<tr><td><b>P3</b> Bridge organ in (transcript+compose+PB, one release)</td><td>sealed M2+M4 injected · shell bubble/composer deleted same release · test.html receipts (name-left, dot/✓) · S4a invite card (refactor) · S4b drawer · pair-scoped PB wiring</td><td>fingerprint match · zero shell-bubble selectors remain · S4/S4-B/S5/S6/S7/S8 inventory elements present by ID · lint clean</td><td>create room → invite card w/ QR · send msg → side-by-side bubble, dots advance · "/" search → Use → Go · save from bubble → S7 shows card · joiner phone: S10 name+Join, room-locked</td></tr>
-<tr><td><b>P4</b> Call layer woken (M3)</td><td>engine mounted as S9 band · live lines · solo call · back-button PiP (expand/×) · call-ended pill · entry-heal · PB write-back on hang-up</td><td>fingerprint match · INERT-ON-BOOT: doer must open browser console on the deployed file, confirm zero bridge/call engine initialisation messages before any room is entered — this is a hard STOP criterion, not optional · dormant-wake only on room entry · S9 inventory elements present</td><td>two phones: call → band over same transcript · speak → 🎤 lines live both sides · search mid-call · hang up → pill, lines persist · solo call then join-in-progress</td></tr>
-<tr><td><b>P5</b> Polish + defects</td><td>meta-line placement live (top/bottom/off) · S8 stacking defect · receipts detail popup · PB refresh on entry</td><td>each defect has a reproduce-step that now returns the specified result in scripted DOM test · inventory diff = zero</td><td>toggle meta placements, dots move/hide · open + twice, one card · reopen room, PB fresh</td></tr>
-<tr><td><b>P6</b> PWA (M6)</td><td>manifest · service worker · install · ring w/ Accept-Decline · message-waiting · per-room mute</td><td>Lighthouse installable pass · notification payloads validate against S14 spec · mute state provably suppresses (unit trace)</td><td>install to home screen · lock phone, partner calls → rings, Accept lands in call, Decline leaves missed pill · message → waiting notification · muted room: silence</td></tr>
+<tr><th>Package</th><th>Must be written before implementation</th><th>Pass condition</th></tr>
+<tr><td>Schema map</td><td>Concrete TypeScript/JSDoc-style shapes for AppState, Room, User, Message, PhraseCard, CallState, Settings, Invite.</td><td>Every Part 2/3 surface has the data it needs; no field exists only because old code had it.</td></tr>
+<tr><td>Action map</td><td>All user actions by surface: tap path → function → state mutation → service call if any.</td><td>Every navigation path in Part 2 is represented; no hidden startup action exists.</td></tr>
+<tr><td>Service contracts</td><td>transport, translator, phrasebookStore, speech, calls, pwaNotify interfaces and fallback/error behavior.</td><td>Messaging can work with real or configured adapters; UI does not depend on adapter internals.</td></tr>
+<tr><td>UI component map</td><td>Screen/component ownership for S0–S14.</td><td>Each element in Part 3 has one owner and one render path.</td></tr>
+<tr><td>Acceptance harness</td><td>Scriptable checks plus real-device scripts.</td><td>Checks prove positive behavior (bilingual send/join/search/save) before polish-only claims.</td></tr>
 </table>
 
-<h4>Mandatory inert-on-boot acceptance</h4>
+<h3>Layered final-app build</h3>
+<table>
+<tr><th>Layer</th><th>Builds</th><th>Deterministic acceptance (pre-device)</th><th>Device script (see/do/pass)</th></tr>
+<tr><td><b>L0</b> Architecture package</td><td>New app target decision, schemas, action map, adapter interfaces, component map, persistence keys, route table.</td><td>Every S0–S14 route/surface has owner/data/actions · no prior HTML file is listed as runtime base · copied helpers list is empty or dependency-audited.</td><td>Review the plan/package only; no product claim until L1+L2 are implemented together.</td></tr>
+<tr><td><b>L1</b> App shell + planned navigation</td><td>S0/S1/S2/S3/S10/S13/S11 skeletons, role guards, local persistence, panel/create/join route flow.</td><td>All planned routes exist · boot lands S0/S1 only · S2 has no share icon · joiner route cannot open room list/create · old routers absent.</td><td>Fresh load name → S1; ☰ → S2; + → S3; invite URL → S10; role restrictions visible.</td></tr>
+<tr><td><b>L2</b> Conversation engine (must ride with or immediately after L1)</td><td>S4 planned room, S4a invite card, one compose strip, bilingual Message model, send/receive/sync, translation adapter, receipts, persistence.</td><td>Two-session scripted path creates/joins one room and exchanges original+translated messages · one transcript owner · one composer · adapter errors render pending/error without breaking send.</td><td>Phone A creates room; Phone B joins invite; A sends; B sees original+translation; B replies; reload preserves room/transcript.</td></tr>
+<tr><td><b>L3</b> Phrasebook as conversation capability</td><td>S5 search overlay, S6/S7/S8 phrasebook, save from bubble, use in compose, edit/delete, pair scoping.</td><td>Search opens only from /, .., or 📖 · phrase use inserts into the single composer · save writes pairKey · no legacy catalog/PB surface.</td><td>Save message as phrase; type /; use phrase; edit phrase; reload; phrase remains for same language pair.</td></tr>
+<tr><td><b>L4</b> Room drawer/settings assembly</td><td>S4b room title/meta placement/link-device/export/debug, settings persistence, invite/link access after join.</td><td>S4b is the only room settings owner · Link a device exists only in S4b · S2 share controls absent · setting changes re-render S4 from state.</td><td>Open ⋯; edit title/meta; use Link a device; verify S2 card title updates and no S2 share icon appears.</td></tr>
+<tr><td><b>L5</b> Calls/STT</td><td>S9 band over S4, call/video start, accept/decline, STT live lines into transcript, PiP/back, hangup pill.</td><td>No media permission before explicit call action · S9 never boots alone · liveLine appends Message.kind=speech · call-ended pill persists as system line.</td><td>Two phones call; speak; both see live lines; back to PiP; hang up; transcript persists spoken lines.</td></tr>
+<tr><td><b>L6</b> PWA/notifications</td><td>Manifest, service worker, install, incoming call notification, message waiting, accept/decline, mute-room.</td><td>Installable check passes · notification payload routes to room/call actions · mute suppresses · no notification duplicates in-room UI.</td><td>Install; lock/background; incoming call rings; Accept lands in S9; Decline leaves missed pill; muted room stays silent.</td></tr>
+<tr><td><b>L7</b> Final certification</td><td>Accessibility sanity, visual polish against mockups, deployment byte verify, full owner/joiner walkthrough.</td><td>Inventory diff zero · do-not-touch regressions zero · all deterministic checks pass · deployed file matches commit bytes.</td><td>Complete owner and joiner walkthrough on real phones: create, invite, join, bilingual chat, phrase search/save/use, call/STT, PWA notifications.</td></tr>
+</table>
+
+<h4>Non-negotiable positive acceptance</h4>
 <ul>
-<li>Applies to any gate importing bridge, phrasebook, relay, speech, or call code.</li>
-<li>Cold boot lands on S1; no room auto-opens; no bridge lobby; no call surface; no microphone/camera permission prompt.</li>
-<li>No relay/call/Deepgram connection starts before explicit room entry or call start.</li>
-<li>Console/log checkpoints prove zero bridge/call initialization before the intended trigger.</li>
-<li>Must be checked in a real browser/device path, not jsdom/static checks alone.</li>
+<li>After L2, the app must send bilingual messages between two people in the planned S4 surface. If not, stop and fix the architecture; do not continue to polish.</li>
+<li>After every later layer, the two-person bilingual send/receive/translate path must still pass.</li>
+<li>Acceptance is not only "nothing woke on boot"; acceptance must prove the planned user capability works.</li>
+<li>Static/lint/fingerprint checks are hygiene only. They never replace the positive device path.</li>
+<li>Any copied reference helper must be inert until called by the new app action map.</li>
 </ul>
 
 <h4>Device-test scripts (minimum tap paths)</h4>
@@ -509,8 +517,9 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><th>Surface</th><th>Start</th><th>Do</th><th>Pass</th></tr>
 <tr><td>S0/S1</td><td>Fresh or cleared name</td><td>Enter name, reload</td><td>Name asks once; subsequent boot shows S1 only.</td></tr>
 <tr><td>S2/S3</td><td>S1</td><td>☰, long-press square, +, Cancel/OK</td><td>Panel/date/time/S13/Create work; no share icon.</td></tr>
+<tr><td>S4/S4a</td><td>New room</td><td>Copy/share invite, send queued message, partner joins</td><td>Invite card appears before join; disappears after join; messages remain.</td></tr>
 <tr><td>S4/S4b</td><td>Existing room</td><td>Tap room, open ⋯, edit settings, Link a device</td><td>Room opens only by tap; drawer owns room settings and device link.</td></tr>
-<tr><td>S5</td><td>S4 compose</td><td>Type / and .., filter, send/cancel</td><td>Search overlays transcript; no / text sent accidentally.</td></tr>
+<tr><td>S5</td><td>S4 compose</td><td>Type / and .., filter, use phrase, send/cancel</td><td>Search overlays transcript; no / text sent accidentally.</td></tr>
 <tr><td>S7/S8</td><td>S4</td><td>Open 📖, + twice, edit source, Enter</td><td>One empty card focused; translation/back-translation inline.</td></tr>
 <tr><td>S9</td><td>S4</td><td>Start call, BACK, expand, ×/hang up</td><td>S9 over S4; PiP works; transcript persists spoken lines.</td></tr>
 <tr><td>S10</td><td>Invite URL</td><td>Open as joiner, enter localized name, Join</td><td>Only that room; no panel/create.</td></tr>
@@ -518,7 +527,7 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <tr><td>S14</td><td>PWA background</td><td>Incoming call/message, mute room, retry</td><td>Accept/Decline/message-waiting per spec; mute suppresses.</td></tr>
 </table>
 
-<div class="rule">Ship gate = all P1–P6 device-passed on real phones (initiator + joiner) with zero do-not-touch regressions (Part 9). Post-ship = observation window, graveyard/process review, then out-of-scope items unfreeze (language rollout, PB scale, category redesign).</div>
+<div class="rule">Ship gate = all L0–L7 device-passed on real phones (initiator + joiner) with zero do-not-touch regressions (Part 9). Post-ship = observation window, graveyard/process review, then out-of-scope items unfreeze (language rollout, PB scale, category redesign).</div>
 
 <h2 id="p8">Part 8 · Methodology</h2>
 <h4>Doer / Manager protocol</h4>
@@ -529,26 +538,26 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <li>Failure order (mandatory): rollback deployed file → graveyard entry (version bump) → plan bump → only then a new build prompt. <b>Never patch forward. Ever.</b></li>
 </ol>
 <h4>Turn-zero doer prompt (every prompt starts with this verbatim)</h4>
-<div class="rule">"Verify golden baseline checksums (Plan Part 5) before any work; mismatch = stop and report. Read only the plan sections named below. Execute only the numbered steps. Touch no file, surface, or behavior outside them — the do-not-touch registry (Part 9) is live. Report results into the plan section named. If anything is unclear or unexpected, stop and report; do not improvise, do not patch forward."</div>
+<div class="rule">"Confirm this session is using TALKBRIDGE-MASTER-PLAN-v6.html v6.3.0 as the only active product authority. Read the named plan sections before coding. Treat existing HTML files as reference only unless the prompt names an isolated helper to extract. Execute only the numbered steps. Touch no file, surface, or behavior outside them — the do-not-touch registry (Part 9) is live. Report results into the plan section named. If anything is unclear or unexpected, stop and report; do not improvise, do not patch forward."</div>
 <h4>Gates &amp; definition of done</h4>
 <ul>
-<li>Confidence 2.5/2.5 before build: spec read from plan (never memory) + fingerprint locked.</li>
-<li>Pre-certification question, answered in the plan per piece: <i>how do I know this will succeed</i> — deterministic criteria only; lint is not done; device test is not an answer, it's the gift after certification.</li>
-<li>Definition of done per piece: deployed + byte-verified at commit SHA + device-passed + plan updated + graveyard updated. Missing any one = not done.</li>
-<li>Rollback map: every piece names its known-good file to restore (P1→golden floor; Pn→last passed piece's verified output, checksum recorded at its gate).</li>
+<li>Confidence 2.5/2.5 before build: spec read from plan (never memory) + target layer/action map understood.</li>
+<li>Pre-certification question, answered in the plan per layer: <i>how do I know this will work</i> — deterministic criteria plus the named positive user capability; lint is not done.</li>
+<li>Definition of done per layer: deployed + byte-verified at commit SHA + positive device path passed + plan updated + graveyard updated. Missing any one = not done.</li>
+<li>Rollback map: every layer names its known-good app target or prior committed plan package to restore, with checksum recorded at its gate.</li>
 <li>Change control: inventory (Part 3) and mockups (Part 2) are frozen. Any change = plan version bump with owner approval, before the change rides in any build.</li>
 <li>After each confirmed ship: owner-provided process/self assessment → improvements enshrined here and in the graveyard, same turn.</li>
 <li>Token discipline: no play-by-play; report started/completed/blocked only.</li>
 </ul>
 
 <h4>Implementation staging vs product shipping</h4>
-<div class="rule">Bridge organs (transcript, compose/search, phrasebook) may be integrated behind internal gates only when incomplete states are hidden or dormant. No final/pilot build may expose transcript without compose/search/phrasebook, or compose/search/phrasebook without transcript. Temporary scaffolding is allowed only when acceptance proves it has no visible behavior.</div>
+<div class="rule">The real app may be built in layers, but exposed states must be coherent final-product states. No final/pilot build may expose transcript without compose/search/phrasebook, or compose/search/phrasebook without transcript. Temporary scaffolding is allowed only in the planning/package layer or when clearly inaccessible to users.</div>
 
 <h4>Mandatory stop conditions</h4>
 <ul>
-<li>Stop if cold boot shows any room/call/bridge surface, or any permission prompt appears before user intent.</li>
+<li>Stop if cold boot shows any room/call surface, any prior-app surface, or any permission prompt before user intent.</li>
 <li>Stop if a prior fixed issue reappears, a touched surface passes but an adjacent surface breaks, or deployed bytes do not match verified checksum.</li>
-<li>Stop if a device-only failure appears that deterministic checks missed, or a second patch is proposed for the same failed gate.</li>
+<li>Stop if the positive bilingual messaging path fails after L2, or if a second patch is proposed for the same failed gate without rollback/re-plan.</li>
 <li>Required response: rollback, record signature, compare graveyard, update acceptance criteria, restart from last banked baseline. Do not patch forward.</li>
 </ul>
 
@@ -563,10 +572,10 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 
 <h4>Coding-agent implementation contract</h4>
 <ol>
-<li>Restate target gate, exact files to touch, exact files not to touch, and that v6.2.0 is the only active plan.</li>
+<li>Restate target gate, exact files to touch, exact files not to touch, and that v6.3.0 is the only active plan.</li>
 <li>Confirm graveyard scan and pre-build checklist before editing.</li>
 <li>Produce the minimal diff only; never improvise beyond the named target.</li>
-<li>Never runtime-inject an independently booting app; modules must be inert until their trigger.</li>
+<li>Never import an independently booting prior app; services must be inert until called by the new app action map.</li>
 <li>Record deterministic checks, device script status, rollback metadata, and any blockers. If ambiguous, stop rather than guess.</li>
 </ol>
 
@@ -583,10 +592,10 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 </ul>
 <h4>Open items (nothing hides)</h4>
 <ul>
-<li>S8 empty-card stacking defect — fix in P5</li>
-<li>Receipt status-detail popup content — spec at P5 prompt time</li>
-<li>PWA ring on iOS Safari limitations — validated in P6; fallback = in-app full-screen ring + badge</li>
-<li>QR generation library choice — doer proposes at P3, manager approves (in-file, no CDN dependency)</li>
+<li>S8 empty-card stacking defect — fix in L3</li>
+<li>Receipt status-detail popup content — spec before L2/L4 implementation</li>
+<li>PWA ring on iOS Safari limitations — validated in L6; fallback = in-app full-screen ring + badge</li>
+<li>QR generation library choice — doer proposes before L2/L4, manager approves (in-file, no CDN dependency)</li>
 <li>Appearance persistence transport (link payload + local storage now; relay-stored later?) — revisit post-ship</li>
 <li>Room-specific PB append-on-top-of-pair — owner leaning no; parked post-ship</li>
 </ul>
@@ -594,19 +603,19 @@ code{background:var(--paper);border:1px solid var(--bd);border-radius:4px;paddin
 <ul><li>Language pair rollout beyond EN↔TH · PB search scale (1,500+ cards) · category-match dropdown redesign · O-Ring · TM</li></ul>
 <h4>Graveyard learnings enshrined (high/low)</h4>
 <ul>
-<li>Runtime merge of two live apps = startup races, always. Build-time injection of a sealed, dormant module is the only survivor.</li>
-<li>Shared namespace = silent function overwrites. One IIFE per module.</li>
+<li>Runtime merge of two live apps = startup races, always. v6.3.0 replacement: do not merge prior apps at all; build the planned app with isolated helper extraction only.</li>
+<li>Shared namespace = silent function overwrites. One app namespace/module boundary; no global old-app owners.</li>
 <li>"It compiled / it lints" has shipped zero working builds. Only phone confirmation counts (§PIECE).</li>
 <li>Patching forward converted 1-attempt problems into 10-attempt spirals. Rollback is cheaper every single time.</li>
-<li>Splitting bridge organs across releases broke both halves. They move together.</li>
+<li>Splitting transcript, compose/search, and phrasebook across visible releases broke both halves. They ship as one coherent conversation product.</li>
 <li>Stale reads (raw CDN, main-ref, cached SHA) caused false passes and 409s. Contents API, exact commit SHA, fresh SHA before every write.</li>
 <li>Building from memory instead of reading the spec produced the mockup failures of 2026-07-05. Inventory first, always.</li>
 </ul>
 
-<p class="small" style="margin-top:30px;">TALKBRIDGE MASTER PLAN v6.2.0 · owner Confi · manager Claude · graveyard separate (TALKBRIDGE-GRAVEYARD.md) · previous plan v5.8.2.29 superseded and archived in repo history.</p>
+<p class="small" style="margin-top:30px;">TALKBRIDGE MASTER PLAN v6.3.0 · owner Confi · manager Claude · graveyard separate (TALKBRIDGE-GRAVEYARD.md) · previous plan v5.8.2.29 superseded and archived in repo history.</p>
 
 <h2 id="p10">Part 10 · Graveyard — complete failure history (verbatim)</h2>
-<p class="small">Every failed attempt and its lesson. Codex: read before writing a line. The same three failures killed 50+ attempts: bridge waking on load, patching forward, splitting bridge organs.</p>
+<p class="small">Every failed attempt and its lesson. Codex: read before writing a line. The historical failures remain below for context; v6.3.0 supersedes their old shell/bridge-injection remedies with the plan-first final-app strategy.</p>
 <pre style="white-space:pre-wrap;font-size:11px;background:#fff;border:1px solid var(--bd);border-radius:10px;padding:12px;">&lt;!-- v5.8.2.25 --&gt;
 # TALKBRIDGE — THE GRAVEYARD (living; keep in project knowledge)
 ## Approaches PROVEN to fail. Scanned before every change and at every exit condition. Never resurrect.


### PR DESCRIPTION
### Motivation
- Create an auditable, top‑down implementation blueprint for the TalkBridge app so the first build targets the final app architecture rather than reusing prior runtime shells.
- Record non‑negotiable product rules, schemas, module contracts, and deterministic L1/L2 acceptance criteria to prevent past failures (runtime merges, hidden prior apps, split bridge organs).
- Update the master plan to reflect the new plan‑first final‑app strategy and to reference the new logical design package as the implementation blueprint.

### Description
- Add `talkbridge/TALKBRIDGE-LOGICAL-DESIGN-v1.md`, a 700+ line auditable design that includes inventory, file layout, full schemas, function contracts, service adapter contracts, and an L1+L2 acceptance harness. 
- Update `talkbridge/TALKBRIDGE-MASTER-PLAN-v6.html` to `v6.3.0`, rework architecture and build sections toward a plan‑first final app, surface new layer-based build sequencing (L0–L7), and point to the new logical design file as the implementation blueprint.
- Replace references that treated older HTML artifacts as runtime bases with explicit guidance that they are reference ingredients only, tighten stop conditions/gates, and rehome room share/device‑link behaviors to S4b per the new inventory.
- Revise registries, open items, and graveyard learnings to enforce the non‑negotiable rules and to clarify acceptance, rollback, and module ownership responsibilities.

### Testing
- No automated tests were executed as part of this textual/design change; this PR adds and updates plan/spec documents only.
- Changes were limited to documentation and HTML plan text so no runtime behavior was modified and no build verification was performed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b68d39764832d8bbf61e75f7b7d58)