### PR TITLE
Fix board switching behavior, restore last-used board, and add Trello import

### DIFF
--- a/kanban-boards.json
+++ b/kanban-boards.json
@@ -3,6 +3,19 @@
   "activeBoard": "legacy-archive",
   "boards": [
     {
+      "name": "trello",
+      "archived": false,
+      "lastUpdated": 1786183669076,
+      "createdAt": 1786183669076,
+      "cardCount": 17,
+      "lastCardUpdatedId": "trello-verifying-its-you",
+      "lastCardUpdatedAt": 1786183669076,
+      "phase": "dev",
+      "phaseUpdatedAt": 1786183669076,
+      "stage": "concept",
+      "stageUpdatedAt": 1786183669076
+    },
+    {
       "name": "openclaw",
       "archived": false,
       "lastUpdated": 1763646000000,

--- a/kanban.html
+++ b/kanban.html
@@ -452,7 +452,7 @@ dialog{border:none;border-radius:14px;padding:0;width:min(900px,96vw)}
 </div>
 
 <script>
-const BUILD = "2025-10-28";
+const BUILD = "2026-08-08";
 
 /* ===== NEW: Board Key System ===== */
 const BOARD_KEY_LS   = "kanban_board_key";
@@ -473,7 +473,7 @@ let startupBoardName = "";
 
 
 function _cleanKey(raw){ return (raw||"").trim().replace(/[^A-Za-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"")||"kanban"; }
-function getBoardKey(){ return _cleanKey(urlBoardParamRaw || localStorage.getItem(BOARD_KEY_LS) || "kanban"); }
+function getBoardKey(){ return _cleanKey(urlBoardParamRaw || localStorage.getItem(LAST_SEEN_BOARD_LS) || localStorage.getItem(BOARD_KEY_LS) || "kanban"); }
 function setBoardKey(raw){
   const k=_cleanKey(raw);
   localStorage.setItem(BOARD_KEY_LS, k);
@@ -655,9 +655,14 @@ function persistNow(options={}){
 }
 function scheduleSave(){ if(repoLoadBlocked) return false; dirty=true; clearTimeout(saveTimer); saveTimer=setTimeout(persistNow, 250); return true; }
 function loadState(){
-  // keyed slot first, then legacy
-  let raw = localStorage.getItem(boardLS()) || localStorage.getItem(STABLE_KEY);
-  if(!raw){ for(let i=LEGACY_KEYS.length-1;i>=0;i--){ raw=localStorage.getItem(LEGACY_KEYS[i]); if(raw) break; } if(raw) trySave(boardLS(), raw); }
+  // Never let one named board inherit the global/previous board cache. The
+  // unkeyed values are only migration sources for the original kanban board.
+  let raw = localStorage.getItem(boardLS());
+  if(!raw && canonicalBoardKey(currentBoardKey)==="kanban") raw=localStorage.getItem(STABLE_KEY);
+  if(!raw && canonicalBoardKey(currentBoardKey)==="kanban"){
+    for(let i=LEGACY_KEYS.length-1;i>=0;i--){ raw=localStorage.getItem(LEGACY_KEYS[i]); if(raw) break; }
+    if(raw) trySave(boardLS(), raw);
+  }
   if(raw){ try{ const obj=JSON.parse(raw); if(obj?.cards && obj?.stages && obj?.platforms) return obj; }catch{} }
   return null;
 }
@@ -2230,26 +2235,33 @@ function sanitizeMarkdownImages(s){
   const downloadSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 20h14v-2H5v2Zm7-16v9.17l3.09-3.08 1.41 1.41L12 17l-4.5-5.5 1.41-1.41L11 13.17V4h1Z"/></svg>';
   const trashSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 3h6l1 2h5v2H3V5h5l1-2Zm1 6h2v9h-2V9Zm4 0h2v9h-2V9ZM7 9h2v9H7V9Z"/></svg>';
     const chevronSvg='<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m10 17 5-5-5-5v10Z"/></svg>';
-  function switchToBoard(name){
+  async function switchToBoard(name){
     const key = setBoardKey(name);
     currentBoardKey = key;
     updateKeyLabel();
-    const fresh = loadState();
-    if(fresh){
-      state = fresh;
-      state.collapsed = (state.collapsed && typeof state.collapsed==="object") ? state.collapsed : {};
-      state.cardCollapsed = (state.cardCollapsed && typeof state.cardCollapsed==="object") ? state.cardCollapsed : {};
-      state.archive = Array.isArray(state.archive) ? state.archive : [];
-      state.layout = state.layout || "auto";
-    } else {
-      state.cards=[]; state.archive=[]; state.collapsed={}; state.cardCollapsed={}; state.layout="auto";
-      state.stages=Array.isArray(state.stages)&&state.stages.length?state.stages:["Done","Doing","Next"];
-      state.platforms=Array.isArray(state.platforms)&&state.platforms.length?state.platforms:["Gemini","Claude","ChatGPT","Perplexity"];
+    setStatus(`Loading ${key} from repository…`);
+    try{
+      const remote=await fetchJson(boardFilePath(key));
+      if(!isValidBoardData(remote)) throw new Error("Invalid repo board payload");
+      clearRepoLoadBlocked();
+      applyImportedBoard(remote,"repo");
+      toast("Switched","board: "+key);
+    }catch(err){
+      const cached=loadState();
+      if(!cached){
+        setRepoLoadBlocked(err);
+        toast("Switch failed",`${key}: ${err.message}`,true);
+        setStatus(`Could not load ${key}: ${err.message}`);
+        return false;
+      }
+      clearRepoLoadBlocked();
+      applyImportedBoard(cached,"local cache");
+      toast("Offline board loaded",`Using cached ${key}`,true);
     }
     upsertBoardRecord(key,{ archived:false });
-    render();
     renderBoardManager();
-    toast("Switched","board: "+key);
+    dlg.close();
+    return true;
   }
   function isBoardNameUnique(name, ignoreName=""){
     const key=canonicalBoardKey(name), ignore=canonicalBoardKey(ignoreName);
@@ -2343,7 +2355,6 @@ document.getElementById("boardKeyPill").addEventListener("click", ()=>{
     if(!isBoardNameUnique(raw)){ alert("Board name must be unique."); return; }
     const next=upsertBoardRecord(raw,{ archived:false });
     switchToBoard(next.name);
-    dlg.close();
   });
 
   function setImportSourceUi(){
@@ -2393,14 +2404,14 @@ async function bootstrapBoardsLifecycle(){
   await loadRepoBoardsIndex();
   const boards=(repoBoardsIndex.boards||[]).map(normalizeBoardRecord).filter(b=>b && !b.archived);
   boards.sort((a,b)=>Number(b.lastUpdated||0)-Number(a.lastUpdated||0));
-  const requested=canonicalBoardKey((urlBoardParamRaw||"").trim());
-  if(!hasBoardQueryParam){
+  // A query-string selection wins; otherwise restore the last board used on
+  // this device, then the repository's active board, then the newest board.
+  const remembered=(localStorage.getItem(LAST_SEEN_BOARD_LS)||localStorage.getItem(BOARD_KEY_LS)||"").trim();
+  const requested=canonicalBoardKey((urlBoardParamRaw||remembered||repoBoardsIndex.activeBoard||boards[0]?.name||"").trim());
+
+  if(!boards.length){
     state={ cards:[], archive:[], stages:["Done","Doing","Next"], platforms:["Gemini","Claude","ChatGPT","Perplexity"], collapsed:{}, cardCollapsed:{}, layout:"auto", lastModified:Date.now() };
     render();
-    const msg=document.createElement("div");
-    msg.className="empty-boarding";
-    msg.textContent="Welcome. Create a board from Board Manager to get started.";
-    document.getElementById("board").appendChild(msg);
     window.__openBoardManager?.("new-board","list");
     setStatus("Select or create a board to begin");
     boardsBootstrapped=true;

--- a/trello.json
+++ b/trello.json
@@ -1,0 +1,29 @@
+{
+  "stages": ["Backlog", "Doing", "Done"],
+  "platforms": ["Trello"],
+  "cards": [
+    {"id":"trello-verifying-its-you","title":"Verifying it's you","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/u070rzEz","live":"","tags":[],"notes":"Imported from Trello card #220.","pos":1000,"createdAt":1786183668627,"updatedAt":1786183669076,"files":[],"statusColor":"gray"},
+    {"id":"trello-scrape","title":"Scrape","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/Mx5l9ipC","live":"","tags":[],"notes":"Imported from Trello card #219.","pos":2000,"createdAt":1786183632116,"updatedAt":1786183632116,"files":[],"statusColor":"gray"},
+    {"id":"trello-ph-trip","title":"PH Trip","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/DFZDld14","live":"","tags":[],"notes":"Imported from Trello card #218.","pos":3000,"createdAt":1786183626869,"updatedAt":1786183626869,"files":[],"statusColor":"gray"},
+    {"id":"trello-phone-watch","title":"PHONE+ WATCH","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/Y4OrWSLa","live":"","tags":[],"notes":"Imported from Trello card #217.","pos":4000,"createdAt":1786183622355,"updatedAt":1786183622355,"files":[],"statusColor":"gray"},
+    {"id":"trello-penang-trip","title":"Penang Trip","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/LomVllC4","live":"","tags":[],"notes":"Imported from Trello card #216.","pos":5000,"createdAt":1786183617652,"updatedAt":1786183617652,"files":[],"statusColor":"gray"},
+    {"id":"trello-eyes","title":"Eyes","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/tSMAbjXP","live":"","tags":[],"notes":"Imported from Trello card #215.","pos":6000,"createdAt":1786183612432,"updatedAt":1786183612432,"files":[],"statusColor":"gray"},
+    {"id":"trello-laundry","title":"Laundry - cull clothes","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/PLeSh8dd","live":"","tags":[],"notes":"Imported from Trello card #214.","pos":7000,"createdAt":1786183603104,"updatedAt":1786183603104,"files":[],"statusColor":"gray"},
+    {"id":"trello-sot","title":"SOT","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/fVOzjVuW","live":"","tags":[],"notes":"Imported from Trello card #213.","pos":8000,"createdAt":1786183595298,"updatedAt":1786183595298,"files":[],"statusColor":"gray"},
+    {"id":"trello-ui-v2","title":"Ui-v2","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/q728IZQt","live":"","tags":[],"notes":"Imported from Trello card #212.","pos":9000,"createdAt":1786183589294,"updatedAt":1786183589294,"files":[],"statusColor":"gray"},
+    {"id":"trello-tb-pb","title":"tb/pb","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/mtLqJ4Wt","live":"","tags":[],"notes":"Imported from Trello card #211.","pos":10000,"createdAt":1786183583605,"updatedAt":1786183583605,"files":[],"statusColor":"gray"},
+    {"id":"trello-mkt-view","title":"Mkt View","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/yfsbQHHX","live":"","tags":[],"notes":"Imported from Trello card #210.","pos":11000,"createdAt":1786183576049,"updatedAt":1786183576049,"files":[],"statusColor":"gray"},
+    {"id":"trello-diem-bnb","title":"Diem bnb","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/Etg27jtI","live":"","tags":[],"notes":"Imported from Trello card #209.","pos":12000,"createdAt":1786183570228,"updatedAt":1786183570228,"files":[],"statusColor":"gray"},
+    {"id":"trello-bath-vanity","title":"Bath and vanity","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/PQK563tZ","live":"","tags":[],"notes":"Imported from Trello card #208.","pos":13000,"createdAt":1786183557258,"updatedAt":1786183557258,"files":[],"statusColor":"gray"},
+    {"id":"trello-teeth","title":"Teeth","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/oRLHWy6B","live":"","tags":[],"notes":"Imported from Trello card #207.","pos":14000,"createdAt":1786183551722,"updatedAt":1786183551722,"files":[],"statusColor":"gray"},
+    {"id":"trello-nathan-wedding","title":"Nathan wedding","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/Uz6thtzk","live":"","tags":[],"notes":"Imported from Trello card #206.","pos":15000,"createdAt":1786183545106,"updatedAt":1786183545106,"files":[],"statusColor":"gray"},
+    {"id":"trello-big-sur","title":"Big Sur milky way","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/9Brc7rp5","live":"","tags":[],"notes":"Imported from Trello card #205.","pos":16000,"createdAt":1786183539957,"updatedAt":1786183539957,"files":[],"statusColor":"gray"},
+    {"id":"trello-bassie","title":"Bassie","platform":"Trello","stage":"Backlog","dev":"https://trello.com/c/ToyjLyCK","live":"","tags":[],"notes":"Imported from Trello card #204.","pos":17000,"createdAt":1786183531052,"updatedAt":1786183531052,"files":[],"statusColor":"gray"}
+  ],
+  "archive": [],
+  "collapsed": {},
+  "cardCollapsed": {},
+  "layout": "auto",
+  "lastModified": 1786183669076,
+  "source": {"type":"trello","boardId":"55faf8e9e69fbf49b6355c65","name":"2026","url":"https://trello.com/b/HWGmNyT2/2026"}
+}


### PR DESCRIPTION
### Motivation
- Users saw the app not restoring the last-used board and board switches only fully loading after closing the Board Manager and reloading, so switching should load the selected board immediately and fall back to a local cache when offline. 
- Named boards were inheriting the legacy/global unkeyed cache which caused incorrect board contents to appear. 
- Provide a way to import the supplied Trello export as a repository-backed board for immediate use in `kanban.html`.

### Description
- Restore board selection precedence to prefer a URL `?board=` parameter, then the device’s last-seen board, then the repository active board, then the newest board. Implemented in the bootstrap lifecycle. 
- Make board switching immediate and robust by turning the `switchToBoard` handler into an `async` function that attempts to fetch the board payload from the repository, applies it on success, and falls back to a board-specific local cache if the repo fetch fails. 
- Prevent named boards from inheriting the global/legacy unkeyed cache by changing `loadState()` to read only the keyed slot for non-default boards and only use unkeyed legacy keys for the original `kanban` board as a migration source. 
- Add a persistent `LAST_SEEN_BOARD_LS` last-seen key and use it in `getBoardKey()` so opening `kanban.html` without a `?board=` restores the last-used board. 
- Bump `BUILD` timestamp. 
- Add a new `trello.json` board payload (17 backlog cards converted from the supplied Trello export) and add a `trello` entry to `kanban-boards.json` so the Trello board is available via the Board Manager. 

### Testing
- `python -m json.tool kanban-boards.json` — succeeded. 
- `python -m json.tool trello.json` — succeeded. 
- Inline JavaScript syntax validation by evaluating the page's inline scripts with Node — succeeded (no syntax/runtime initialization errors for the inline scripts). 
- `git diff --check` — succeeded (no whitespace/patch issues). 
- `git status --short --branch` — working tree was clean after committing the changes. 
- Attempted to submit PR metadata via the local `make_pr` MCP tool as part of the automated flow, but that environment call failed due to missing/blocked MCP dependencies in this environment (external dependency/network limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a771f4e880c832da7b4fd569811fbe4)