### PR TITLE
Clarify T10-23 to require visible pending sync for offline phrasebook edits

### DIFF
--- a/TalkBridge-Build-Specification.md
+++ b/TalkBridge-Build-Specification.md
@@ -916,7 +916,7 @@ Elevation is trust. When it lapses, the trust lapses with it.
 | T10-20 | Tag input suggests from tags already used anywhere in this phrasebook |
 | T10-21 | Categories survive edit, comment, use, and soft-delete-then-restore |
 | T10-22 | Soft-delete → appears in trash section, restorable with all fields |
-| T10-23 | Edit a card offline → saved locally, indicator green, no pending state shown |
+| T10-23 | Edit a card offline → edit saved locally and remains available; sync indicator visibly dirty/pending; pending synchronization survives reload and retries when connectivity returns without duplicating the edit |
 | T10-24 | Force the central write to fail → "trouble updating GitHub, check the debug log"; log explains the real cause; local change intact |
 | T10-25 | Central copy newer → write refused, person informed, retried, local never overwritten |
 | T10-26 | Edit in the other application, then in this one → neither loses the other's change |


### PR DESCRIPTION
### Motivation
- The existing T10-23 wording contradicted the governing P3 and the established sync-indicator behavior by saying an offline edit shows "no pending state," so it was revised to reflect that local edits are durable while external synchronization can remain visibly pending.

### Description
- Updated the `T10-23` acceptance criterion in `TalkBridge-Build-Specification.md` to require that an offline phrasebook card edit is saved locally and remains available; that the sync indicator visibly shows dirty/pending state; that the pending state survives reload; that synchronization retries when connectivity returns; and that retries do not duplicate the edit.

### Testing
- Ran `git diff --check` with no issues, searched the file with `rg -n 'T10-23|no pending state|dirty|pending synchronization|sync indicator' TalkBridge-Build-Specification.md` to confirm the updated criterion appears and no contradictory remnants remain, and inspected `git diff -- TalkBridge-Build-Specification.md` to verify the change is a single-line, minimal patch; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7058f83ea8832d983cbfec702752ad)