### PR TITLE
Fix Repo Recall Live sidebar scrolling and setup sections

### DIFF
--- a/repo-live-lineage-v4.html
+++ b/repo-live-lineage-v4.html
@@ -53,6 +53,7 @@
       display: grid;
       grid-template-columns: var(--sidebar) 1fr;
       height: 100vh;
+      height: 100dvh;
       min-height: 0;
       background: linear-gradient(180deg, rgba(79, 70, 229, .12), transparent 300px), var(--bg);
       transition: grid-template-columns .18s ease;
@@ -67,7 +68,10 @@
       flex-direction: column;
       background: color-mix(in srgb, var(--panel) 92%, transparent);
       transition: width .18s ease, transform .18s ease;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior-y: contain;
+      -webkit-overflow-scrolling: touch;
     }
 
     .sidebar.collapsed {
@@ -78,9 +82,6 @@
     }
 
     .side-head {
-      position: sticky;
-      top: 0;
-      z-index: 3;
       padding: 14px;
       display: grid;
       gap: 12px;
@@ -200,9 +201,9 @@
     .stat span { display: block; color: var(--muted); font-size: .68rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 800; }
 
     .timeline {
-      flex: 1;
+      flex: 0 0 auto;
       min-height: 0;
-      overflow: auto;
+      overflow: visible;
       padding: 12px;
       display: grid;
       align-content: start;
@@ -408,15 +409,11 @@
       .app, .app.sidebar-collapsed { grid-template-columns: 1fr; height: auto; min-height: 100vh; }
       .main, .workspace { min-height: 0; }
       .sidebar-toggle-global { top: 8px; left: 8px; }
-      .sidebar { position: fixed; top: 0; bottom: 0; left: 0; width: min(92vw, 390px); z-index: 9; box-shadow: var(--shadow); }
+      .sidebar { position: fixed; top: 0; bottom: auto; left: 0; width: min(92vw, 390px); height: 100vh; height: 100dvh; z-index: 9; box-shadow: var(--shadow); }
       .sidebar.collapsed { transform: translateX(-102%); width: min(92vw, 390px); border-right: 1px solid var(--border); }
       .drawer-toggle-floating { display: none; }
       .main { min-height: 100vh; }
       .topbar { padding: 10px 12px; }
-      .app { grid-template-columns: 1fr; }
-      .sidebar { position: fixed; top: 0; bottom: 0; left: 0; width: min(92vw, 390px); z-index: 9; box-shadow: var(--shadow); }
-      .sidebar.collapsed { transform: translateX(-102%); width: min(92vw, 390px); border-right: 1px solid var(--border); }
-      .drawer-toggle-floating { display: none; }
       .preview-layout, .preview-layout.actions-closed { grid-template-columns: 1fr; }
       .preview-area { border-right: 0; border-bottom: 1px solid var(--border); min-height: 52vh; }
       .side-column { max-height: 42vh; }
@@ -485,15 +482,26 @@
                 <label for="branchInput">Branch</label>
                 <input id="branchInput" type="text" value="main" placeholder="main" autocomplete="off" />
               </div>
-              <div class="field">
-                <label for="patternInput">File patterns</label>
-                <input id="patternInput" type="text" value="bridge*" placeholder="*.html, *.md" autocomplete="off" />
-                <p class="field-help">Comma-separated wildcards are combined with OR.</p>
-                <details id="searchHistoryDetails" class="setup-details" style="margin-top:8px;">
-                  <summary>Prior searches</summary>
-                  <div id="searchHistoryList" class="setup-content"></div>
-                </details>
-              </div>
+            </div>
+
+            <div class="field">
+              <label for="tokenInput">GitHub token optional for public read, required for publish</label>
+              <input id="tokenInput" type="text" placeholder="ghp_…" autocomplete="off" />
+            </div>
+          </div>
+        </details>
+
+        <details id="searchDetails" class="setup-details">
+          <summary>Search terms</summary>
+          <div class="setup-content">
+            <div class="field">
+              <label for="patternInput">File patterns</label>
+              <input id="patternInput" type="text" value="bridge*" placeholder="*.html, *.md" autocomplete="off" />
+              <p class="field-help">Comma-separated wildcards are combined with OR.</p>
+              <details id="searchHistoryDetails" class="setup-details" style="margin-top:8px;">
+                <summary>Prior searches</summary>
+                <div id="searchHistoryList" class="setup-content"></div>
+              </details>
             </div>
 
             <div class="field inline">
@@ -509,11 +517,6 @@
 
             <div class="button-row">
               <button id="july2026PresetBtn" class="btn small" type="button">July 2026 · HTML + Markdown</button>
-            </div>
-
-            <div class="field">
-              <label for="tokenInput">GitHub token optional for public read, required for publish</label>
-              <input id="tokenInput" type="text" placeholder="ghp_…" autocomplete="off" />
             </div>
 
             <div class="field inline">
@@ -542,15 +545,15 @@
                 </dl>
               </div>
             </details>
-
-            <div class="button-row">
-              <button id="scanBtn" class="btn primary" type="button">Build timeline</button>
-              <button id="cancelScanBtn" class="btn danger" type="button" disabled>Cancel</button>
-              <button id="saveDefaultsBtn" class="btn" type="button">Save defaults</button>
-            </div>
-            <div id="scanStatus" class="status" hidden></div>
           </div>
         </details>
+
+        <div class="button-row">
+          <button id="scanBtn" class="btn primary" type="button">Build timeline</button>
+          <button id="cancelScanBtn" class="btn danger" type="button" disabled>Cancel</button>
+          <button id="saveDefaultsBtn" class="btn" type="button">Save defaults</button>
+        </div>
+        <div id="scanStatus" class="status" hidden></div>
 
         <div class="timeline-tools">
           <div class="field">


### PR DESCRIPTION
### Motivation
- The left setup/sidebar could not be fully scrolled on some viewports and its form felt crowded; the UI must allow reaching every control and the Build timeline button without extra input focus or nested-scroll traps. 
- The setup form should be clearer by separating repository connection fields from search/query fields while preserving existing element IDs and behavior.

### Description
- Modified `repo-live-lineage-v4.html` CSS to make the sidebar use a single viewport-height scroll surface (`height: 100dvh` with fallbacks), enabled vertical scrolling (`overflow-y: auto`), added `overscroll-behavior-y: contain` and `-webkit-overflow-scrolling: touch`, and removed nested timeline scrolling by adjusting `.timeline` flex/overflow rules.  
- Consolidated duplicate mobile sidebar rules and gave the mobile drawer an explicit dynamic viewport height so the open sidebar is scrollable in desktop, mobile portrait, and mobile landscape without changing collapse/open behavior.  
- Reorganized the left-panel HTML to split the original setup into two native `<details>` sections: `Repository setup` (`setupDetails`) and a new `Search terms` (`searchDetails`), moving file-patterns, prior-searches, date-range, preset, pages, and concurrency into `Search terms`, while keeping all existing element IDs (e.g. `patternInput`, `dateFromInput`, `concurrencyInput`, `searchHistoryDetails`) unchanged.  
- Kept primary actions (`scanBtn`, `cancelScanBtn`, `saveDefaultsBtn`) and `scanStatus` outside the collapsible sections immediately below them so they remain reachable when either section is closed.  

### Testing
- Ran `git diff --check` with no reported spacing or trailing-whitespace problems; result OK.  
- Parsed all inline JavaScript via Node (`new Function(...)`) to confirm no syntax errors; parsing succeeded.  
- Verified via a Node script that every JavaScript-referenced element ID exists exactly once and that document IDs are unique; verification succeeded.  
- Attempted to run browser automation checks but Playwright/Chromium were not available in the environment, so interactive viewport checks (desktop, mobile portrait, mobile landscape) were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f0a0bdd40832d9c32742d20320cb8)