### PR TITLE
Prevent service worker from caching navigations

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,14 @@
-/* TalkBridge service worker — v5.8.1 (Turn 08 Base). Network-first; cached shell as offline fallback. */
-var CACHE='tb-v581';
+/* TalkBridge service worker — v5.8.2. Navigations always come from the network. */
+var CACHE='tb-v582';
 self.addEventListener('install',function(e){self.skipWaiting();});
 self.addEventListener('activate',function(e){
   e.waitUntil(caches.keys().then(function(ks){return Promise.all(ks.filter(function(k){return k!==CACHE}).map(function(k){return caches.delete(k)}));}).then(function(){return self.clients.claim();}));
 });
 self.addEventListener('fetch',function(e){
   if(e.request.method!=='GET')return;
+  /* Never let an old root-scoped worker revive stale application HTML. */
+  if(e.request.mode==='navigate')return;
   e.respondWith(
-    fetch(e.request).then(function(r){
-      if(e.request.mode==='navigate'&&r&&r.ok){var c=r.clone();caches.open(CACHE).then(function(cache){cache.put(e.request,c);});}
-      return r;
-    }).catch(function(){return caches.match(e.request);})
+    fetch(e.request).catch(function(){return caches.match(e.request);})
   );
 });


### PR DESCRIPTION
### Motivation

- Prevent the root-scoped service worker from serving stale application HTML as a navigation response which can revive an older deployed page and cause mismatched behavior. 
- Rotate the service-worker cache version so activation removes previously cached app shell HTML. 
- Retain existing network-first/offline-fallback behavior for non-navigation GET requests so other assets keep working offline.

### Description

- Updated `sw.js` header and bumped `CACHE` from `tb-v581` to `tb-v582` to trigger cache cleanup on activate. 
- Modified the `fetch` handler in `sw.js` to return early for requests where `e.request.mode === 'navigate'`, preventing the worker from intercepting navigations. 
- Removed code that cached navigation responses and retained `fetch(...).catch(() => caches.match(...))` behavior for non-navigation GET requests. 
- Verified the in-repo HTML (`program.html` and `mello.html`) already include `knownUnavailableBoards=new Set(["openclaw"])` and do not load `program.js`, so an initiator referencing `program.js` would indicate a stale/different HTML document.

### Testing

- Ran `git diff --check` which succeeded with no whitespace or diff-check errors. 
- Ran `node --check sw.js` which validated the service worker syntax. 
- Executed a Node VM assertion test that confirmed navigation-mode requests are not intercepted while non-navigation GETs are still routed to the fetch/cached-fallback logic. 
- Confirmed via `rg` that `program.html` and `mello.html` contain `knownUnavailableBoards=new Set(["openclaw"])` and do not include `<script src="program.js">`. 
- Created a commit for the change (`Prevent service worker from caching navigations`) and verified the working tree is clean; attempts to run the local `make_pr` helper failed due to environment package/installation issues (`mcp` import/pip resolution) which are external to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78b180872c832d95134d830be0a11e)