### PR TITLE
Simplify clock UI and extract timer into focused dialog

### DIFF
--- a/time.html
+++ b/time.html
@@ -1,309 +1,82 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Visual Timer & Clock — Rings • Hourglass • Analog • Spiral • Multi‑Zone</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Time Flow Clock</title>
 <style>
-  html, body { height: 100%; margin: 0; background: #0a0a0a; color: #e5e5e5; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial; }
-  #wrap { position: fixed; inset: 0; }
-  canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
-  #bg { z-index: 0; }
-  #ui { z-index: 1; pointer-events: none; }
-
-  #drawer { position: fixed; z-index: 1000; pointer-events: none; }
-  #drawer .panel { background: rgba(0,0,0,0.7); border: 1px solid rgba(255,255,255,0.12); backdrop-filter: blur(6px); pointer-events: auto; max-width: 1200px; margin: auto; transform: translateY(-100%); transition: transform 200ms ease; }
-  #drawer.open .panel { transform: translate(0,0); }
-
-  #handle { position: absolute; width: 80px; height: 18px; border-radius: 999px; background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.25); cursor: pointer; z-index: 1001; pointer-events: auto; display: flex; align-items: center; justify-content: center; left: 50%; top: 6px; transform: translateX(-50%); }
-  #handle:after{ content: ""; display: block; width: 36px; height: 2px; background: rgba(255,255,255,0.6); border-radius: 2px; }
-
-  #hud { display: grid; grid-template-columns: repeat(3, minmax(260px, 1fr)); gap: 16px; padding: 36px 12px 12px; }
-  fieldset { border: 1px solid rgba(255,255,255,0.15); border-radius: 10px; padding: 10px 12px; }
-  legend { font-weight: 700; color: #d0d0d0; letter-spacing: .2px; }
-  label { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 8px; font-size: 12px; margin: 6px 0; }
-  .row { display:flex; gap:10px; align-items:center; flex-wrap: wrap; }
-  input, select, button { background: #111; color: #e5e5e5; border: 1px solid #333; border-radius: 6px; padding: 6px 8px; font-size: 12px; }
-  input[type=range] { width: 160px; }
-  input[type=number] { width: 90px; }
-  button { cursor: pointer; }
-  button:disabled { opacity: 0.55; cursor: not-allowed; }
-  .pill { display:inline-block; padding:2px 8px; border:1px solid #444; border-radius: 999px; font-size: 11px; color:#ddd; }
-  #status { font-size:12px; color:#9ad; }
-  @media (max-width: 1000px) { #hud { grid-template-columns: 1fr; } }
+:root{color-scheme:dark;--bg:#090b12;--panel:#111522e8;--text:#f5f7ff;--muted:#aab2ca;--accent:#71d7ff;--track:#ffffff18;--border:#ffffff22}
+*{box-sizing:border-box}html,body{height:100%;margin:0}body{overflow:hidden;background:var(--bg);color:var(--text);font:14px system-ui,sans-serif}button,input,select{font:inherit;color:inherit}button,select,input[type=number]{background:#151a29;border:1px solid var(--border);border-radius:.55rem;padding:.55rem .7rem}button{cursor:pointer}button:hover{border-color:var(--accent)}button:focus-visible,input:focus-visible,select:focus-visible,summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.icon-button{display:grid;place-items:center;width:44px;height:44px;padding:0;border-radius:50%;font-size:1.3rem;background:#101522dd;box-shadow:0 4px 20px #0008}.floating{position:fixed;z-index:4}.controls-button{top:1rem;right:1rem}.timer-button{right:1rem;bottom:1rem}#clockCanvas{width:100%;height:100%;display:block}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+#panel{position:fixed;z-index:5;inset:0 0 0 auto;width:min(390px,100%);padding:1rem;background:var(--panel);border-left:1px solid var(--border);backdrop-filter:blur(16px);overflow:auto;transform:translateX(100%);transition:.2s}#panel.open{transform:none}.panel-head{display:flex;justify-content:space-between;align-items:center}.panel-head h1{font-size:1.2rem;margin:.2rem 0 1rem}.panel-head button{border:0;background:transparent;font-size:1.4rem}.group{border:1px solid var(--border);border-radius:.8rem;padding:.8rem;margin:0 0 .8rem}.group legend{font-weight:700;padding:0 .3rem}.field{display:flex;justify-content:space-between;gap:1rem;align-items:center;margin:.55rem 0}.field select{max-width:55%}.checks{display:grid;grid-template-columns:1fr 1fr;gap:.3rem}.checks label{display:flex;gap:.5rem;align-items:center;padding:.3rem}.actions{display:flex;gap:.45rem;flex-wrap:wrap}.hint{color:var(--muted);font-size:.82rem;margin:.5rem 0}details{margin-top:.5rem}summary{cursor:pointer;color:var(--muted)}#message{min-height:1.2em;color:var(--accent);font-size:.85rem;margin:.5rem 0 0}
+dialog{width:min(520px,calc(100% - 2rem));border:1px solid var(--border);border-radius:1rem;padding:0;background:#101522;color:var(--text);box-shadow:0 20px 80px #000b}dialog::backdrop{background:#000a;backdrop-filter:blur(5px)}.dialog-body{padding:1rem}.dialog-head{display:flex;justify-content:space-between;align-items:center}.dialog-head h2{margin:.2rem 0 1rem}.dialog-head button{border:0;background:transparent;font-size:1.4rem}.timer-display{text-align:center;font-size:clamp(2.5rem,12vw,5rem);font-variant-numeric:tabular-nums;font-weight:300;margin:1rem}.duration{display:flex;justify-content:center;align-items:end;gap:.5rem}.duration label{display:grid;gap:.3rem;text-align:center;color:var(--muted)}.duration input{width:5rem;text-align:center}.timer-viz{display:block;width:180px;height:180px;margin:.5rem auto}.center-actions{justify-content:center;margin-top:1rem}@media(prefers-reduced-motion:reduce){*{transition:none!important}}
 </style>
 </head>
 <body>
-<div id="wrap">
-  <canvas id="bg"></canvas>
-  <canvas id="ui"></canvas>
+<canvas id="clockCanvas"></canvas>
+<p id="accessibleTime" class="sr-only" aria-live="polite"></p>
+<button id="openControls" class="icon-button floating controls-button" aria-label="Open clock settings" aria-controls="panel" aria-expanded="false">⚙</button>
+<button id="openTimer" class="icon-button floating timer-button" aria-label="Open timer" title="Open timer">⌛</button>
 
-  <div id="handle" role="button" aria-controls="hud" aria-expanded="false" title="Open controls"></div>
-  <div id="drawer" class="open" aria-hidden="false">
-    <div class="panel">
-      <div id="hud">
-        <!-- Background visual tuning (simplified, lightweight) -->
-        <fieldset>
-          <legend>Background</legend>
-          <label>Period (s) <input id="period" type="number" step="0.1" min="0.2" max="120" value="12"></label>
-          <label>Density <input id="density" type="range" min="0.5" max="6.0" step="0.01" value="2.0"></label>
-          <label>Contrast <input id="gamma" type="range" min="0.5" max="2.5" step="0.01" value="1.1"></label>
-          <label>Palette <input id="pal" type="range" min="0" max="1" step="0.001" value="0.2"></label>
-          <div id="status" class="pill">Live</div>
-        </fieldset>
+<aside id="panel" aria-label="Clock settings">
+ <div class="panel-head"><h1>Clock settings</h1><button id="closeControls" aria-label="Close settings">×</button></div>
+ <fieldset class="group"><legend>Display</legend>
+  <label class="field">Clock style <select id="clockStyle"><option value="circular">Circular + digital</option><option value="digital">Digital only</option></select></label>
+  <label class="field">Center <select id="centerStyle"><option value="digital">Digital</option><option value="verbal">Verbal</option></select></label>
+  <details><summary>Shown units</summary><div class="checks" id="unitChecks">
+   <label><input type="checkbox" value="minute" checked> Minute</label><label><input type="checkbox" value="hour" checked> Hour</label><label><input type="checkbox" value="day" checked> Day</label><label><input type="checkbox" value="week" checked> Week</label><label><input type="checkbox" value="month" checked> Month</label><label><input type="checkbox" value="year" checked> Year</label>
+  </div><button id="restoreUnits" type="button">Restore defaults</button></details>
+ </fieldset>
+ <fieldset class="group"><legend>Sound</legend>
+  <label class="field">Hourly chime <input id="hourlyChime" type="checkbox"></label>
+  <label class="field">Visual pulse <input id="hourlyFlash" type="checkbox" checked></label>
+  <label class="field">Volume <input id="volume" type="range" min="0" max="1" step=".05" value=".5"></label>
+  <button id="testSound">Test sound</button><p class="hint">Sound begins only after you interact with this page.</p>
+ </fieldset>
+ <fieldset class="group"><legend>Appearance</legend>
+  <label class="field">Theme <select id="theme"><option value="midnight">Midnight blue</option><option value="ember">Warm ember</option><option value="forest">Forest</option><option value="mono">Monochrome</option></select></label>
+  <label class="field">Ring thickness <input id="thickness" type="range" min="8" max="28" value="16"></label>
+  <label class="field">Glow <input id="glow" type="checkbox" checked></label>
+ </fieldset>
+ <fieldset class="group"><legend>Preferences</legend><div class="actions"><button id="saveConfig">Save</button><button id="exportConfig">Export</button><button id="importButton">Import</button><input id="importConfig" type="file" accept="application/json,.json" hidden></div><p id="message" role="status"></p></fieldset>
+</aside>
 
-        <!-- Visualization selection -->
-        <fieldset>
-          <legend>Visualization</legend>
-          <label>Use case
-            <select id="mode">
-              <option value="timer" selected>Timer</option>
-              <option value="clock">Clock</option>
-            </select>
-          </label>
-          <label>Model
-            <select id="visModel">
-              <option value="rings" selected>Radial Rings</option>
-              <option value="hourglass">Hourglass</option>
-              <option value="analog">Analog Hands</option>
-              <option value="spiral">Spiral Arcs</option>
-              <option value="teardrop">Sand Teardrop</option>
-              <option value="multizone">Multi‑Zone Clock</option>
-            </select>
-          </label>
-          <div class="row" id="ringRow">
-            <label class="row"><input id="ringSec" type="checkbox" checked> Sec</label>
-            <label class="row"><input id="ringMin" type="checkbox" checked> Min</label>
-            <label class="row"><input id="ringHour" type="checkbox" checked> Hour</label>
-            <label class="row"><input id="ringDay" type="checkbox"> Day</label>
-            <label class="row"><input id="ringWeek" type="checkbox" checked> Week</label>
-            <label class="row"><input id="ringMonth" type="checkbox" checked> Month</label>
-            <label class="row"><input id="ringYear" type="checkbox" checked> Year</label>
-          </div>
-        </fieldset>
-
-        <!-- Timer controls -->
-        <fieldset>
-          <legend>Timer</legend>
-          <label>Type
-            <select id="timerType">
-              <option value="countdown" selected>Countdown</option>
-              <option value="countup">Countup</option>
-            </select>
-          </label>
-          <label>Minutes <input id="timerMin" type="number" min="0" step="0.1" value="5"></label>
-          <div class="row">
-            <button id="startTimer">Start</button>
-            <button id="stopTimer" disabled>Stop</button>
-            <div id="timeDisplay" class="pill">00:00</div>
-          </div>
-        </fieldset>
-
-        <!-- Multi‑zone config (for multi‑zone model) -->
-        <fieldset>
-          <legend>Multi‑Zone</legend>
-          <label>Zones (comma‑separated IANA TZ)
-            <input id="zones" type="text" placeholder="America/Los_Angeles, America/New_York, Europe/London, Asia/Tokyo" value="America/Los_Angeles, America/New_York, Europe/London, Asia/Tokyo">
-          </label>
-        </fieldset>
-
-        <!-- Export / Config -->
-        <fieldset>
-          <legend>Config</legend>
-          <div class="row">
-            <button id="saveConfigBtn">Save</button>
-            <button id="exportConfigBtn">Export</button>
-            <label class="row" style="gap:8px; align-items:center;">
-              <button id="importConfigBtn">Import</button>
-              <input id="importConfig" type="file" accept=".json" style="display:none;" />
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>Export Image</legend>
-          <button id="snapshot">Snapshot PNG</button>
-        </fieldset>
-
-        <fieldset>
-          <legend>Settings</legend>
-          <label>Handle position
-            <select id="handlePos">
-              <option value="top" selected>Top</option>
-              <option value="bottom">Bottom</option>
-              <option value="left">Left</option>
-              <option value="right">Right</option>
-            </select>
-          </label>
-        </fieldset>
-      </div>
-    </div>
-  </div>
-</div>
+<dialog id="timerDialog"><div class="dialog-body">
+ <div class="dialog-head"><h2>Timer</h2><button id="closeTimer" aria-label="Close timer">×</button></div>
+ <label class="field">Mode <select id="timerMode"><option value="countdown">Countdown</option><option value="countup">Count up</option></select></label>
+ <label class="field">Visual <select id="timerVisual"><option value="hourglass">Hourglass</option><option value="analog">Analog</option><option value="spiral">Spiral</option></select></label>
+ <div class="duration"><label>Hours<input id="timerHours" type="number" min="0" max="99" value="0"></label><label>Minutes<input id="timerMinutes" type="number" min="0" max="59" value="5"></label><label>Seconds<input id="timerSeconds" type="number" min="0" max="59" value="0"></label></div>
+ <canvas id="timerCanvas" class="timer-viz" width="360" height="360"></canvas><div id="timerDisplay" class="timer-display">05:00</div>
+ <div class="actions center-actions"><button id="timerStart">Start</button><button id="timerPause" disabled>Pause</button><button id="timerReset">Reset</button></div>
+</div></dialog>
 <script>
-// ===== Drawer & handle positioning =====
-const handle = document.getElementById('handle');
-const drawer = document.getElementById('drawer');
-const handlePos = document.getElementById('handlePos');
-function applyHandlePos(pos){
-  Object.assign(handle.style, {top:'',bottom:'',left:'',right:'',transform:''});
-  Object.assign(drawer.style, {top:'',bottom:'',left:'',right:''});
-  if(pos==='top'){ handle.style.top='6px'; handle.style.left='50%'; handle.style.transform='translateX(-50%)'; drawer.style.top='0'; }
-  if(pos==='bottom'){ handle.style.bottom='6px'; handle.style.left='50%'; handle.style.transform='translateX(-50%)'; drawer.style.bottom='0'; }
-  if(pos==='left'){ handle.style.left='6px'; handle.style.top='50%'; handle.style.transform='translateY(-50%)'; drawer.style.left='0'; }
-  if(pos==='right'){ handle.style.right='6px'; handle.style.top='50%'; handle.style.transform='translateY(-50%)'; drawer.style.right='0'; }
-}
-applyHandlePos(handlePos.value);
-handlePos.addEventListener('change', ()=>applyHandlePos(handlePos.value));
-let drawerOpen=true; function setDrawer(open){ drawer.classList.toggle('open', open); handle.setAttribute('aria-expanded', String(open)); drawer.setAttribute('aria-hidden', String(!open)); }
-setDrawer(true); handle.addEventListener('click', ()=>{drawerOpen=!drawerOpen; setDrawer(drawerOpen)});
-
-// ===== Lightweight background (2D canvas) =====
-const bg = document.getElementById('bg');
-const bctx = bg.getContext('2d');
-const period = document.getElementById('period');
-const density = document.getElementById('density');
-const gamma = document.getElementById('gamma');
-const pal = document.getElementById('pal');
-
-let t0 = performance.now()/1000;
-function resize(){ const dpr=Math.min(2, window.devicePixelRatio||1); const w=Math.max(2, Math.floor(bg.clientWidth*dpr)); const h=Math.max(2, Math.floor(bg.clientHeight*dpr)); if(bg.width!==w||bg.height!==h){ bg.width=w; bg.height=h; } if(ui.width!==w||ui.height!==h){ ui.width=w; ui.height=h; } }
-window.addEventListener('resize', resize);
-
-function palette(u){ // gentle two-tone
-  const a=[0.12,0.12,0.14], b=[0.08,0.06,0.10], c=[1.0,0.9,0.8], d=[0.20,0.35,0.55];
-  const k=6.28318*(c[0]*u + d[0]);
-  const r = a[0] + b[0]*Math.cos(k);
-  const g = a[1] + b[1]*Math.cos(k*1.01 + 1.3);
-  const bl= a[2] + b[2]*Math.cos(k*0.99 + 2.1);
-  return `rgb(${Math.round((r+0.5)*255)}, ${Math.round((g+0.5)*255)}, ${Math.round((bl+0.5)*255)})`;
-}
-
-function drawBackground(){
-  const w=bg.width, h=bg.height; const cx=w/2, cy=h/2; bctx.clearRect(0,0,w,h);
-  // radial gradient base
-  const u = (parseFloat(pal.value)||0.2);
-  const grad=bctx.createRadialGradient(cx, cy, 0, cx, cy, Math.hypot(w,h)/1.2);
-  grad.addColorStop(0, palette(u));
-  grad.addColorStop(1, '#0a0a0a');
-  bctx.fillStyle=grad; bctx.fillRect(0,0,w,h);
-  // ring lines (very light)
-  const time = performance.now()/1000 - t0; const per=Math.max(0.1, +period.value); const phase=(time%per)/per;
-  const dens = Math.max(0.5, +density.value);
-  const maxR = Math.hypot(w,h)/2; const step = Math.max(6, 40/dens);
-  bctx.save(); bctx.translate(cx,cy); bctx.globalAlpha = 0.25;
-  bctx.strokeStyle = 'rgba(255,255,255,0.22)';
-  bctx.lineWidth = Math.max(1, Math.floor(Math.max(w,h)/900));
-  const shift = phase*step*2; // slow drift
-  for(let r=step; r<maxR; r+=step){
-    const rr = r + shift;
-    bctx.beginPath(); bctx.arc(0,0, rr, 0, Math.PI*2); bctx.stroke();
-  }
-  bctx.restore();
-  // gamma-ish contrast tweak
-  const g = Math.max(0.5, +gamma.value);
-  if(g !== 1){ const img=bctx.getImageData(0,0,w,h); const d=img.data; const inv=1/g; for(let i=0;i<d.length;i+=4){ d[i]=255*Math.pow(d[i]/255, inv); d[i+1]=255*Math.pow(d[i+1]/255, inv); d[i+2]=255*Math.pow(d[i+2]/255, inv);} bctx.putImageData(img,0,0); }
-}
-
-// ===== Visualization overlay (unchanged from prior 2D) =====
-const ui = document.getElementById('ui');
-const ctx = ui.getContext('2d');
-const mode = document.getElementById('mode');
-const visModel = document.getElementById('visModel');
-const ringSec=document.getElementById('ringSec'), ringMin=document.getElementById('ringMin'), ringHour=document.getElementById('ringHour'), ringDay=document.getElementById('ringDay'), ringWeek=document.getElementById('ringWeek'), ringMonth=document.getElementById('ringMonth'), ringYear=document.getElementById('ringYear');
-const timerType=document.getElementById('timerType'), timerMin=document.getElementById('timerMin');
-const startTimerBtn=document.getElementById('startTimer'), stopTimerBtn=document.getElementById('stopTimer');
-const timeDisplay=document.getElementById('timeDisplay');
-const zonesInput=document.getElementById('zones');
-
-// time helpers
-function daysInMonth(y,m){ return new Date(y, m+1, 0).getDate(); }
-function dayOfYear(d){ const s=new Date(d.getFullYear(),0,1); return Math.floor((d-s)/86400000)+1; }
-function daysInYear(y){ return ((y%4===0 && y%100!==0) || (y%400===0)) ? 366 : 365; }
-function clockFractions(now){ const ms=now.getMilliseconds(); const s=now.getSeconds()+ms/1000; const m=now.getMinutes()+s/60; const h=now.getHours()+m/60; const dim=daysInMonth(now.getFullYear(), now.getMonth()); const doy=dayOfYear(now)-1 + h/24; return { sec:s/60, min:m/60, hour:h/24, day:h/24, week:(now.getDay()+h/24)/7, month:(now.getDate()-1+h/24)/dim, year:doy/daysInYear(now.getFullYear()) } }
-function timerFractions(el){ return { sec:(el%60)/60, min:(el%3600)/3600, hour:(el%86400)/86400, day:(el%86400)/86400, week:(el%(86400*7))/(86400*7), month:(el%(86400*30))/(86400*30), year:(el%(86400*365))/(86400*365) } }
-
-// timer state
-let timerActive=false, timerStart=0, timerTotal=0;
-function fmt(sec){ sec=Math.max(0, Math.floor(sec)); const h=(sec/3600)|0, m=((sec%3600)/60)|0, s=sec%60; if(sec>=3600) return String(h).padStart(2,'0')+':'+String(m).padStart(2,'0')+':'+String(s).padStart(2,'0'); if(sec>=60) return String(m).padStart(2,'0')+':'+String(s).padStart(2,'0'); return String(s).padStart(2,'0'); }
-startTimerBtn.addEventListener('click', ()=>{ timerTotal=+timerMin.value*60; timerStart=performance.now()/1000; timerActive=true; startTimerBtn.disabled=true; stopTimerBtn.disabled=false; });
-stopTimerBtn.addEventListener('click', ()=>{ timerActive=false; startTimerBtn.disabled=false; stopTimerBtn.disabled=true; });
-
-// primitives
-function ring(cx,cy,r0,r1,frac,label){ const thick=Math.max(8, (r1-r0)); const R=(r0+r1)/2; ctx.lineCap='round'; ctx.beginPath(); ctx.strokeStyle='rgba(255,255,255,0.15)'; ctx.lineWidth=thick; ctx.arc(cx,cy,R,-Math.PI/2,Math.PI*1.5); ctx.stroke(); ctx.beginPath(); ctx.strokeStyle='rgba(255,255,255,0.92)'; ctx.lineWidth=thick; ctx.arc(cx,cy,R,-Math.PI/2,-Math.PI/2 + Math.max(0,Math.min(1,frac))*2*Math.PI); ctx.stroke(); if(label){ ctx.fillStyle='rgba(255,255,255,0.8)'; ctx.font=`${Math.max(12, thick*0.5)}px system-ui`; ctx.textAlign='center'; ctx.fillText(label, cx, cy - R - thick*0.6); }}
-function hourglass(cx,cy,size,frac){ const half=size/2, neck=size*0.05; ctx.save(); ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.lineWidth=Math.max(2, size*0.01); ctx.beginPath(); ctx.moveTo(cx-half,cy-half); ctx.lineTo(cx+half,cy-half); ctx.lineTo(cx+neck,cy); ctx.lineTo(cx+half,cy+half); ctx.lineTo(cx-half,cy+half); ctx.lineTo(cx-neck,cy); ctx.closePath(); ctx.stroke(); ctx.save(); ctx.beginPath(); ctx.moveTo(cx-half,cy-half); ctx.lineTo(cx+half,cy-half); ctx.lineTo(cx+neck,cy); ctx.lineTo(cx-neck,cy); ctx.closePath(); ctx.clip(); const topFill=1-frac; const topY=cy-half + topFill*half; ctx.fillStyle='rgba(255,255,255,0.85)'; ctx.fillRect(cx-half+1, topY, size-2, (cy-topY)-1); ctx.restore(); ctx.save(); ctx.beginPath(); ctx.moveTo(cx+neck,cy); ctx.lineTo(cx+half,cy+half); ctx.lineTo(cx-half,cy+half); ctx.lineTo(cx-neck,cy); ctx.closePath(); ctx.clip(); const botY=cy+half - frac*half; ctx.fillStyle='rgba(255,255,255,0.85)'; ctx.fillRect(cx-half+1, botY, size-2, cy+half-botY-1); ctx.restore(); ctx.beginPath(); ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.moveTo(cx,cy-4); ctx.lineTo(cx,cy+4); ctx.stroke(); ctx.restore(); }
-function analog(cx,cy,R,fr){ ctx.save(); ctx.translate(cx,cy); ctx.strokeStyle='rgba(255,255,255,0.2)'; ctx.lineWidth=Math.max(2,R*0.02); ctx.beginPath(); ctx.arc(0,0,R,0,Math.PI*2); ctx.stroke(); for(let i=0;i<60;i++){ const a=i/60*2*Math.PI; const r1=R*(i%5?0.92:0.85); ctx.beginPath(); ctx.moveTo(Math.cos(a)*r1, Math.sin(a)*r1); ctx.lineTo(Math.cos(a)*R, Math.sin(a)*R); ctx.strokeStyle='rgba(255,255,255,'+(i%5?0.25:0.5)+')'; ctx.stroke(); } const secA=fr.sec*2*Math.PI - Math.PI/2; const minA=fr.min*2*Math.PI - Math.PI/2; const hourA=fr.hour*2*Math.PI - Math.PI/2; ctx.lineCap='round'; ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.lineWidth=Math.max(3,R*0.035); ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(Math.cos(hourA)*R*0.5, Math.sin(hourA)*R*0.5); ctx.stroke(); ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.lineWidth=Math.max(2,R*0.025); ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(Math.cos(minA)*R*0.72, Math.sin(minA)*R*0.72); ctx.stroke(); ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.lineWidth=Math.max(1.5,R*0.015); ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(Math.cos(secA)*R*0.85, Math.sin(secA)*R*0.85); ctx.stroke(); ctx.restore(); }
-function spiral(cx,cy,R,frac){ const turns=2.25; const steps=240; const maxT=frac*turns*2*Math.PI; ctx.lineWidth=Math.max(4,R*0.05); ctx.lineCap='round'; ctx.strokeStyle='rgba(255,255,255,0.15)'; ctx.beginPath(); for(let i=0;i<=steps;i++){ const t=i/steps*turns*2*Math.PI; const r=R*(t/(turns*2*Math.PI)); const x=cx+r*Math.cos(t), y=cy+r*Math.sin(t); if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);} ctx.stroke(); ctx.strokeStyle='rgba(255,255,255,0.95)'; ctx.beginPath(); for(let i=0;i<=steps;i++){ const t=i/steps*maxT; const r=R*(t/(turns*2*Math.PI)); const x=cx+r*Math.cos(t), y=cy+r*Math.sin(t); if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);} ctx.stroke(); }
-function teardrop(cx,cy,H,frac){ const W=H*0.55; const neck=W*0.12; const topH=H*0.45; ctx.save(); ctx.strokeStyle='rgba(255,255,255,0.9)'; ctx.lineWidth=Math.max(2,H*0.01); ctx.beginPath(); ctx.moveTo(cx, cy-topH); ctx.bezierCurveTo(cx+W*0.5, cy-topH*0.4, cx+W*0.6, cy+neck*0.5, cx, cy+neck); ctx.bezierCurveTo(cx-W*0.6, cy+neck*0.5, cx-W*0.5, cy-topH*0.4, cx, cy-topH); ctx.stroke(); ctx.save(); ctx.beginPath(); ctx.moveTo(cx, cy-topH); ctx.bezierCurveTo(cx+W*0.5, cy-topH*0.4, cx+W*0.6, cy+neck*0.5, cx, cy+neck); ctx.bezierCurveTo(cx-W*0.6, cy+neck*0.5, cx-W*0.5, cy-topH*0.4, cx, cy-topH); ctx.closePath(); ctx.clip(); const fy = cy+neck - (topH+neck)*frac; ctx.fillStyle='rgba(255,255,255,0.85)'; ctx.fillRect(cx-W, fy, W*2, (cy+neck) - fy); ctx.restore(); ctx.restore(); }
-
-function drawOverlay(){ resize(); ctx.clearRect(0,0,ui.width,ui.height); const w=ui.width, h=ui.height; const cx=w/2, cy=h/2; const R=Math.min(w,h)*0.42; let fr; let elapsed=0, remaining=0; if(mode.value==='clock'){ fr=clockFractions(new Date()); } else { if(timerActive){ const now=performance.now()/1000; elapsed = (timerType.value==='countdown') ? Math.min(timerTotal, now - timerStart) : (now - timerStart); remaining = Math.max(0, timerTotal - elapsed); if(remaining<=0 && timerType.value==='countdown'){ timerActive=false; startTimerBtn.disabled=false; stopTimerBtn.disabled=true; } } fr=timerFractions(elapsed); timeDisplay.textContent = fmt(timerType.value==='countdown'? remaining: elapsed); }
-  const model=visModel.value; if(model==='rings'){ const rings=[]; if(ringYear.checked) rings.push(['YEAR', fr.year]); if(ringMonth.checked) rings.push(['MONTH', fr.month]); if(ringWeek.checked) rings.push(['WEEK', fr.week]); if(ringDay.checked) rings.push(['DAY', fr.day]); if(ringHour.checked) rings.push(['HOUR', fr.hour]); if(ringMin.checked) rings.push(['MIN', fr.min]); if(ringSec.checked) rings.push(['SEC', fr.sec]); let r1=R; const gap=Math.max(8, Math.min(R*0.08, 24)); const thick=Math.max(10, Math.min(R*0.12, 28)); rings.forEach(([label,frac])=>{ ring(cx,cy,r1-thick,r1,frac,label); r1 -= (thick+gap); }); } else if(model==='hourglass'){ const unit = mode.value==='clock' ? fr.min : (timerTotal>0? (Math.min(1, (timerType.value==='countdown'? (1-(elapsed/timerTotal)) : (elapsed/timerTotal)))) : 0); hourglass(cx,cy,Math.min(w,h)*0.6, 1-unit); } else if(model==='analog'){ analog(cx,cy,Math.min(w,h)*0.42, {sec:fr.sec, min:fr.min, hour:fr.hour}); } else if(model==='spiral'){ spiral(cx,cy,Math.min(w,h)*0.46, fr.min); } else if(model==='teardrop'){ teardrop(cx,cy,Math.min(w,h)*0.7, (mode.value==='clock'? fr.min : (timerTotal? Math.min(1,(timerType.value==='countdown'? (elapsed/timerTotal) : (elapsed/timerTotal))) : 0))); } else if(model==='multizone'){ const zones = zonesInput.value.split(',').map(s=>s.trim()).filter(Boolean).slice(0,8); const cols = Math.min(4, Math.ceil(Math.sqrt(zones.length||1))); const rows = Math.ceil((zones.length||1)/cols); const gridW = w/cols, gridH=h/rows; const pad=Math.min(gridW,gridH)*0.08; zones.forEach((z,i)=>{ const c=i%cols, r=(i/cols)|0; const gx=c*gridW, gy=r*gridH; const ccx=gx+gridW/2, ccy=gy+gridH/2; const RR=Math.min(gridW,gridH)/2 - pad; let dt; try{ dt=new Date(new Date().toLocaleString('en-US',{timeZone:z})); }catch(e){ dt=new Date(); } const f=clockFractions(dt); analog(ccx, ccy, RR, {sec:f.sec, min:f.min, hour:f.hour}); ctx.fillStyle='rgba(255,255,255,0.85)'; ctx.font=`${Math.max(12, RR*0.18)}px system-ui`; ctx.textAlign='center'; ctx.fillText(z, ccx, ccy+RR+pad*0.6); }); } }
-
-// ===== Config Save/Export/Import =====
-const saveBtn=document.getElementById('saveConfigBtn');
-const exportBtn=document.getElementById('exportConfigBtn');
-const importBtn=document.getElementById('importConfigBtn');
-const importInput=document.getElementById('importConfig');
-
-function gatherConfig(){
-  return {
-    period:+period.value,
-    density:+density.value,
-    gamma:+gamma.value,
-    pal:+pal.value,
-    mode:mode.value,
-    visModel:visModel.value,
-    rings:{sec:ringSec.checked,min:ringMin.checked,hour:ringHour.checked,day:ringDay.checked,week:ringWeek.checked,month:ringMonth.checked,year:ringYear.checked},
-    timerType:timerType.value,
-    timerMin:+timerMin.value,
-    zones:zonesInput.value,
-    handlePos:handlePos.value
-  };
-}
-function applyConfig(cfg){
-  if(cfg.period!==undefined) period.value=cfg.period;
-  if(cfg.density!==undefined) density.value=cfg.density;
-  if(cfg.gamma!==undefined) gamma.value=cfg.gamma;
-  if(cfg.pal!==undefined) pal.value=cfg.pal;
-  if(cfg.mode) mode.value=cfg.mode;
-  if(cfg.visModel) visModel.value=cfg.visModel;
-  if(cfg.rings){ ringSec.checked=cfg.rings.sec; ringMin.checked=cfg.rings.min; ringHour.checked=cfg.rings.hour; ringDay.checked=cfg.rings.day; ringWeek.checked=cfg.rings.week; ringMonth.checked=cfg.rings.month; ringYear.checked=cfg.rings.year; }
-  if(cfg.timerType) timerType.value=cfg.timerType;
-  if(cfg.timerMin!==undefined) timerMin.value=cfg.timerMin;
-  if(cfg.zones) zonesInput.value=cfg.zones;
-  if(cfg.handlePos){ handlePos.value=cfg.handlePos; handlePos.dispatchEvent(new Event('change')); }
-}
-
-saveBtn.addEventListener('click', ()=>{
-  const cfg=gatherConfig();
-  try{ localStorage.setItem('infinite_loop_config', JSON.stringify(cfg)); alert('Saved to browser'); }catch(e){ alert('Save failed'); }
-});
-
-function filenameForExport(){
-  const m = (mode.value||'mode');
-  const d = new Date();
-  const date = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
-  const time = `${String(d.getHours()).padStart(2,'0')}-${String(d.getMinutes()).padStart(2,'0')}-${String(d.getSeconds()).padStart(2,'0')}`;
-  return `infinite_loop_${m}_${date}_${time}.json`;
-}
-
-exportBtn.addEventListener('click', ()=>{
-  const cfg=gatherConfig();
-  const blob=new Blob([JSON.stringify(cfg,null,2)],{type:'application/json'});
-  const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=filenameForExport(); a.click();
-});
-
-importBtn.addEventListener('click', ()=> importInput.click());
-importInput.addEventListener('change', e=>{
-  const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ const cfg=JSON.parse(r.result); applyConfig(cfg);}catch(err){ alert('Invalid JSON'); } }; r.readAsText(f);
-});
-
-// ===== Main loop =====
-function frame(){ drawBackground(); drawOverlay(); requestAnimationFrame(frame); }
-resize(); frame();
-
-// Snapshot (composite)
-document.getElementById('snapshot').addEventListener('click', ()=>{ const comp=document.createElement('canvas'); comp.width=bg.width; comp.height=bg.height; const c=comp.getContext('2d'); c.drawImage(bg,0,0); c.drawImage(ui,0,0); const url=comp.toDataURL('image/png'); const a=document.createElement('a'); a.href=url; a.download='timer_clock_visual.png'; a.click(); });
+const $=id=>document.getElementById(id), canvas=$('clockCanvas'),ctx=canvas.getContext('2d');
+const controls={clockStyle:$('clockStyle'),centerStyle:$('centerStyle'),hourlyChime:$('hourlyChime'),hourlyFlash:$('hourlyFlash'),volume:$('volume'),theme:$('theme'),thickness:$('thickness'),glow:$('glow')};
+const palettes={midnight:{bg:'#090b12',accent:'#71d7ff',text:'#f5f7ff'},ember:{bg:'#160b08',accent:'#ff9b62',text:'#fff4ec'},forest:{bg:'#07130f',accent:'#67e3a5',text:'#effff7'},mono:{bg:'#090909',accent:'#f2f2f2',text:'#fafafa'}};
+let flashUntil=0,audioContext,lastHour=new Date().getHours(),lastAccessibleMinute=-1;
+function selectedUnits(){return [...document.querySelectorAll('#unitChecks input:checked')].map(x=>x.value)}
+function fit(){const d=Math.min(devicePixelRatio||1,2),w=innerWidth*d,h=innerHeight*d;if(canvas.width!==w||canvas.height!==h){canvas.width=w;canvas.height=h}}
+function fractions(d){const sub=(d.getSeconds()+d.getMilliseconds()/1000)/60,min=(d.getMinutes()+sub)/60,hour=(d.getHours()+min)/24;return{minute:sub,hour:min,day:hour,week:(d.getDay()+hour)/7,month:(d.getDate()-1+hour)/new Date(d.getFullYear(),d.getMonth()+1,0).getDate(),year:(d.getMonth()+((d.getDate()-1+hour)/new Date(d.getFullYear(),d.getMonth()+1,0).getDate()))/12}}
+function unitValues(d){return{minute:String(d.getSeconds()).padStart(2,'0')+' sec',hour:String(d.getMinutes()).padStart(2,'0')+' min',day:d.toLocaleTimeString([],{hour:'numeric'}),week:d.toLocaleDateString([],{weekday:'short'}).toUpperCase(),month:String(d.getDate()),year:d.toLocaleDateString([],{month:'short'}).toUpperCase()}}
+function centerText(d){if(controls.centerStyle.value==='verbal')return[d.toLocaleTimeString([],{hour:'numeric',minute:'2-digit'}),d.toLocaleDateString([],{weekday:'long',month:'long',day:'numeric',year:'numeric'})];return[d.toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}),d.toLocaleDateString([],{weekday:'short',month:'short',day:'numeric',year:'numeric'})]}
+function drawCenter(d,cx,cy,R,p){const [a,b]=centerText(d),scale=Math.max(.65,Math.min(1,R/350));ctx.textAlign='center';ctx.fillStyle=p.text;ctx.font=`300 ${Math.round(46*scale)}px system-ui`;ctx.fillText(a,cx,cy+4);ctx.fillStyle=p.text+'bb';ctx.font=`${Math.round(15*scale)}px system-ui`;ctx.fillText(b,cx,cy+31*scale)}
+function drawClock(){fit();const d=new Date(),p=palettes[controls.theme.value],w=canvas.width,h=canvas.height,cx=w/2,cy=h/2,R=Math.min(w,h)*.42;document.body.style.background=p.bg;ctx.clearRect(0,0,w,h);const g=ctx.createRadialGradient(cx,cy,0,cx,cy,Math.max(w,h)*.7);g.addColorStop(0,p.accent+'18');g.addColorStop(1,p.bg);ctx.fillStyle=g;ctx.fillRect(0,0,w,h);if(performance.now()<flashUntil){ctx.fillStyle=p.accent+'24';ctx.fillRect(0,0,w,h)}
+ const fr=fractions(d),vals=unitValues(d),units=selectedUnits();if(controls.clockStyle.value==='circular'&&units.length){const thick=+controls.thickness.value*(devicePixelRatio||1),gap=Math.max(8,thick*.65),available=Math.max(60,R-Math.min(145*(devicePixelRatio||1),R*.5)),step=Math.min(thick+gap,available/units.length);units.slice().reverse().forEach((u,i)=>{const r=R-i*step,a=-Math.PI/2,b=a+fr[u]*Math.PI*2;ctx.lineWidth=thick;ctx.lineCap='round';ctx.strokeStyle='#ffffff18';ctx.beginPath();ctx.arc(cx,cy,r,a,a+Math.PI*2);ctx.stroke();ctx.strokeStyle=p.accent;if(controls.glow.checked){ctx.shadowColor=p.accent;ctx.shadowBlur=12}ctx.beginPath();ctx.arc(cx,cy,r,a,b);ctx.stroke();ctx.shadowBlur=0;ctx.fillStyle=p.text;ctx.font=`${Math.max(11,thick*.62)}px system-ui`;ctx.textAlign='center';ctx.fillText(`${u.toUpperCase()} · ${vals[u]}`,cx,cy-r-thick*.7)})}drawCenter(d,cx,cy,R,p);
+ if(d.getMinutes()!==lastAccessibleMinute){lastAccessibleMinute=d.getMinutes();$('accessibleTime').textContent=`${d.toLocaleTimeString([],{hour:'numeric',minute:'2-digit'})}, ${d.toLocaleDateString([],{dateStyle:'full'})}`}
+ if(d.getHours()!==lastHour){lastHour=d.getHours();if(d.getMinutes()===0){if(controls.hourlyFlash.checked)flashUntil=performance.now()+1200;if(controls.hourlyChime.checked)chime()}}requestAnimationFrame(drawClock)}
+function chime(){audioContext??=new(window.AudioContext||window.webkitAudioContext)();audioContext.resume();const now=audioContext.currentTime;[0,0.18].forEach((delay,i)=>{const o=audioContext.createOscillator(),gain=audioContext.createGain();o.frequency.value=i?659.25:523.25;gain.gain.setValueAtTime(+controls.volume.value*.16,now+delay);gain.gain.exponentialRampToValueAtTime(.001,now+delay+.55);o.connect(gain).connect(audioContext.destination);o.start(now+delay);o.stop(now+delay+.6)})}
+function message(s){$('message').textContent=s;setTimeout(()=>{if($('message').textContent===s)$('message').textContent=''},3000)}
+function config(){return{version:1,...Object.fromEntries(Object.entries(controls).map(([k,v])=>[k,v.type==='checkbox'?v.checked:v.value])),units:selectedUnits(),timer:{mode:$('timerMode').value,visual:$('timerVisual').value,hours:+$('timerHours').value,minutes:+$('timerMinutes').value,seconds:+$('timerSeconds').value}}}
+function applyConfig(c){if(!c||c.version!==1)throw Error('Unsupported configuration');for(const[k,v]of Object.entries(controls)){if(c[k]!==undefined){if(v.type==='checkbox')v.checked=Boolean(c[k]);else if([...v.options||[]].some?.(o=>o.value===String(c[k]))||v.type==='range')v.value=c[k]}}if(Array.isArray(c.units))document.querySelectorAll('#unitChecks input').forEach(x=>x.checked=c.units.includes(x.value));if(c.timer){$('timerMode').value=c.timer.mode==='countup'?'countup':'countdown';$('timerVisual').value=['hourglass','analog','spiral'].includes(c.timer.visual)?c.timer.visual:'hourglass';['hours','minutes','seconds'].forEach(k=>$("timer"+k[0].toUpperCase()+k.slice(1)).value=Math.max(0,Number(c.timer[k])||0))}applyTheme()}
+function applyTheme(){const p=palettes[controls.theme.value];document.documentElement.style.setProperty('--bg',p.bg);document.documentElement.style.setProperty('--accent',p.accent);document.documentElement.style.setProperty('--text',p.text)}
+$('openControls').onclick=()=>{$('panel').classList.add('open');$('openControls').setAttribute('aria-expanded','true')};$('closeControls').onclick=()=>{$('panel').classList.remove('open');$('openControls').setAttribute('aria-expanded','false')};$('restoreUnits').onclick=()=>document.querySelectorAll('#unitChecks input').forEach(x=>x.checked=true);controls.theme.onchange=applyTheme;$('testSound').onclick=chime;
+$('saveConfig').onclick=()=>{localStorage.setItem('time-flow-config',JSON.stringify(config()));message('Preferences saved')};$('exportConfig').onclick=()=>{const url=URL.createObjectURL(new Blob([JSON.stringify(config(),null,2)],{type:'application/json'})),a=document.createElement('a');a.href=url;a.download='time-flow-settings.json';a.click();setTimeout(()=>URL.revokeObjectURL(url),0)};$('importButton').onclick=()=>$('importConfig').click();$('importConfig').onchange=async e=>{try{applyConfig(JSON.parse(await e.target.files[0].text()));message('Preferences imported')}catch{message('Could not import that file')}finally{e.target.value=''}};
+// Timer is intentionally separate from the clock, but continues running while its dialog is closed.
+const td=$('timerDialog'),tc=$('timerCanvas'),tx=tc.getContext('2d');let timer={state:'idle',elapsed:0,started:0};
+function duration(){return Math.max(1,+$('timerHours').value*3600 + +$('timerMinutes').value*60 + +$('timerSeconds').value)}function elapsed(){return timer.elapsed+(timer.state==='running'?(performance.now()-timer.started)/1000:0)}function fmt(n){n=Math.max(0,Math.ceil(n));return`${String(Math.floor(n/3600)).padStart(2,'0')}:${String(Math.floor(n/60)%60).padStart(2,'0')}:${String(n%60).padStart(2,'0')}`}
+function timerFrame(){let e=elapsed(),total=duration();if($('timerMode').value==='countdown'&&e>=total&&timer.state==='running'){timer.elapsed=total;timer.state='done';$('timerPause').disabled=true;chime()}const progress=$('timerMode').value==='countdown'?Math.min(1,e/total):e%total/total,value=$('timerMode').value==='countdown'?total-e:e;$('timerDisplay').textContent=fmt(value);drawTimer(progress);requestAnimationFrame(timerFrame)}
+function drawTimer(f){const w=tc.width,h=tc.height,cx=w/2,cy=h/2,R=130,p=palettes[controls.theme.value];tx.clearRect(0,0,w,h);tx.strokeStyle=p.accent;tx.fillStyle=p.accent;tx.lineCap='round';tx.lineWidth=12;const v=$('timerVisual').value;if(v==='analog'){tx.strokeStyle='#ffffff22';tx.beginPath();tx.arc(cx,cy,R,0,Math.PI*2);tx.stroke();tx.strokeStyle=p.accent;tx.beginPath();tx.arc(cx,cy,R,-Math.PI/2,-Math.PI/2+f*Math.PI*2);tx.stroke();tx.lineWidth=7;tx.beginPath();tx.moveTo(cx,cy);tx.lineTo(cx+Math.cos(-Math.PI/2+f*Math.PI*2)*R*.75,cy+Math.sin(-Math.PI/2+f*Math.PI*2)*R*.75);tx.stroke()}else if(v==='spiral'){tx.beginPath();for(let i=0;i<=200*f;i++){const t=i/200*Math.PI*5,r=R*i/200,x=cx+Math.cos(t)*r,y=cy+Math.sin(t)*r;i?tx.lineTo(x,y):tx.moveTo(x,y)}tx.stroke()}else{tx.lineWidth=6;tx.strokeRect(cx-90,cy-130,180,260);tx.beginPath();tx.moveTo(cx-88,cy-127);tx.lineTo(cx+88,cy+127);tx.moveTo(cx+88,cy-127);tx.lineTo(cx-88,cy+127);tx.stroke();tx.beginPath();tx.moveTo(cx-80,cy+120);tx.lineTo(cx+80,cy+120);tx.lineTo(cx+80-f*80,cy+120-f*120);tx.lineTo(cx-80+f*80,cy+120-f*120);tx.fill()}}
+$('openTimer').onclick=()=>td.showModal();$('closeTimer').onclick=()=>td.close();$('timerStart').onclick=()=>{if(timer.state==='done'||timer.state==='idle')timer.elapsed=0;timer.started=performance.now();timer.state='running';$('timerStart').textContent='Resume';$('timerPause').disabled=false};$('timerPause').onclick=()=>{timer.elapsed=elapsed();timer.state='paused';$('timerPause').disabled=true};$('timerReset').onclick=()=>{timer={state:'idle',elapsed:0,started:0};$('timerStart').textContent='Start';$('timerPause').disabled=true};
+try{const saved=JSON.parse(localStorage.getItem('time-flow-config'));if(saved)applyConfig(saved)}catch{}applyTheme();drawClock();timerFrame();
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce UI complexity by removing the mixed mode/model selector and dense control rows so the primary page communicates time clearly. 
- Separate the timer from the main clock so each surface has focused, appropriate controls and visuals.
- Replace confusing second/interval semantics with calendar-aware unit progress (minute/hour/day/week/month/year).
- Improve accessibility, persistent preferences, and opt-in audible/visual hour signals.

### Description
- Replaced the previous combined drawer and multi-model controls with a compact settings panel exposing two primary clock styles (`Circular + digital`, `Digital only`) and a center-display choice (`Digital` or `Verbal`).
- Implemented six calendar-progress units (minute, hour, day, week, month, year) with readable unit labels and current-value markers rendered in the circular layout; removed the legacy seconds ring and multi-zone controls.
- Moved timer functionality into a dedicated modal dialog (opened via floating hourglass button) that supports countdown/count-up modes, hour/minute/second duration entry, Start/Pause/Resume/Reset lifecycle, and three visuals (Hourglass, Analog, Spiral).
- Added opt-in hourly chime and visual pulse, a test-sound button, adjustable volume, four themes, ring thickness and glow controls, and a versioned save/export/import preferences flow with basic validation and persistence.
- Added a screen-reader-friendly live region that announces the clock text and improved control labeling and keyboard focus behavior; simplified CSS and drawing logic and consolidated JS into a single, minimal script.

### Testing
- `git diff --check` ran with no whitespace or diff-check issues (passed).
- JavaScript syntax validated by extracting the `<script>` content and executing `new Function(...)` in Node (passed).
- HTML structure parsed successfully with Python's `html.parser` (passed).
- Static searches (`rg`) confirmed removal of legacy controls (`mode`, `visModel`, `ringSec`, `zones`) and presence of new clock/timer UI strings (passed).
- Repository status was inspected to ensure the workspace is clean after the change; no browser-based screenshots were produced because Chromium/Playwright/Puppeteer are not installed in the environment (manual/visual QA recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6efc861004832d99dddbfed6d364b7)