### PR TITLE
program.html: matrix views × kanban card detail (expand-in-place, transpose, grouped, GitHub-persisted)

### DIFF
--- a/program.html
+++ b/program.html
@@ -87,6 +87,32 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
 #cardDialog .note-prev:empty{display:none}
 #cardDialog .note-prev p{margin:0 0 5px}
 .note-pop{position:fixed;z-index:130;max-width:340px;max-height:60vh;overflow:auto;padding:12px 14px;border:1px solid var(--line);border-radius:12px;background:#fff;box-shadow:var(--shadow);font-size:13px;line-height:1.5}
+/* attachments (kanban parity) */
+.attachment-list{list-style:none;margin:0 0 6px;padding:0;display:grid;gap:4px}
+.attachment-item{display:flex;align-items:center;gap:8px;padding:5px 8px;border:1px solid var(--line);border-radius:8px;background:var(--surface);font-size:12px}
+.attachment-link,.attachment-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--accent);text-decoration:none}
+.attachment-name{color:var(--ink)}
+.attachment-delete{border:0;background:none;color:#999;font-weight:800;cursor:pointer;padding:0 4px;min-height:0;line-height:1}
+.attachment-delete:hover{color:var(--danger)}
+.att-add{display:inline-flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--accent);border:1px dashed var(--line);border-radius:8px;padding:5px 10px}
+.att-add:hover{border-color:var(--accent)}
+.muted{color:var(--muted);font-size:12px}
+/* single-tap EXPANDED card popover — full kanban card, no scroll needed */
+.card-pop{position:fixed;z-index:140;width:min(440px,calc(100vw - 20px));max-height:calc(100dvh - 24px);overflow:auto;display:flex;flex-direction:column;gap:10px;padding:14px;border:1px solid var(--line);border-left:6px solid var(--ribbon,var(--accent));border-radius:14px;background:var(--surface);box-shadow:var(--shadow)}
+.card-pop .cp-head{display:flex;align-items:center;gap:8px}
+.card-pop .cp-head .kc-status{width:18px;height:18px}
+.card-pop .cp-title{flex:1;min-width:0;font-weight:800;font-size:16px;border:0;background:none;padding:2px 0}
+.card-pop .cp-x{width:28px;height:28px;min-height:0;border:0;background:transparent;color:var(--muted);font-size:20px;border-radius:8px}
+.card-pop .cp-x:hover{background:var(--bg)}
+.card-pop .dialog-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:0}
+.card-pop .span-2{grid-column:1/-1}
+.card-pop label{display:grid;gap:3px;font-size:10px;font-weight:800;text-transform:uppercase;color:var(--muted)}
+.card-pop input,.card-pop select,.card-pop textarea{min-height:34px;padding:6px 8px;border:1px solid var(--line);border-radius:8px;font-size:13px;width:100%}
+.card-pop textarea{min-height:80px;resize:vertical}
+.card-pop .cp-actions{display:flex;align-items:center;gap:8px}
+.card-pop::backdrop{background:transparent}
+.card-scrim{position:fixed;inset:0;z-index:139;background:transparent}
+@media(max-width:520px){.card-pop{left:8px!important;right:8px!important;width:auto}.card-pop .dialog-grid{grid-template-columns:1fr}}
 </style>
 </head>
 <body>
@@ -115,7 +141,7 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
   <script>
 (() => {
   "use strict";
-  const FILES={index:"kanban-boards.json",switch:"kanban-switch.json"};
+  const FILES={index:"kanban-boards.json",switch:"kanban-switch.json",matrices:"program-matrices.json"};
   const KEY="program_configuration_v4", TOKEN_KEY="github_pat";
   const AXES=["title","platform","stage","lineage","statusColor","cardColor","dev","live"];
   const DISPLAY=["title","platform","stage","lineage","statusColor","dev","live","tags","notes"];
@@ -129,7 +155,7 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
   const slug=s=>String(s||"").trim().toLowerCase().replace(/[^a-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"");
   const read=(k,f)=>{try{return JSON.parse(localStorage.getItem(k))??f}catch{return f}};
   const validHex=v=>/^#[0-9a-f]{6}$/i.test(v||"");
-  const defaults=()=>({version:3,portalName:"Program",github:{owner:"acmeproducts",repo:"stuff",branch:"main",pat:localStorage.getItem(TOKEN_KEY)||""},theme:{...THEME},cardColors:PRESETS.map(x=>({...x})),matrices:[],selectedApp:"matrix",selectedMatrix:"",mashupSwap:false,sidebarCollapsed:false});
+  const defaults=()=>({version:3,portalName:"Program",github:{owner:"acmeproducts",repo:"stuff",branch:"main",pat:localStorage.getItem(TOKEN_KEY)||""},theme:{...THEME},cardColors:PRESETS.map(x=>({...x})),matrices:[],matricesUpdatedAt:0,selectedApp:"matrix",selectedMatrix:"",mashupSwap:false,sidebarCollapsed:false});
   let config=defaults(), index={boards:[]}, repoCfg={}, boardData={}, state={}, drag=null, touch=null, saveQueue=Promise.resolve(), toastTimer, pendingImport=null;
 
   function migrate(){
@@ -137,7 +163,15 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
     else {const old=read("program_portal_config_v2",{}),defs=read("program_matrix_definitions_v2",[]);config={...defaults(),portalName:old.portalName||"Mello",github:{...defaults().github,owner:old.owner||"acmeproducts",repo:old.repo||"stuff",branch:old.branch||"main"},cardColors:(old.colors||[]).filter(validHex).map((color,i)=>({name:`Color ${i+1}`,color})),matrices:defs.map(d=>({...d,intersection:d.intersection||"title",fields:d.fields||[],updatedAt:d.updatedAt||d.createdAt||Date.now()}))};}
     if(!config.github.pat)config.github.pat=localStorage.getItem(TOKEN_KEY)||""; persist();
   }
-  function persist(){localStorage.setItem(KEY,JSON.stringify(config));localStorage.setItem(TOKEN_KEY,config.github.pat||"");applyTheme()}
+  /* Matrix definitions are persisted to GitHub (source of truth) AND locally,
+     using the same read(fetch)/write(putJson) method as kanban boards. GitHub
+     wins unless the local copy is newer; we only UPDATE the file, never blindly
+     overwrite it (putJson refuses when the remote copy is newer). */
+  let matricesSnapshot=null, matricesSaveTimer=null;
+  const matricesPath=()=>`${typeof repoCfg.pathPrefix==="string"?repoCfg.pathPrefix:""}${FILES.matrices}`;
+  async function saveMatricesToGithub(){if(!config.github.pat){return;}try{sync("Saving matrices…");await putJson(matricesPath(),{version:1,matrices:config.matrices,lastModified:config.matricesUpdatedAt||Date.now()},"Update matrix definitions");sync("Saved");}catch(e){sync(`Matrix save failed — ${e.message}`,"error");notify(e.message.includes("changed on GitHub")?"Matrices changed on GitHub — reload before editing.":"Matrix save failed.");}}
+  function scheduleMatricesSave(){clearTimeout(matricesSaveTimer);matricesSaveTimer=setTimeout(saveMatricesToGithub,1200);}
+  function persist(){const cur=JSON.stringify(config.matrices||[]);if(matricesSnapshot!==null&&cur!==matricesSnapshot){config.matricesUpdatedAt=Date.now();scheduleMatricesSave();}matricesSnapshot=cur;localStorage.setItem(KEY,JSON.stringify(config));localStorage.setItem(TOKEN_KEY,config.github.pat||"");applyTheme()}
   function applyTheme(){Object.entries(config.theme||{}).forEach(([k,v])=>{const map={sidebar:"sidebar-bg",accentSoft:"accent-soft"};if(validHex(v))document.documentElement.style.setProperty(`--${map[k]||k}`,v)});document.title=`${config.portalName} Portal`}
   function notify(s){const t=$("#toast");t.textContent=s;t.classList.add("show");clearTimeout(toastTimer);toastTimer=setTimeout(()=>t.classList.remove("show"),2600)}
   function sync(s,kind=""){$("#syncState").textContent=s;$("#syncState").className=`sync-state ${kind}`}
@@ -153,7 +187,7 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
   const value=(c,f)=>String(c?.[f]??(f==="stage"?c?.lane:"")).trim()||"Unassigned";
   const activeDefs=()=>config.matrices.filter(d=>!d.deletedAt&&Object.hasOwn(boardData,d.board));
 
-  async function boot(){migrate();repoCfg=await fetchJson(FILES.switch).catch(()=>({}));index=await fetchJson(FILES.index);if(!Array.isArray(index.boards))throw new Error(`${FILES.index} does not contain a boards array.`);const failures=[];await Promise.all(indexedBoards().map(async b=>{const path=boardPath(b.name);try{const data=await fetchJson(path);if(!data||typeof data!=="object"||!Array.isArray(data.cards))throw new Error("invalid board data");boardData[b.name]=data}catch(e){failures.push(`${b.name} (${path}: ${e.message})`)}}));if(!boards().length)throw new Error(`No board data could be loaded.${failures.length?` ${failures.join("; ")}`:""}`);bindShell();setSidebar(!config.sidebarCollapsed);sync(failures.length?`${failures.length} unavailable`:"·",failures.length?"warning":"");$("#syncState").title=failures.join("\n");const query=new URLSearchParams(location.search),app=query.get('app');openApp(APP_NAMES[app]?app:(APP_NAMES[config.selectedApp]?config.selectedApp:"matrix"))}
+  async function boot(){migrate();repoCfg=await fetchJson(FILES.switch).catch(()=>({}));index=await fetchJson(FILES.index);if(!Array.isArray(index.boards))throw new Error(`${FILES.index} does not contain a boards array.`);const failures=[];await Promise.all(indexedBoards().map(async b=>{const path=boardPath(b.name);try{const data=await fetchJson(path);if(!data||typeof data!=="object"||!Array.isArray(data.cards))throw new Error("invalid board data");boardData[b.name]=data}catch(e){failures.push(`${b.name} (${path}: ${e.message})`)}}));if(!boards().length)throw new Error(`No board data could be loaded.${failures.length?` ${failures.join("; ")}`:""}`);const remoteMx=await fetchJson(matricesPath()).catch(()=>null);if(remoteMx&&Array.isArray(remoteMx.matrices)){const rt=Number(remoteMx.lastModified||0),lt=Number(config.matricesUpdatedAt||0);if(rt>lt){config.matrices=remoteMx.matrices;config.matricesUpdatedAt=rt;localStorage.setItem(KEY,JSON.stringify(config));}else if(lt>rt){scheduleMatricesSave();}}else if((config.matrices||[]).length){scheduleMatricesSave();}matricesSnapshot=JSON.stringify(config.matrices||[]);bindShell();setSidebar(!config.sidebarCollapsed);sync(failures.length?`${failures.length} unavailable`:"·",failures.length?"warning":"");$("#syncState").title=failures.join("\n");const query=new URLSearchParams(location.search),app=query.get('app');openApp(APP_NAMES[app]?app:(APP_NAMES[config.selectedApp]?config.selectedApp:"matrix"))}
   function bindShell(){$("#sidebarToggle").onclick=()=>setSidebar(config.sidebarCollapsed);$("#scrim").onclick=()=>setSidebar(false);$$('[data-app]').forEach(b=>b.onclick=()=>openApp(b.dataset.app))}
   function setSidebar(open){config.sidebarCollapsed=!open;persist();$(".portal").classList.toggle("sidebar-collapsed",!open);$("#sidebar").classList.toggle("open",open);$("#scrim").classList.toggle("open",open&&innerWidth<760);const b=$("#sidebarToggle");b.setAttribute("aria-expanded",String(open));b.setAttribute("aria-label",`${open?"Collapse":"Expand"} application sidebar`)}
   function openApp(app){config.selectedApp=app;persist();$("#headerTitle").textContent=APP_NAMES[app];$("#appControls").replaceChildren();$$('[data-app]').forEach(b=>{const on=b.dataset.app===app;b.classList.toggle("active",on);b.setAttribute("aria-current",on?"page":"false")});if(innerWidth<760)setSidebar(false);state={};({builder:renderBuilder,matrix:renderBoardMatrix,mashup:renderMashup,config:renderConfig}[app])()}
@@ -182,7 +216,9 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
 
   function renderCreate(editId=""){const root=$("#view"),editing=config.matrices.find(d=>d.id===editId),s=editing?{...editing,fields:[...editing.fields]}:{board:boards()[0]?.name||"",x:"platform",y:"stage",z:"",intersection:"title",fields:["platform","stage"]};root.innerHTML=head("Create Matrix","Define and manage reusable matrix definitions.")+`<section class="panel"><form id="defForm"><div class="control"><label>Name<input name="name" required value="${esc(s.name||"")}"></label></div>${matrixControls(s,{save:false,z:true})}</form><div data-message></div><div class="definition-list">${config.matrices.map(d=>`<div class="definition"><span><b>${esc(d.name)}</b><br><small>${esc(d.board)} · ${esc(d.x)} × ${esc(d.y)}${d.deletedAt?" · Deleted":""}</small></span>${d.deletedAt?"":`<button class="btn" data-edit="${d.id}">Edit</button><button class="btn danger" data-delete="${d.id}" aria-label="Soft delete ${esc(d.name)}">×</button>`}</div>`).join("")||'<div class="empty">No saved definitions.</div>'}</div></section>`;$("[data-go]",root).textContent=editing?"Update definition":"Create definition";$("[data-go]",root).onclick=()=>{const e=readMatrixControls(root,s),name=$("[name=name]",root).value.trim();if(e||!name)return showMessage(root,e||"Name is required.");const now=new Date().toISOString();if(editing)Object.assign(editing,s,{name,updatedAt:now});else config.matrices.push({...s,id:uid(),name,createdAt:now,updatedAt:now,deletedAt:null});persist();renderCreate()};$$('[data-edit]',root).forEach(b=>b.onclick=()=>renderCreate(b.dataset.edit));$$('[data-delete]',root).forEach(b=>b.onclick=()=>{const d=config.matrices.find(x=>x.id===b.dataset.delete);d.deletedAt=new Date().toISOString();d.updatedAt=d.deletedAt;persist();renderCreate()})}
   function renderUse(){const root=$("#view"),defs=activeDefs(),id=state.definitionId&&defs.some(d=>d.id===state.definitionId)?state.definitionId:defs[0]?.id,def=defs.find(d=>d.id===id);state.definitionId=id;root.innerHTML=head("Use Matrix","Open a saved definition and move cards.")+`<section class="panel"><div class="toolbar"><div class="control"><label>Saved matrix<select data-def>${options(defs.map(d=>d.id),id).replaceAll(/>([^<]+)</g,(m,v)=>`>${esc(defs.find(d=>d.id===v)?.name||v)}<`)}</select></label></div>${def?.z?`<div class="control"><label>${esc(def.z)} filter<select data-zvalue>${options(matrixValues(cards(def.board),def.z),"")}</select></label></div>`:""}</div><div class="matrix-scroll"><div class="matrix-grid"></div></div></section>`;$("[data-def]",root)?.addEventListener("change",e=>{state.definitionId=e.target.value;renderUse()});const draw=()=>def&&drawMatrix($(".matrix-grid",root),def,$("[data-zvalue]",root)?.value||"");$("[data-zvalue]",root)?.addEventListener("change",draw);draw()}
-  function defSelect(side,defs,id){return `<div class="control"><label>Matrix ${side}<select data-matrix="${side}">${defs.map(d=>`<option value="${d.id}" ${d.id===id?"selected":""}>${esc(d.name)}</option>`).join("")}</select></label></div>`}
+  /* A matrix is a VIEW; group views of the same board together. */
+  function groupedMatrixOptions(defs,selectedId){const byBoard={};defs.forEach(d=>{(byBoard[d.board]??=[]).push(d)});return Object.keys(byBoard).sort((a,b)=>a.localeCompare(b)).map(board=>`<optgroup label="${esc(board)}">`+byBoard[board].map(d=>`<option value="${esc(d.id)}" ${d.id===selectedId?"selected":""}>${esc(d.name)}</option>`).join("")+`</optgroup>`).join("")}
+  function defSelect(side,defs,id){return `<div class="control"><label>Matrix ${side}<select data-matrix="${side}">${groupedMatrixOptions(defs,id)}</select></label></div>`}
   function renderMashup(){const root=$("#view"),defs=activeDefs();state.one=state.one||defs[0]?.id;state.two=state.two||defs[1]?.id||defs[0]?.id;const one=defs.find(d=>d.id===state.one),two=defs.find(d=>d.id===state.two);root.innerHTML=head("Create Matrix Mashup","Move cards—not copies—between independently scrolling matrices.")+`<div class="mashup"><section class="panel">${defSelect("one",defs,state.one)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="one"></div></div></section><section class="panel">${defSelect("two",defs,state.two)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="two"></div></div></section></div>`;$$('[data-matrix]',root).forEach(s=>s.onchange=()=>{state[s.dataset.matrix]=s.value;renderMashup()});if(one)drawMatrix($('[data-grid=one]',root),one,"","mashup");if(two)drawMatrix($('[data-grid=two]',root),two,"","mashup")}
 
   function renderTransfer(){const root=$("#view");state.left=state.left||boards()[0]?.name||"";state.right=state.right||boards().find(b=>b.name!==state.left)?.name||"";root.innerHTML=head("Card Transfer","Tap a card then a destination lane, or drag it.")+`<div class="split"><section class="panel" data-side="left"></section><section class="panel" data-side="right"></section></div>`;["left","right"].forEach(side=>drawPane(root,side));wireCards(root);wireDrops(root,".lane",(el,d)=>transferCard(d.board,el.dataset.board,d.id,el.dataset.stage))}
@@ -233,14 +269,14 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
   /* Program integration: matrix definitions own the ribbon and board management
      is a self-contained page.  The standalone kanban surface can therefore be
      retired without losing board/card workflows. */
-  function matrixRibbon(defs,s){return `<div class="command"><div class="control"><label data-label="Matrix">Matrix<select data-def>${defs.map(d=>`<option value="${d.id}" ${d.id===s.id?'selected':''}>${esc(d.name)}</option>`).join('')}<option value="">＋ New matrix</option></select></label></div><div class="control"><label data-label="Board">Board<select data-board>${boardOptions(s.board)}</select></label></div><div class="control"><label data-label="Columns">Columns<select data-x>${axisOptions(s.x)}</select></label></div><div class="control"><label data-label="Rows">Rows<select data-y>${axisOptions(s.y)}</select></label></div><div class="control"><label data-label="Center">Center<select data-intersection>${options(DISPLAY,s.intersection||'title')}</select></label></div>${fieldsPopover(s.fields)}${s.id?'<button class="btn danger" data-delete-matrix aria-label="Delete matrix">×</button>':''}</div>`}
+  function matrixRibbon(defs,s){return `<div class="command"><div class="control"><label data-label="Matrix">Matrix<select data-def>${groupedMatrixOptions(defs,s.id)}<option value="">＋ New matrix</option></select></label></div><div class="control"><label data-label="Board">Board<select data-board>${boardOptions(s.board)}</select></label></div><div class="control"><label data-label="Columns">Columns<select data-x>${axisOptions(s.x)}</select></label></div><div class="control"><label data-label="Rows">Rows<select data-y>${axisOptions(s.y)}</select></label></div><div class="control"><label data-label="Center">Center<select data-intersection>${options(DISPLAY,s.intersection||'title')}</select></label></div>${fieldsPopover(s.fields)}<button class="btn" data-transpose title="Swap X and Y axes" aria-label="Transpose matrix">⇄ Transpose</button>${s.id?'<button class="btn danger" data-delete-matrix aria-label="Delete matrix">×</button>':''}</div>`}
   function deletedMatrices(){return config.matrices.filter(d=>d.deletedAt)}
   function matrixTrash(){const gone=deletedMatrices();return `<details class="trash-panel panel"><summary>▾ Deleted matrices (${gone.length})</summary>${gone.map(d=>`<div class="trash-item"><span>${esc(d.name)}</span><button class="btn" data-restore-matrix="${d.id}">Restore</button><button class="btn danger" data-purge-matrix="${d.id}">Delete forever</button></div>`).join('')||'<p class="empty">Recycle bin is empty.</p>'}</details>`}
   function renderBoardMatrix(){const root=$("#view"),bar=$("#appControls"),defs=activeDefs();let saved=defs.find(d=>d.id===config.selectedMatrix);if(!saved){saved=defs[0]||{id:'',name:'New matrix',board:defaultBoard(),x:'platform',y:'stage',z:'',intersection:'title',fields:['platform','stage']};config.selectedMatrix=saved.id||''}state.def={...saved,fields:[...(saved.fields||[])]};const s=state.def;bar.innerHTML=matrixRibbon(defs,s);root.innerHTML=matrixTrash()+`<section class="panel matrix-panel"><h1 class="matrix-title"><input data-matrix-name aria-label="Matrix name" value="${esc(s.name)}"></h1><div data-message></div><div class="matrix-scroll"><div class="matrix-grid"></div></div></section>`;
     const commit=()=>{readMatrixControls(bar,s);s.name=$('[data-matrix-name]',root).value.trim()||'Untitled matrix';const error=validateDefinition(s);if(error)return showMessage(root,error);const now=new Date().toISOString();if(!s.id){s.id=uid();s.createdAt=now;s.deletedAt=null;config.matrices.push({...s,fields:[...s.fields]});config.selectedMatrix=s.id}else Object.assign(config.matrices.find(d=>d.id===s.id),s,{updatedAt:now});persist();showMessage(root,'');drawMatrix($('.matrix-grid',root),s)};
-    $$('select,input[type=checkbox]',bar).forEach(el=>el.onchange=commit);$('[data-matrix-name]',root).onchange=commit;$('[data-matrix-name]',root).onblur=commit;$('[data-def]',bar).onchange=e=>{config.selectedMatrix=e.target.value;persist();renderBoardMatrix()};$('[data-delete-matrix]',bar)?.addEventListener('click',()=>confirmAction(`Move ${s.name} to the matrix recycle bin?`,()=>{const d=config.matrices.find(x=>x.id===s.id);d.deletedAt=new Date().toISOString();config.selectedMatrix='';persist();renderBoardMatrix()}));$$('[data-restore-matrix]',root).forEach(b=>b.onclick=()=>{const d=config.matrices.find(x=>x.id===b.dataset.restoreMatrix);d.deletedAt=null;persist();renderBoardMatrix()});$$('[data-purge-matrix]',root).forEach(b=>b.onclick=()=>confirmAction('Permanently delete this matrix? This cannot be undone.',()=>{config.matrices=config.matrices.filter(x=>x.id!==b.dataset.purgeMatrix);persist();renderBoardMatrix()}));if(s.board&&s.x&&s.y)drawMatrix($('.matrix-grid',root),s)}
+    $$('select,input[type=checkbox]',bar).forEach(el=>el.onchange=commit);$('[data-matrix-name]',root).onchange=commit;$('[data-matrix-name]',root).onblur=commit;$('[data-def]',bar).onchange=e=>{config.selectedMatrix=e.target.value;persist();renderBoardMatrix()};$('[data-transpose]',bar)?.addEventListener('click',()=>{const xs=$('[data-x]',bar),ys=$('[data-y]',bar);[xs.value,ys.value]=[ys.value,xs.value];commit()});$('[data-delete-matrix]',bar)?.addEventListener('click',()=>confirmAction(`Move ${s.name} to the matrix recycle bin?`,()=>{const d=config.matrices.find(x=>x.id===s.id);d.deletedAt=new Date().toISOString();config.selectedMatrix='';persist();renderBoardMatrix()}));$$('[data-restore-matrix]',root).forEach(b=>b.onclick=()=>{const d=config.matrices.find(x=>x.id===b.dataset.restoreMatrix);d.deletedAt=null;persist();renderBoardMatrix()});$$('[data-purge-matrix]',root).forEach(b=>b.onclick=()=>confirmAction('Permanently delete this matrix? This cannot be undone.',()=>{config.matrices=config.matrices.filter(x=>x.id!==b.dataset.purgeMatrix);persist();renderBoardMatrix()}));if(s.board&&s.x&&s.y)drawMatrix($('.matrix-grid',root),s)}
   function openBoardSurface(board,newTab=false){const url=`program.html?app=builder&board=${encodeURIComponent(board)}`;if(newTab)return window.open(url,'_blank','noopener');state.manageBoard=board;openApp('builder')}
-  function drawMatrix(root,def,zValue='',context='matrix'){let list=cards(def.board);if(def.z&&zValue)list=list.filter(c=>value(c,def.z)===zValue);const xs=orderedValues(list,def.x,def,'x'),ys=orderedValues(list,def.y,def,'y');if(!xs.length||!ys.length){root.innerHTML='<div class="empty">No cards match this matrix.</div>';return}root.dataset.context=context;root.style.setProperty('--matrix-columns',xs.length);root.style.setProperty('--matrix-rows',ys.length);root.innerHTML=`<div class="matrix-corner"><button class="board-chip" type="button" data-board-axis>${esc(def.board)}</button></div>${xs.map(x=>`<div class="matrix-header" draggable="true" data-axis="x" data-value="${esc(x)}">${esc(x)}</div>`).join('')}`;ys.forEach(y=>{root.insertAdjacentHTML('beforeend',`<div class="matrix-rowhead" draggable="true" data-axis="y" data-value="${esc(y)}">${esc(y)}</div>`);xs.forEach(x=>{const cs=list.filter(c=>value(c,def.x)===x&&value(c,def.y)===y).sort((a,b)=>(a.matrixPosition??a.position??0)-(b.matrixPosition??b.position??0));root.insertAdjacentHTML('beforeend',`<div class="matrix-cell" data-board="${esc(def.board)}" data-x="${esc(x)}" data-y="${esc(y)}">${cs.map(c=>cardMarkup(c,def.board,def)).join('')}</div>`)})});wireCards(root);wireDrops(root,'.matrix-cell',(el,d)=>moveMatrixCard(d,def,el.dataset.x,el.dataset.y));wireAxisOrder(root,def,xs,ys,zValue);let tap;const chip=$('[data-board-axis]',root);chip.onclick=()=>{clearTimeout(tap);tap=setTimeout(()=>{[def.x,def.y]=[def.y,def.x];const saved=config.matrices.find(d=>d.id===def.id);if(saved)Object.assign(saved,{x:def.x,y:def.y,updatedAt:new Date().toISOString()});persist();config.selectedApp==='mashup'?renderMashup():renderBoardMatrix()},240)};chip.ondblclick=e=>{e.preventDefault();clearTimeout(tap);openBoardSurface(def.board,true)}}
+  function drawMatrix(root,def,zValue='',context='matrix'){let list=cards(def.board);if(def.z&&zValue)list=list.filter(c=>value(c,def.z)===zValue);const xs=orderedValues(list,def.x,def,'x'),ys=orderedValues(list,def.y,def,'y');if(!xs.length||!ys.length){root.innerHTML='<div class="empty">No cards match this matrix.</div>';return}root.dataset.context=context;root.style.setProperty('--matrix-columns',xs.length);root.style.setProperty('--matrix-rows',ys.length);root.innerHTML=`<div class="matrix-corner"><button class="board-chip" type="button" data-board-axis>${esc(def.board)}</button></div>${xs.map(x=>`<div class="matrix-header" draggable="true" data-axis="x" data-value="${esc(x)}">${esc(x)}</div>`).join('')}`;ys.forEach(y=>{root.insertAdjacentHTML('beforeend',`<div class="matrix-rowhead" draggable="true" data-axis="y" data-value="${esc(y)}">${esc(y)}</div>`);xs.forEach(x=>{const cs=list.filter(c=>value(c,def.x)===x&&value(c,def.y)===y).sort((a,b)=>(a.matrixPosition??a.position??0)-(b.matrixPosition??b.position??0));root.insertAdjacentHTML('beforeend',`<div class="matrix-cell" data-board="${esc(def.board)}" data-x="${esc(x)}" data-y="${esc(y)}">${cs.map(c=>cardMarkup(c,def.board,def)).join('')}</div>`)})});wireCards(root);wireDrops(root,'.matrix-cell',(el,d)=>moveMatrixCard(d,def,el.dataset.x,el.dataset.y));wireAxisOrder(root,def,xs,ys,zValue);const chip=$('[data-board-axis]',root);chip.title='Open this board (drill down)';chip.onclick=()=>openBoardSurface(def.board);chip.ondblclick=e=>{e.preventDefault();openBoardSurface(def.board,true)}}
   function wireAxisOrder(root,def,xs,ys,zValue){$$('[data-axis]',root).forEach(el=>{el.ondragstart=e=>{state.axisDrag={def,axis:el.dataset.axis,value:el.dataset.value};e.stopPropagation();el.classList.add('axis-dragging')};el.ondragover=e=>{if(state.axisDrag?.axis===el.dataset.axis){e.preventDefault();e.stopPropagation();el.classList.add('axis-drop')}};el.ondragleave=()=>el.classList.remove('axis-drop');el.ondrop=e=>{const moving=state.axisDrag;if(!moving||moving.axis!==el.dataset.axis)return;e.preventDefault();e.stopPropagation();el.classList.remove('axis-drop');if(moving.def.id===def.id){const vals=[...(moving.axis==='x'?xs:ys)],from=vals.indexOf(moving.value),to=vals.indexOf(el.dataset.value);vals.splice(to,0,vals.splice(from,1)[0]);matrixPrefs().matrixOrder[orderKey(def,moving.axis)]=vals;persist();drawMatrix(root,def,zValue,root.dataset.context);return}askAxisTransfer(moving,def,el.dataset.axis)};el.ondragend=()=>{el.classList.remove('axis-dragging');setTimeout(()=>state.axisDrag=null,0)}})}
   function askAxisTransfer(source,target,targetAxis){const d=$("#confirmDialog");d.innerHTML=`<form method="dialog" class="dialog-body"><h2>Transfer ${esc(source.value)}</h2><p>Copy or move this entire ${source.axis==='x'?'column':'row'} into ${esc(target.name)}?</p><div class="dialog-actions"><button class="btn" value="cancel" autofocus>Cancel</button><button class="btn" value="copy">Copy</button><button class="btn primary" value="move">Move</button></div></form>`;d.onclose=()=>{if(d.returnValue==='copy'||d.returnValue==='move')transferAxis(source,target,targetAxis,d.returnValue)};d.showModal()}
   function transferAxis(source,target,targetAxis,mode){const sourceField=source.def[source.axis],targetField=target[targetAxis],matches=cards(source.def.board).filter(c=>value(c,sourceField)===source.value),existing=new Set(cards(target.board).map(c=>value(c,targetField))),qualified=existing.has(source.value)?`${source.value} (${source.def.board})`:source.value,added=[];matches.forEach(c=>{const clone=mode==='copy'?structuredClone(c):c;if(mode==='copy'&&cards(target.board).some(x=>String(x.id)===String(clone.id)))clone.id=`${clone.id}-${slug(source.def.board)}`;setAxis(clone,targetField,qualified);clone.sourceBoard=clone.sourceBoard||source.def.board;clone.position=1;added.push(clone)});if(mode==='move')boardData[source.def.board].cards=cards(source.def.board).filter(c=>!matches.includes(c));cards(target.board).unshift(...added);normalize(source.def.board);normalize(target.board);updateIndex([source.def.board,target.board]);saveBoards(mode==='move'?[source.def.board,target.board]:[target.board],`${mode} ${source.value} from ${source.def.board} to ${target.board}`,true);renderMashup()}
@@ -303,7 +339,12 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
 
   function wireCards(root){$$(".card",root).forEach(el=>{
     const board=el.dataset.board,id=el.dataset.card;
-    const title=$(".card-title",el); if(title)title.onclick=e=>{e.stopPropagation();openCardEditor(board,id);};
+    /* single tap anywhere on the card (except its inline controls/links) → expand */
+    const expand=e=>{if(e.target.closest("[data-kstatus],[data-kcopy],[data-karch],a,.kc-tag,[data-stop],input,select,textarea,button"))return;e.stopPropagation();openCardExpand(board,id,el);};
+    el.addEventListener("click",expand);
+    const title=$(".card-title",el); if(title)title.onclick=e=>{e.stopPropagation();openCardExpand(board,id,el);};
+    /* right-click / long-press context menu → change card color */
+    el.oncontextmenu=e=>{e.preventDefault();e.stopPropagation();showColorMenu(e.clientX,e.clientY,board,id);};
     const st=$("[data-kstatus]",el); if(st)st.onclick=e=>{e.stopPropagation();showStatusMenu(st,board,id);};
     const cp=$("[data-kcopy]",el); if(cp)cp.onclick=e=>{e.stopPropagation();duplicateCard(board,id);};
     const ar=$("[data-karch]",el); if(ar)ar.onclick=e=>{e.stopPropagation();archiveCard(board,id);};
@@ -340,42 +381,93 @@ html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(-
     setTimeout(()=>document.addEventListener("pointerdown",function h(e){if(!m.contains(e.target)){m.remove();document.removeEventListener("pointerdown",h);}}),0);
   }
 
+  /* ---- attachments + popover helpers (kanban parity) ---- */
+  function fmtBytes(n){if(typeof n!=="number"||n<0)return"";if(n<1024)return n+" B";if(n<1048576)return (n/1024).toFixed(1)+" KB";return (n/1048576).toFixed(1)+" MB";}
+  function readFileData(file){return new Promise((res,rej)=>{const r=new FileReader();r.onload=()=>res(r.result);r.onerror=rej;r.readAsDataURL(file);});}
+  function closeCardPop(){document.querySelector(".card-pop")?.remove();document.querySelector(".card-scrim")?.remove();}
+  function positionPop(pop,anchor){const w=pop.offsetWidth,h=pop.offsetHeight;let left=(innerWidth-w)/2,top=(innerHeight-h)/2;if(anchor&&anchor.getBoundingClientRect){const r=anchor.getBoundingClientRect();left=Math.min(Math.max(8,r.left),innerWidth-w-8);top=Math.min(Math.max(8,r.bottom+6),innerHeight-h-8);if(top+h>innerHeight-8)top=Math.max(8,r.top-h-6);}pop.style.left=Math.round(left)+"px";pop.style.top=Math.round(top)+"px";}
+
+  /* Shared rich card fields (kanban "rich texture" = the standard for card detail).
+     Used by BOTH the modal editor and the single-tap expand popover so they stay
+     identical and carry every feature: status, platform, stage, lineage, tags with
+     history/suggestions, dev/live, attachments, and markdown notes. */
+  function buildCardFields(c,board){
+    const plats=[...new Set([...(boardData[board]?.platforms||[]),c.platform].filter(Boolean))];
+    let activeTags=(c.tags||[]).map(String);
+    let files=Array.isArray(c.files)?c.files.map(f=>({...f})):[];
+    let dirty=false;
+    const grid=
+      `<div class="control span-2"><label>Title<input name="title" required value="${esc(c.title||"")}"></label></div>`+
+      `<div class="control"><label>Platform<select name="platform">${options(plats,c.platform)}</select></label></div>`+
+      `<div class="control"><label>Stage<select name="stage">${options(stages(board),c.stage||c.lane)}</select></label></div>`+
+      `<div class="control"><label>Lineage<select name="lineage">${options(CARD_LINEAGES,normLineage(c.lineage))}</select></label></div>`+
+      `<div class="control"><label>Status<select name="statusColor">${options(STATUS_COLORS,normStatus(c.statusColor))}</select></label></div>`+
+      `<div class="control span-2"><label>Tags</label><div class="tag-chips" data-chips></div><input data-taginput placeholder="type a tag, press Enter"><div class="tag-suggestions" data-sug aria-label="Previously used tags"></div></div>`+
+      `<div class="control span-2"><label>Development link<input name="dev" type="url" value="${esc(c.dev||"")}"></label></div>`+
+      `<div class="control span-2"><label>Live link<input name="live" type="url" value="${esc(c.live||"")}"></label></div>`+
+      `<div class="control span-2"><label>Attachments</label><ul class="attachment-list" data-attlist></ul><label class="att-add">＋ Add files<input type="file" multiple hidden data-attinput></label></div>`+
+      `<div class="control span-2"><label>Notes (Markdown · text--url shorthand)<textarea name="notes">${esc(c.notes||"")}</textarea></label><div class="note-prev" data-noteprev></div></div>`;
+    function wire(scope){
+      const chipsEl=$("[data-chips]",scope), inputEl=$("[data-taginput]",scope), sugEl=$("[data-sug]",scope), prev=$("[data-noteprev]",scope), attList=$("[data-attlist]",scope), attInput=$("[data-attinput]",scope);
+      const get=n=>$(`[name=${n}]`,scope);
+      const mark=()=>dirty=true;
+      const drawChips=()=>{chipsEl.innerHTML=activeTags.map(t=>`<span class="chip">${esc(t)}<button type="button" data-x="${esc(t)}" aria-label="Remove ${esc(t)}">×</button></span>`).join("");chipsEl.querySelectorAll("[data-x]").forEach(b=>b.onclick=()=>{activeTags=activeTags.filter(x=>x!==b.dataset.x);drawChips();drawSug();mark();});};
+      const drawSug=()=>{const q=inputEl.value.trim().toLowerCase(),seen=new Set();sugEl.innerHTML=allKnownTags().filter(t=>{const k=t.toLowerCase();if(activeTags.includes(t)||seen.has(k))return false;if(q&&!k.includes(q))return false;seen.add(k);return true;}).slice(0,14).map(t=>`<span class="chip" data-add="${esc(t)}">${esc(t)}<span class="sx" data-del="${esc(t)}" title="Remove from history">×</span></span>`).join("");sugEl.querySelectorAll("[data-add]").forEach(el=>el.onclick=e=>{if(e.target.dataset.del!==undefined){tagHistDel(el.dataset.add);drawSug();return;}if(!activeTags.includes(el.dataset.add)){activeTags.push(el.dataset.add);drawChips();drawSug();mark();}});};
+      const commitInput=()=>{const raw=inputEl.value.trim();if(!raw){drawSug();return;}raw.split(/[,\n]+/).forEach(p=>{const t=p.trim();if(t&&!activeTags.includes(t))activeTags.push(t);});inputEl.value="";drawChips();drawSug();mark();};
+      const drawAtt=()=>{if(!attList)return;attList.innerHTML="";if(!files.length){const li=document.createElement("li");li.className="muted";li.textContent="No attachments";attList.append(li);return;}files.forEach((f,idx)=>{const li=document.createElement("li");li.className="attachment-item";const meta=[f?.type,typeof f?.size==="number"&&f.size>=0?fmtBytes(f.size):""].filter(Boolean).join(" • ");const name=f?.name||"attachment";if(typeof f?.data==="string"&&f.data){const a=document.createElement("a");a.className="attachment-link";a.href=f.data;a.download=name;a.target="_blank";a.rel="noopener";a.textContent=meta?`${name} (${meta})`:name;a.draggable=false;a.addEventListener("click",e=>e.stopPropagation());li.append(a);}else{const s=document.createElement("span");s.className="attachment-name";s.textContent=meta?`${name} (${meta})`:name;li.append(s);}const rm=document.createElement("button");rm.type="button";rm.className="attachment-delete";rm.textContent="×";rm.title="Remove attachment";rm.setAttribute("aria-label",`Remove ${name}`);rm.addEventListener("click",e=>{e.stopPropagation();files.splice(idx,1);drawAtt();mark();});li.append(rm);attList.append(li);});};
+      if(attInput)attInput.onchange=async e=>{const fl=[...e.target.files];for(const f of fl){try{const data=await readFileData(f);files.push({name:f.name,type:f.type,size:f.size,data});}catch{}}e.target.value="";drawAtt();mark();};
+      inputEl.onkeydown=e=>{if(e.key==="Enter"||e.key===","){e.preventDefault();commitInput();}else if(e.key==="Backspace"&&!inputEl.value&&activeTags.length){activeTags.pop();drawChips();drawSug();mark();}};
+      inputEl.oninput=drawSug; inputEl.onblur=commitInput;
+      scope.addEventListener("input",()=>{mark();if(prev)prev.innerHTML=renderMd(get("notes").value);});
+      drawChips(); drawSug(); drawAtt(); if(prev)prev.innerHTML=renderMd(c.notes||"");
+      const save=()=>{const t=get("title");if(t&&t.reportValidity&&!t.reportValidity())return false;Object.assign(c,{title:(get("title").value||"").trim()||"(untitled)",platform:(get("platform").value||"").trim(),stage:get("stage").value,lineage:get("lineage").value,statusColor:get("statusColor").value,dev:(get("dev").value||"").trim(),live:(get("live").value||"").trim(),notes:get("notes").value||"",tags:activeTags.slice(),files:files.slice(),updatedAt:new Date().toISOString()});if("lane" in c)c.lane=c.stage;tagHistAdd(activeTags);dirty=false;saveBoards([board],`Update ${c.title||c.id}`);return true;};
+      return {save,isDirty:()=>dirty};
+    }
+    return {grid,wire};
+  }
+
   function openCardEditor(board,id){
     const c=cards(board).find(x=>String(x.id)===String(id)); if(!c)return;
-    const d=$("#cardDialog");
-    const plats=[...new Set([...(boardData[board]?.platforms||[]),c.platform].filter(Boolean))];
-    let activeTags=(c.tags||[]).map(String), dirty=false;
-    d.innerHTML=`<form method="dialog" class="dialog-body" novalidate><div class="dialog-head"><h2>Edit card</h2><button class="icon-btn" value="close" aria-label="Save and close">×</button></div>`+
-      `<div class="dialog-grid">`+
-        `<div class="control span-2"><label>Title<input name="title" required value="${esc(c.title)}"></label></div>`+
-        `<div class="control"><label>Platform<select name="platform">${options(plats,c.platform)}</select></label></div>`+
-        `<div class="control"><label>Stage<select name="stage">${options(stages(board),c.stage||c.lane)}</select></label></div>`+
-        `<div class="control"><label>Lineage<select name="lineage">${options(CARD_LINEAGES,normLineage(c.lineage))}</select></label></div>`+
-        `<div class="control"><label>Status<select name="statusColor">${options(STATUS_COLORS,normStatus(c.statusColor))}</select></label></div>`+
-        `<div class="control span-2"><label>Tags</label><div class="tag-chips" data-chips></div><input data-taginput placeholder="type a tag, press Enter"><div class="tag-suggestions" data-sug aria-label="Previously used tags"></div></div>`+
-        `<div class="control span-2"><label>Development link<input name="dev" type="url" value="${esc(c.dev)}"></label></div>`+
-        `<div class="control span-2"><label>Live link<input name="live" type="url" value="${esc(c.live)}"></label></div>`+
-        `<div class="control span-2"><label>Notes (Markdown · text--url shorthand)<textarea name="notes">${esc(c.notes)}</textarea></label><div class="note-prev" data-noteprev></div></div>`+
-      `</div>`+
-      `<div class="dialog-actions"><button class="btn primary" value="close">Save &amp; close</button><button type="button" class="btn" data-dup>Duplicate</button><span style="flex:1"></span><button type="button" class="btn danger" data-archive>Archive</button></div>`+
-    `</form>`;
-    const form=$("form",d), chipsEl=$("[data-chips]",d), inputEl=$("[data-taginput]",d), sugEl=$("[data-sug]",d), prev=$("[data-noteprev]",d);
-    const mark=()=>dirty=true;
-    const drawChips=()=>{chipsEl.innerHTML=activeTags.map(t=>`<span class="chip">${esc(t)}<button type="button" data-x="${esc(t)}" aria-label="Remove ${esc(t)}">×</button></span>`).join("");chipsEl.querySelectorAll("[data-x]").forEach(b=>b.onclick=()=>{activeTags=activeTags.filter(x=>x!==b.dataset.x);drawChips();drawSug();mark();});};
-    const drawSug=()=>{const q=inputEl.value.trim().toLowerCase(),seen=new Set();sugEl.innerHTML=allKnownTags().filter(t=>{const k=t.toLowerCase();if(activeTags.includes(t)||seen.has(k))return false;if(q&&!k.includes(q))return false;seen.add(k);return true;}).slice(0,14).map(t=>`<span class="chip" data-add="${esc(t)}">${esc(t)}<span class="sx" data-del="${esc(t)}" title="Remove from history">×</span></span>`).join("");sugEl.querySelectorAll("[data-add]").forEach(el=>el.onclick=e=>{if(e.target.dataset.del!==undefined){tagHistDel(el.dataset.add);drawSug();return;}if(!activeTags.includes(el.dataset.add)){activeTags.push(el.dataset.add);drawChips();drawSug();mark();}});};
-    const commitInput=()=>{const raw=inputEl.value.trim();if(!raw){drawSug();return;}raw.split(/[,\n]+/).forEach(p=>{const t=p.trim();if(t&&!activeTags.includes(t))activeTags.push(t);});inputEl.value="";drawChips();drawSug();mark();};
-    inputEl.onkeydown=e=>{if(e.key==="Enter"||e.key===","){e.preventDefault();commitInput();}else if(e.key==="Backspace"&&!inputEl.value&&activeTags.length){activeTags.pop();drawChips();drawSug();mark();}};
-    inputEl.oninput=drawSug; inputEl.onblur=commitInput;
-    const save=()=>{if(!form.reportValidity())return false;const f=new FormData(form);Object.assign(c,{title:(f.get("title")||"").trim()||"(untitled)",platform:(f.get("platform")||"").trim(),stage:f.get("stage"),lineage:f.get("lineage"),statusColor:f.get("statusColor"),dev:(f.get("dev")||"").trim(),live:(f.get("live")||"").trim(),notes:f.get("notes")||"",tags:activeTags.slice(),updatedAt:new Date().toISOString()});if("lane" in c)c.lane=c.stage;tagHistAdd(activeTags);dirty=false;saveBoards([board],`Update ${c.title||c.id}`);return true;};
-    form.addEventListener("input",()=>{mark();if(prev)prev.innerHTML=renderMd($("[name=notes]",form).value);});
-    form.addEventListener("focusout",e=>{if(!form.contains(e.relatedTarget)&&dirty)save();});
-    $("[data-dup]",d).onclick=()=>{if(dirty)save();d.close();duplicateCard(board,id);};
+    const d=$("#cardDialog"); const {grid,wire}=buildCardFields(c,board);
+    d.innerHTML=`<form method="dialog" class="dialog-body" novalidate><div class="dialog-head"><h2>Edit card</h2><button class="icon-btn" value="close" aria-label="Save and close">×</button></div><div class="dialog-grid">${grid}</div><div class="dialog-actions"><button class="btn primary" value="close">Save &amp; close</button><button type="button" class="btn" data-dup>Duplicate</button><span style="flex:1"></span><button type="button" class="btn danger" data-archive>Archive</button></div></form>`;
+    const form=$("form",d), ctl=wire(form);
+    form.addEventListener("focusout",e=>{if(!form.contains(e.relatedTarget)&&ctl.isDirty())ctl.save();});
+    $("[data-dup]",d).onclick=()=>{if(ctl.isDirty())ctl.save();d.close();duplicateCard(board,id);};
     $("[data-archive]",d).onclick=()=>{d.close("archive");};
-    d.onclose=()=>{if(d.returnValue==="archive"){archiveCard(board,id);return;}if(dirty)save();rerender();};
-    d.showModal(); drawChips(); drawSug(); if(prev)prev.innerHTML=renderMd(c.notes||"");
+    d.onclose=()=>{if(d.returnValue==="archive"){archiveCard(board,id);return;}if(ctl.isDirty())ctl.save();rerender();};
+    d.showModal();
+  }
+
+  /* Single tap on a matrix (or lane) card → expand to the full kanban card in a
+     floating popover anchored to the card: no page scroll, every feature intact. */
+  function openCardExpand(board,id,anchor){
+    closeCardPop();
+    const c=cards(board).find(x=>String(x.id)===String(id)); if(!c)return;
+    const {grid,wire}=buildCardFields(c,board);
+    const scrim=document.createElement("div"); scrim.className="card-scrim";
+    const pop=document.createElement("div"); pop.className="card-pop";
+    pop.style.setProperty("--ribbon",c.cardColor||STATUS_MAP[normStatus(c.statusColor)]);
+    pop.innerHTML=`<div class="cp-head"><span class="kc-status" title="Status: ${esc(normStatus(c.statusColor))}"><span class="kc-dot" data-cpdot style="background:${esc(STATUS_MAP[normStatus(c.statusColor)])}"></span></span><span class="cp-title">${esc(c.title||"(untitled)")}</span><button class="cp-x" type="button" data-x aria-label="Close">×</button></div><div class="dialog-grid">${grid}</div><div class="cp-actions"><button class="btn" type="button" data-dup>Duplicate</button><button class="btn" type="button" data-color>Color</button><span style="flex:1"></span><button class="btn danger" type="button" data-archive>Archive</button></div>`;
+    document.body.append(scrim,pop);
+    positionPop(pop,anchor);
+    const ctl=wire(pop);
+    const titleInput=$("[name=title]",pop), cpTitle=$(".cp-title",pop);
+    if(titleInput&&cpTitle)titleInput.addEventListener("input",()=>cpTitle.textContent=titleInput.value||"(untitled)");
+    const statusSel=$("[name=statusColor]",pop), dot=$("[data-cpdot]",pop);
+    if(statusSel&&dot)statusSel.addEventListener("change",()=>{dot.style.background=STATUS_MAP[normStatus(statusSel.value)];pop.style.setProperty("--ribbon",c.cardColor||STATUS_MAP[normStatus(statusSel.value)]);});
+    const onKey=e=>{if(e.key==="Escape"){e.preventDefault();close();}};
+    function close(after){if(ctl.isDirty())ctl.save();document.removeEventListener("keydown",onKey);scrim.remove();pop.remove();if(after)after();else rerender();}
+    document.addEventListener("keydown",onKey);
+    scrim.onclick=()=>close();
+    $("[data-x]",pop).onclick=()=>close();
+    $("[data-dup]",pop).onclick=()=>close(()=>duplicateCard(board,id));
+    $("[data-archive]",pop).onclick=()=>close(()=>archiveCard(board,id));
+    $("[data-color]",pop).onclick=()=>{const r=(anchor&&anchor.getBoundingClientRect?anchor:pop).getBoundingClientRect();close(()=>showColorMenu(r.left,r.bottom,board,id));};
+    (titleInput||pop).focus?.();
   }
 
   window.addEventListener("keydown",e=>{if(e.key==="Escape"){$(".color-menu")?.remove();document.querySelector(".status-menu")?.remove();document.querySelector(".note-pop")?.remove();}});
+  window.addEventListener("resize",()=>{const pop=document.querySelector(".card-pop");if(pop)positionPop(pop,null);});
   boot().catch(e=>{sync("Portal failed to load","error");$("#view").innerHTML=`<div class="panel empty"><b>Mello could not start.</b><br>${esc(e.message)}</div>`;bindShell()});
 })();
 

--- a/program.html
+++ b/program.html
@@ -1,1050 +1,384 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-<meta name="theme-color" content="#101827">
-<title>Program</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="theme-color" content="#101827">
+  <title>Program</title>
+  <style>
+:root{--bg:#f4f6fa;--surface:#fff;--sidebar-bg:#101827;--ink:#142033;--muted:#667085;--line:#dfe4ec;--accent:#6658e8;--accent-soft:#eeecff;--danger:#cf3f4f;--card:#fff;--sidebar-width:245px;--radius:12px;--shadow:0 14px 40px #14203322}
+*{box-sizing:border-box}html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink);font:14px/1.4 Inter,system-ui,sans-serif}button,input,select,textarea{font:inherit;color:inherit}button,input,select{min-height:42px}button{cursor:pointer}.topbar{position:fixed;z-index:50;inset:0 0 auto 0;height:58px;display:flex;align-items:center;gap:12px;padding:8px 12px;background:color-mix(in srgb,var(--surface) 94%,transparent);border-bottom:1px solid var(--line);backdrop-filter:blur(12px)}.icon-btn{width:42px;border:1px solid var(--line);border-radius:9px;background:var(--surface);font-size:20px}.sync-state{margin-left:auto;font-size:12px;color:var(--muted)}.sync-state.error{color:var(--danger);font-weight:700}.sidebar{position:fixed;z-index:40;inset:58px auto 0 0;width:var(--sidebar-width);padding:14px 10px;background:var(--sidebar-bg);color:#edf1f8;transform:translateX(-101%);transition:transform .18s ease;overflow:auto}.sidebar.open{transform:none}.brand{display:flex;align-items:center;gap:10px;padding:4px 8px 18px}.brand>span:last-child{display:flex;flex-direction:column}.brand small{color:#aab3c1}.brand-mark{display:grid;place-items:center;width:36px;height:36px;border-radius:10px;background:var(--accent);font-weight:900}.sidebar nav{display:grid;gap:4px}.app-link{display:flex;align-items:center;gap:10px;width:100%;border:0;border-radius:9px;padding:10px;background:transparent;color:inherit;text-align:left}.app-link>span:first-child{width:24px;text-align:center;font-size:18px}.app-link:hover,.app-link.active{background:#ffffff18}.app-link.active{outline:1px solid #ffffff44}.view{padding:72px 10px 20px;min-height:100dvh}.view-head{display:flex;align-items:start;justify-content:space-between;gap:10px;margin-bottom:10px}.view-head h1{margin:0;font-size:21px}.view-head p{margin:2px 0;color:var(--muted)}.panel{min-width:0;padding:10px;border:1px solid var(--line);border-radius:var(--radius);background:var(--surface)}.command,.toolbar,.actions{display:flex;flex-wrap:wrap;align-items:end;gap:7px}.command{margin-bottom:10px}.control{display:grid;gap:3px;min-width:125px;flex:1}.control>label,.label{font-size:11px;font-weight:750;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}input,select,textarea{width:100%;border:1px solid var(--line);border-radius:8px;padding:8px;background:var(--surface)}textarea{min-height:90px;resize:vertical}.btn{border:1px solid var(--line);border-radius:8px;padding:8px 11px;background:var(--surface);font-weight:650}.btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}.btn.danger{color:var(--danger)}:focus-visible{outline:3px solid color-mix(in srgb,var(--accent) 55%,white);outline-offset:2px}.field-pop{position:relative}.field-pop summary{min-height:42px;display:flex;align-items:center;border:1px solid var(--line);border-radius:8px;padding:8px;background:var(--surface);cursor:pointer}.field-pop>div{position:absolute;z-index:10;top:45px;right:0;width:210px;padding:9px;border:1px solid var(--line);border-radius:9px;background:var(--surface);box-shadow:var(--shadow)}.check{display:flex;align-items:center;gap:7px;padding:4px}.check input{width:auto;min-height:auto}.matrix-scroll{overflow:auto;max-width:100%;max-height:70dvh}.matrix-grid{display:grid;gap:5px;min-width:max-content}.matrix-corner,.matrix-header,.matrix-rowhead{padding:7px;background:var(--surface);font-size:11px;font-weight:800}.matrix-corner,.matrix-header{position:sticky;top:0;z-index:3}.matrix-rowhead{position:sticky;left:0;z-index:2;max-width:120px}.matrix-cell{width:170px;min-height:48px;padding:5px;border:1px dashed var(--line);border-radius:8px;background:color-mix(in srgb,var(--surface) 78%,var(--bg));display:flex;flex-direction:column;gap:5px}.matrix-cell.over,.lane.over{outline:2px solid var(--accent);background:var(--accent-soft)}.card{position:relative;padding:6px 34px 6px 8px;border:1px solid var(--line);border-left:5px solid var(--card-color,var(--card));border-radius:7px;background:var(--card);box-shadow:0 1px 3px #14203318;cursor:grab}.card.selected{outline:3px solid var(--accent)}.card-title{border:0;padding:0;background:none;min-height:0;font-weight:750;text-align:left}.card-meta{font-size:10px;color:var(--muted);overflow-wrap:anywhere}.card-edit{position:absolute;right:4px;top:4px;width:27px;min-height:27px;height:27px;border:0;border-radius:6px;background:var(--bg)}.split,.mashup{display:grid;gap:10px}.mini-board{display:flex;gap:7px;overflow:auto;min-height:55dvh}.lane{flex:0 0 min(78vw,250px);padding:7px;border:1px solid var(--line);border-radius:9px;background:var(--bg)}.lane h3{margin:2px 2px 8px;font-size:11px;text-transform:uppercase}.lane .card{margin-bottom:5px}.definition-list,.preset-list,.theme-list{display:grid;gap:7px;margin-top:10px}.definition,.color-row{display:flex;align-items:center;gap:7px;padding:7px;border:1px solid var(--line);border-radius:8px}.definition span:first-child{flex:1}.swatch{width:30px;height:30px;min-height:30px;flex:0 0 30px;border:2px solid var(--surface);border-radius:7px;box-shadow:0 0 0 1px var(--line)}.color-row input[type=text]{min-width:90px}.color-row input[type=color]{width:42px;padding:3px}.config-grid{display:grid;gap:10px}.warning,.message{padding:9px;border-radius:8px;background:var(--accent-soft)}.message.error{border:1px solid var(--danger);color:var(--danger)}dialog{width:min(640px,calc(100vw - 18px));max-height:calc(100dvh - 18px);padding:0;border:0;border-radius:14px;box-shadow:var(--shadow)}dialog::backdrop{background:#0a101c88}.dialog-body{padding:16px}.dialog-head{display:flex;align-items:center;justify-content:space-between;gap:10px}.dialog-head h2{margin:0}.dialog-grid{display:grid;gap:8px}.dialog-actions{display:flex;justify-content:flex-end;gap:7px;margin-top:13px}.color-menu{position:fixed;z-index:100;display:grid;gap:5px;width:190px;padding:8px;border:1px solid var(--line);border-radius:9px;background:var(--surface);box-shadow:var(--shadow)}.color-choice{display:flex;align-items:center;gap:7px;border:0;background:none;text-align:left}.toast{position:fixed;z-index:110;left:50%;bottom:14px;transform:translate(-50%,15px);opacity:0;padding:9px 12px;border-radius:8px;background:#101827;color:white;pointer-events:none}.toast.show{opacity:1;transform:translate(-50%,0)}.scrim{display:none;position:fixed;z-index:35;inset:58px 0 0;background:#0a101c66}.scrim.open{display:block}.empty{padding:24px;text-align:center;color:var(--muted)}
+@media(min-width:760px){.sidebar{transform:none}.view{margin-left:var(--sidebar-width);padding:76px 18px 22px;transition:margin .18s ease}.portal.sidebar-collapsed .sidebar{transform:translateX(-101%)}.portal.sidebar-collapsed .view{margin-left:0}.split,.mashup{grid-template-columns:minmax(0,1fr) minmax(0,1fr)}.config-grid{grid-template-columns:minmax(250px,1fr) 2fr}.dialog-grid{grid-template-columns:1fr 1fr}.span-2{grid-column:1/-1}.command{flex-wrap:nowrap}.scrim{display:none!important}}
+@media(max-width:520px){.sync-state{max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.control{min-width:calc(50% - 5px)}.command .btn{flex:1}.color-row{flex-wrap:wrap}.view-head p{display:none}}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition:none!important}}
+
+/* Compact application shell and faithful, viewport-sized matrices */
+:root{--topbar-height:64px;--sidebar-width:220px;--radius:14px;--shadow:0 16px 45px rgba(15,23,42,.14)}
+html,body{height:100%;overflow:hidden}.portal{height:100dvh}.topbar{height:var(--topbar-height);gap:10px;padding:7px 10px;box-shadow:0 1px 10px #1420330c}.topbar>strong{flex:0 0 auto;white-space:nowrap;font-size:15px}.app-controls{display:flex;align-items:center;min-width:0;flex:1;overflow-x:auto;overscroll-behavior-inline:contain;scrollbar-width:thin}.app-controls:empty{display:none}.app-controls .command{flex-wrap:nowrap;margin:0;align-items:center;width:max-content}.app-controls .control{display:block;min-width:96px;flex:0 0 auto}.app-controls .control label{display:flex;align-items:center;gap:5px;white-space:nowrap;font-size:0}.app-controls .control label::before{content:attr(data-label);font-size:11px}.app-controls select,.app-controls summary,.app-controls .btn{min-height:38px;height:38px}.app-controls select{width:auto;max-width:150px;padding:5px 25px 5px 8px;font-size:14px}.app-controls .field-pop summary{white-space:nowrap}.app-controls .field-pop>div{top:42px}.sync-state{flex:0 0 auto}.sidebar{inset:var(--topbar-height) auto 0 0;padding-top:10px}.view{height:100dvh;min-height:0;padding:calc(var(--topbar-height) + 8px) 8px 8px;overflow:auto}.view-head{margin:0 0 8px}.view-head h1{display:none}.view-head p{margin:0}.panel{padding:8px;border-color:color-mix(in srgb,var(--line) 72%,transparent);box-shadow:0 5px 18px #1420330a}.matrix-panel{height:calc(100dvh - var(--topbar-height) - 16px);display:flex;flex-direction:column}.matrix-panel>[data-message]:not(:empty){flex:0 0 auto}.matrix-scroll{width:100%;height:100%;max-height:none;min-height:0;overflow:auto;border-radius:10px}.matrix-grid{display:grid;grid-template-columns:clamp(46px,9vw,100px) repeat(var(--matrix-columns),minmax(0,1fr));grid-template-rows:minmax(26px,auto) repeat(var(--matrix-rows),minmax(0,1fr));gap:3px;width:100%;height:100%;min-width:0;min-height:0}.matrix-corner,.matrix-header,.matrix-rowhead{min-width:0;padding:4px;font-size:clamp(8px,1vw,11px);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.matrix-cell{width:auto;min-width:0;min-height:0;height:auto;padding:3px;gap:3px;overflow:auto;border-style:solid}.matrix-cell .card{flex:0 0 auto;min-width:0;padding:4px 24px 4px 5px;border-radius:9px;overflow:hidden}.matrix-cell .card-title,.matrix-cell .card-meta{display:block;width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:clamp(8px,.85vw,12px)}.matrix-cell .card-edit{right:2px;top:2px;width:20px;height:20px;min-height:20px;font-size:11px}.matrix-grid[data-context="mashup"]{gap:2px}.matrix-grid[data-context="mashup"] .matrix-cell{padding:2px}.matrix-grid[data-context="mashup"] .card-meta{display:none}.matrix-grid[data-context="mashup"] .card{padding-block:2px}.mashup .matrix-scroll{height:calc(100dvh - var(--topbar-height) - 95px);max-height:none}.mashup .panel{min-width:0}.card,.lane,.panel,.btn,input,select,textarea,.field-pop summary{transition:border-color .12s ease,background-color .12s ease,box-shadow .12s ease,transform .12s ease}.card:hover{border-color:color-mix(in srgb,var(--accent) 42%,var(--line));box-shadow:0 5px 15px #14203318}.btn:hover{transform:translateY(-1px)}
+/* Match KANBAN's card editor proportions and field rhythm. */
+#cardDialog{width:min(900px,96vw);border-radius:14px}#cardDialog .dialog-body{position:relative;padding:16px;background:var(--surface);border:1px solid var(--line);border-radius:14px}#cardDialog .dialog-head{padding-right:38px}#cardDialog .dialog-head .icon-btn{position:absolute;right:12px;top:10px;border:0;background:transparent;color:var(--muted)}#cardDialog .dialog-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;margin-top:10px}#cardDialog .control{gap:6px}#cardDialog input,#cardDialog select,#cardDialog textarea{border-radius:10px;padding:10px}#cardDialog textarea{min-height:144px;max-height:40vh}#cardDialog .dialog-actions{justify-content:flex-start}
+@media(min-width:760px){.view{margin-left:var(--sidebar-width);padding:calc(var(--topbar-height) + 8px) 8px 8px}.portal.sidebar-collapsed .view{margin-left:0}}
+@media(max-width:759px){:root{--topbar-height:58px}.topbar{gap:6px;padding-inline:6px}.topbar>strong{max-width:92px;overflow:hidden;text-overflow:ellipsis}.sync-state{display:none}.app-controls .control{min-width:82px}.app-controls select{max-width:112px}.sidebar{inset:var(--topbar-height) auto 0}.scrim{inset:var(--topbar-height) 0 0}.matrix-grid{grid-template-columns:42px repeat(var(--matrix-columns),minmax(0,1fr))}.matrix-cell .card-meta{display:none}.matrix-cell .card{padding-left:3px}}
+@media(max-width:520px){#cardDialog .dialog-grid{grid-template-columns:1fr}#cardDialog .span-2{grid-column:1}.app-controls .field-pop{display:none}.view{padding-inline:4px;padding-bottom:4px}.matrix-panel{height:calc(100dvh - var(--topbar-height) - 8px);padding:4px}}
+
+</style>
 <style>
-:root{
-  --bg:#f4f6fa; --surface:#fff; --sidebar:#101827; --ink:#142033; --muted:#667085;
-  --line:#dfe4ec; --accent:#6658e8; --accent-soft:#eeecff; --danger:#cf3f4f; --card:#fff;
-  --ok:#166534; --radius:12px; --shadow:0 14px 40px #14203322; --shadow-sm:0 2px 8px #14203314;
-  --rail-w:230px; --top-h:56px;
-}
-*{box-sizing:border-box}
-html,body{margin:0;height:100%;overflow:hidden}
-body{background:var(--bg);color:var(--ink);font:14px/1.45 Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
-button,input,select,textarea{font:inherit;color:inherit}
-button{cursor:pointer;background:none;border:0}
-a{color:var(--accent)}
-:focus-visible{outline:2px solid color-mix(in srgb,var(--accent) 60%,white);outline-offset:1px}
-.hidden{display:none!important}
-
-/* ---- shell ---- */
-.app{display:grid;grid-template-columns:var(--rail-w) 1fr;grid-template-rows:var(--top-h) 1fr;
-  grid-template-areas:"brand top" "rail main";height:100dvh}
-.topbar{grid-area:top;display:flex;align-items:center;gap:10px;padding:0 12px;background:var(--surface);
-  border-bottom:1px solid var(--line);box-shadow:var(--shadow-sm);z-index:30}
-.brand{grid-area:brand;display:flex;align-items:center;gap:10px;padding:0 12px;background:var(--sidebar);
-  color:#edf1f8;border-bottom:1px solid #ffffff14}
-.brand-mark{display:grid;place-items:center;width:32px;height:32px;border-radius:9px;background:var(--accent);font-weight:900;color:#fff}
-.brand b{font-size:15px;letter-spacing:.2px}
-.seg{display:inline-flex;background:var(--bg);border:1px solid var(--line);border-radius:10px;padding:3px}
-.seg button{padding:7px 14px;border-radius:8px;font-weight:650;color:var(--muted);white-space:nowrap}
-.seg button.on{background:var(--surface);color:var(--ink);box-shadow:var(--shadow-sm)}
-.top-title{font-weight:750;font-size:15px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
-.spacer{flex:1;min-width:8px}
-.sync{font-size:12px;color:var(--muted);white-space:nowrap;max-width:150px;overflow:hidden;text-overflow:ellipsis}
-.sync.err{color:var(--danger);font-weight:700}
-.sync.ok{color:var(--ok)}
-.icon-btn{width:38px;height:38px;display:grid;place-items:center;border:1px solid var(--line);border-radius:9px;
-  background:var(--surface);font-size:17px;color:var(--muted)}
-.icon-btn:hover{color:var(--ink);border-color:color-mix(in srgb,var(--accent) 40%,var(--line))}
-
-/* ---- rail (boards on the left) ---- */
-.rail{grid-area:rail;background:var(--surface);border-right:1px solid var(--line);display:flex;flex-direction:column;min-height:0}
-.rail-search{padding:10px 10px 6px;display:flex;gap:6px}
-.rail-search input{flex:1;min-width:0;border:1px solid var(--line);border-radius:9px;padding:8px 10px;background:var(--bg)}
-.rail-list{flex:1;overflow:auto;padding:4px 8px 10px}
-.rail-sec{font-size:10px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);padding:10px 8px 4px}
-.brow{display:flex;align-items:center;gap:8px;padding:8px 9px;border-radius:9px;cursor:pointer;position:relative}
-.brow:hover{background:var(--bg)}
-.brow.on{background:var(--accent-soft)}
-.brow .bdot{width:9px;height:9px;border-radius:50%;flex:0 0 auto;background:var(--muted)}
-.brow .bname{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:650}
-.brow .bcount{font-size:11px;color:var(--muted);background:var(--bg);border:1px solid var(--line);border-radius:999px;padding:1px 7px}
-.brow.on .bcount{background:var(--surface)}
-.brow .bx{opacity:0;color:var(--muted);font-size:15px;width:20px;height:20px;border-radius:6px}
-.brow:hover .bx{opacity:1}
-.brow .bx:hover{background:#fff;color:var(--danger)}
-.rail-new{margin:6px 10px;border:1px dashed var(--line);border-radius:10px;padding:9px;color:var(--accent);font-weight:700;text-align:center}
-.rail-new:hover{background:var(--accent-soft)}
-
-/* ---- main ---- */
-.main{grid-area:main;min-width:0;min-height:0;overflow:hidden;display:flex;flex-direction:column}
-.toolbar{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:10px 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-.field{display:flex;flex-direction:column;gap:3px}
-.field label{font-size:10px;font-weight:750;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
-.field select,.field input{border:1px solid var(--line);border-radius:8px;padding:7px 9px;background:var(--bg);min-height:36px}
-.btn{border:1px solid var(--line);border-radius:9px;padding:8px 12px;background:var(--surface);font-weight:650}
-.btn:hover{border-color:color-mix(in srgb,var(--accent) 40%,var(--line))}
-.btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}
-.btn.primary:hover{filter:brightness(1.05)}
-.btn.danger{color:var(--danger)}
-.btn.small{padding:5px 9px;font-size:12px}
-.pop-anchor{position:relative}
-.chipbtn{border:1px solid var(--line);border-radius:999px;padding:6px 12px;background:var(--surface);font-weight:650;font-size:13px;color:var(--muted);display:inline-flex;gap:6px;align-items:center}
-.chipbtn.active{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,var(--line));background:var(--accent-soft)}
-.content{flex:1;min-height:0;overflow:auto;padding:14px}
-
-/* ---- board matrix ---- */
-.mx-wrap{height:100%;display:flex;flex-direction:column;min-height:0}
-.mx-scroll{flex:1;min-height:0;overflow:auto;border:1px solid var(--line);border-radius:12px;background:var(--surface)}
-.mx-grid{display:grid;min-width:max-content}
-.mx-corner,.mx-colh,.mx-rowh{position:sticky;background:var(--surface);z-index:2;font-size:11px;font-weight:800;
-  color:var(--ink);display:flex;align-items:center;justify-content:center;text-align:center;padding:8px 6px;
-  border-right:1px solid var(--line);border-bottom:1px solid var(--line)}
-.mx-colh{top:0}
-.mx-rowh{left:0;z-index:3;text-transform:capitalize}
-.mx-corner{top:0;left:0;z-index:4;font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
-.mx-colh{text-transform:capitalize;cursor:grab;user-select:none}
-.mx-cell{border-right:1px solid var(--line);border-bottom:1px solid var(--line);padding:6px;min-height:74px;
-  display:flex;flex-direction:column;gap:5px;background:color-mix(in srgb,var(--surface) 60%,var(--bg));min-width:0}
-.mx-cell.drop{outline:2px solid var(--accent);outline-offset:-2px;background:var(--accent-soft)}
-.mx-cell.empty{background:var(--surface)}
-.bchip{display:flex;align-items:center;gap:7px;padding:6px 8px;border:1px solid var(--line);border-left:4px solid var(--chip,var(--muted));
-  border-radius:8px;background:var(--surface);box-shadow:var(--shadow-sm);cursor:grab;min-width:0}
-.bchip:hover{border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
-.bchip .n{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700;font-size:12.5px}
-.bchip .c{font-size:10px;color:var(--muted);flex:0 0 auto}
-.mx-more{border:1px dashed var(--line);border-radius:8px;padding:5px;font-size:11px;font-weight:700;color:var(--muted);text-align:center}
-.mx-more:hover{color:var(--accent);border-color:var(--accent)}
-.mx-empty-note{padding:40px;text-align:center;color:var(--muted)}
-
-/* ---- kanban board view (cards on the right) ---- */
-.kb-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:10px 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-.kb-title{font-size:20px;font-weight:800;border:1px solid transparent;border-radius:8px;padding:3px 7px;min-width:120px}
-.kb-title:focus{border-color:var(--line);background:var(--bg);outline:none}
-.kb-meta{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
-.kb-board{flex:1;min-height:0;overflow:auto;padding:14px;display:grid;gap:12px;align-content:start}
-.kb-board[data-layout="horizontal"]{grid-auto-flow:column;grid-auto-columns:minmax(300px,340px);overflow-x:auto}
-.kb-board[data-layout="vertical"]{grid-template-columns:1fr}
-.kb-board[data-layout="auto"]{grid-template-columns:repeat(auto-fill,minmax(300px,1fr))}
-.lane{background:var(--surface);border:1px solid var(--line);border-radius:12px;display:flex;flex-direction:column;min-height:80px;max-height:100%}
-.lane.drop{outline:2px solid var(--accent);outline-offset:-2px}
-.lane-head{display:flex;align-items:center;gap:8px;padding:9px 11px;border-bottom:1px solid var(--line);position:sticky;top:0;background:var(--surface);border-radius:12px 12px 0 0;z-index:1}
-.lane-head h3{margin:0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;flex:1;color:var(--muted)}
-.lane-head .n{font-size:11px;color:var(--muted);background:var(--bg);border-radius:999px;padding:1px 8px}
-.lane-add{width:26px;height:26px;border-radius:7px;color:var(--muted);font-size:17px}
-.lane-add:hover{background:var(--bg);color:var(--accent)}
-.lane-cards{padding:9px;display:flex;flex-direction:column;gap:9px;overflow:auto}
-
-.card{border:1px solid var(--line);border-left:4px solid var(--chip,var(--card));border-radius:10px;background:var(--card);
-  box-shadow:var(--shadow-sm);position:relative}
-.card.dragging{opacity:.45}
-.card.open{border-color:color-mix(in srgb,var(--accent) 55%,var(--line));box-shadow:0 8px 26px #14203322}
-.card-top{display:flex;align-items:center;gap:7px;padding:8px 8px 6px}
-.status-dot{width:11px;height:11px;border-radius:50%;flex:0 0 auto;cursor:pointer;border:1px solid #0001}
-.card-title{flex:1;min-width:0;text-align:left;font-weight:700;font-size:13.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:2px 0}
-.card.open .card-title{white-space:normal}
-.card-links{display:flex;gap:5px;flex:0 0 auto}
-.card-links a,.card-links span{font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.03em;
-  padding:2px 6px;border-radius:6px;background:var(--bg);color:var(--muted);text-decoration:none}
-.card-links a{background:var(--accent-soft);color:var(--accent)}
-.ic{width:24px;height:24px;border-radius:6px;color:var(--muted);font-size:13px;display:grid;place-items:center;flex:0 0 auto}
-.ic:hover{background:var(--bg);color:var(--ink)}
-.ic svg{width:15px;height:15px;fill:currentColor}
-.card-chips{display:flex;gap:4px;flex-wrap:wrap;padding:0 8px 8px}
-.card.collapsed .card-chips,.card.collapsed .card-notes{display:none}
-.chip{font-size:10.5px;font-weight:700;border:1px solid var(--line);border-radius:999px;padding:2px 8px;background:var(--bg);color:var(--muted)}
-.chip.plat{background:#eef4ff;color:#3457c7;border-color:#dbe6ff}
-.chip.lin{background:#f3eeff;color:#6b45c9;border-color:#e7dcff}
-.chip.tag:hover{border-color:var(--accent);color:var(--accent);cursor:pointer}
-.card-notes{padding:0 10px 9px;font-size:12px;color:var(--muted);max-height:66px;overflow:hidden;position:relative;-webkit-mask-image:none}
-.card-notes.clamped{-webkit-mask-image:linear-gradient(180deg,#000 60%,transparent)}
-.card-notes p{margin:0 0 5px}
-.card-notes a{word-break:break-word}
-.card-notes .more{color:var(--accent);font-weight:700;cursor:pointer}
-
-/* inline editor */
-.card-edit{display:grid;grid-template-columns:1fr 1fr;gap:8px;padding:8px 10px 12px;border-top:1px solid var(--line);margin-top:2px}
-.card-edit .fld{display:flex;flex-direction:column;gap:3px}
-.card-edit .fld.wide{grid-column:1/-1}
-.card-edit label{font-size:9px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
-.card-edit input,.card-edit select,.card-edit textarea{border:1px solid var(--line);border-radius:8px;padding:7px 8px;background:var(--bg);width:100%;font-size:12.5px}
-.card-edit textarea{min-height:70px;resize:vertical;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
-.note-prev{border:1px dashed var(--line);border-radius:8px;padding:7px 9px;font-size:12px;min-height:24px;background:var(--surface)}
-.note-prev:empty::before{content:attr(data-ph);color:var(--muted)}
-.tag-edit{display:flex;flex-wrap:wrap;gap:4px;align-items:center;border:1px solid var(--line);border-radius:8px;padding:5px;background:var(--bg)}
-.tag-edit .chip{display:inline-flex;gap:4px;align-items:center;background:var(--surface)}
-.tag-edit .chip b{cursor:pointer;color:var(--muted)}
-.tag-edit input{border:0;background:none;flex:1;min-width:80px;padding:3px}
-.tag-sug{display:flex;flex-wrap:wrap;gap:4px;margin-top:4px}
-.tag-sug button{font-size:10px;border:1px solid var(--line);border-radius:999px;padding:2px 8px;background:var(--surface);color:var(--muted)}
-.tag-sug button:hover{border-color:var(--accent);color:var(--accent)}
-.swatches{display:flex;gap:5px;flex-wrap:wrap}
-.swatches button{width:22px;height:22px;border-radius:50%;border:2px solid var(--surface);box-shadow:0 0 0 1px var(--line)}
-.swatches button.on{box-shadow:0 0 0 2px var(--accent)}
-.edit-actions{grid-column:1/-1;display:flex;gap:7px;justify-content:flex-end;flex-wrap:wrap}
-
-/* ---- popover / dialog / toast ---- */
-.pop{position:fixed;z-index:200;background:var(--surface);border:1px solid var(--line);border-radius:11px;box-shadow:var(--shadow);
-  padding:10px;max-width:320px;max-height:60vh;overflow:auto}
-.pop h4{margin:0 0 8px;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
-.pop .bchip{margin-bottom:6px}
-.pop .check{display:flex;align-items:center;gap:8px;padding:5px 4px;cursor:pointer}
-.pop .check input{width:auto}
-.pop-note{font-size:13px;line-height:1.5;white-space:pre-wrap;word-break:break-word}
-dialog{border:0;border-radius:14px;padding:0;box-shadow:var(--shadow);width:min(560px,94vw);color:var(--ink)}
-dialog::backdrop{background:#0a101c88}
-.dlg{padding:18px}
-.dlg h2{margin:0 0 12px;font-size:18px}
-.dlg .row{display:flex;flex-direction:column;gap:4px;margin-bottom:10px}
-.dlg .row label{font-size:11px;font-weight:750;text-transform:uppercase;color:var(--muted)}
-.dlg input,.dlg select{border:1px solid var(--line);border-radius:8px;padding:9px 10px;background:var(--bg)}
-.dlg .two{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-.dlg .actions{display:flex;justify-content:flex-end;gap:8px;margin-top:6px}
-.toast{position:fixed;left:50%;bottom:18px;transform:translate(-50%,16px);opacity:0;background:#101827;color:#fff;
-  padding:10px 15px;border-radius:9px;z-index:400;pointer-events:none;transition:.2s;font-weight:600;box-shadow:var(--shadow)}
-.toast.show{opacity:1;transform:translate(-50%,0)}
-.toast.err{background:var(--danger)}
-
-.rail-toggle{display:none}
-@media(max-width:820px){
-  .app{grid-template-columns:1fr;grid-template-rows:var(--top-h) 1fr;grid-template-areas:"top" "main"}
-  .brand{display:none}
-  .rail{position:fixed;inset:var(--top-h) auto 0 0;width:280px;z-index:60;transform:translateX(-102%);transition:transform .18s;box-shadow:var(--shadow)}
-  .app.rail-open .rail{transform:none}
-  .scrim{position:fixed;inset:var(--top-h) 0 0;background:#0a101c55;z-index:55;display:none}
-  .app.rail-open .scrim{display:block}
-  .rail-toggle{display:grid}
-  .kb-board[data-layout="auto"]{grid-template-columns:1fr}
-}
-@media(min-width:821px){.scrim{display:none!important}}
-@media(prefers-reduced-motion:reduce){*{transition:none!important}}
+/* Mello keeps editing in context: an open card is the editor, not a second UI. */
+.card{padding:7px;border-radius:10px}.card-summary{display:flex;align-items:center;gap:5px}.card-toggle{width:24px;min-height:24px;height:24px;border:0;background:transparent;color:var(--muted)}
+.card-editor{display:none;margin-top:7px;padding-top:7px;border-top:1px solid var(--line);gap:6px}.card.is-open .card-editor{display:grid}.card.is-open{min-width:230px;overflow:visible}
+.card-editor label{display:grid;gap:2px;font-size:9px;font-weight:800;text-transform:uppercase;color:var(--muted)}.card-editor input,.card-editor select,.card-editor textarea{min-height:30px;padding:5px;font-size:11px}.card-editor textarea{min-height:55px}.card-editor .wide{grid-column:1/-1}.card-tags-editor{display:flex;gap:4px;flex-wrap:wrap}.tag-suggestion{border:1px solid var(--line);border-radius:999px;background:var(--surface);padding:2px 6px;min-height:22px;font-size:10px}
+.matrix-header,.matrix-rowhead{cursor:grab;user-select:none}.matrix-header.axis-dragging,.matrix-rowhead.axis-dragging{opacity:.45}.axis-drop{outline:2px solid var(--accent);outline-offset:-2px}.matrix-header::before,.matrix-rowhead::before{content:"⠿ ";color:var(--muted)}
+.lane-head{display:flex;align-items:center;gap:5px}.lane-head h3{flex:1}.lane-toggle{width:26px;height:26px;min-height:26px;border:0;background:transparent}.lane.is-closed>.lane-cards{display:none}.lane-cards{display:block}
+.board-builder{max-width:760px}.board-builder form{display:grid;gap:10px}.board-builder h2{margin-bottom:4px}.builder-actions{display:flex;flex-wrap:wrap;gap:8px}.builder-divider{margin:18px 0;border:0;border-top:1px solid var(--line)}
+@media(min-width:560px){.card-editor{grid-template-columns:1fr 1fr}.board-builder .form-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}.board-builder .form-grid .wide{grid-column:1/-1}}
+/* Configurable matrix surfaces, separators, headers, and modal editor. */
+:root{--ribbon:#64748b;--card-text:#142033;--card-font-size:12px;--panel-text:#142033;--panel-font-size:14px;--matrix-text:#142033;--matrix-font-size:11px;--header-text:#142033;--header-font-size:11px;--separator:#dfe4ec}.panel{color:var(--panel-text);font-size:var(--panel-font-size)}.matrix-grid{gap:0;border:1px solid var(--separator)}.matrix-corner,.matrix-header,.matrix-rowhead{display:flex;align-items:center;justify-content:center;text-align:center;color:var(--header-text);font-size:var(--header-font-size);border-right:1px solid var(--separator);border-bottom:1px solid var(--separator)}.matrix-cell{color:var(--matrix-text);font-size:var(--matrix-font-size);border:0;border-right:1px solid var(--separator);border-bottom:1px solid var(--separator);border-radius:0}.matrix-cell .card{color:var(--card-text);font-size:var(--card-font-size);border-left-color:var(--ribbon)}.matrix-cell .card-title,.matrix-cell .card-meta{font-size:inherit;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.board-chip{display:block;max-width:100%;min-height:0;padding:4px 7px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-weight:800;text-decoration:none;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.matrix-header,.matrix-rowhead{cursor:grab;user-select:none}.axis-dragging{opacity:.45}.axis-drop{outline:2px solid var(--accent);outline-offset:-2px}#cardDialog{width:min(900px,96vw)}#cardDialog .dialog-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}#cardDialog .span-2{grid-column:1/-1}#cardDialog textarea{min-height:140px}.appearance-list{display:grid;gap:8px}.appearance-row{display:grid;grid-template-columns:minmax(130px,1fr) 90px 90px;align-items:end;gap:8px}.appearance-row label{font-size:11px;font-weight:750;color:var(--muted)}@media(max-width:520px){#cardDialog .dialog-grid{grid-template-columns:1fr}#cardDialog .span-2{grid-column:1}.appearance-row{grid-template-columns:1fr 80px 80px}}
+.matrix-title{margin:0 0 8px;font-size:20px}.matrix-title input{min-height:34px;padding:3px 7px;font-size:inherit;font-weight:800}.trash-panel{margin-bottom:8px}.trash-panel summary{cursor:pointer;font-weight:800}.trash-item,.board-row{display:flex;align-items:center;gap:6px;padding:6px;border-bottom:1px solid var(--line)}.trash-item span,.board-row button:first-of-type{flex:1}.manage-layout{display:grid;grid-template-columns:minmax(190px,260px) minmax(0,1fr);gap:10px;min-height:calc(100dvh - var(--topbar-height) - 16px)}.board-list{overflow:auto}.board-row.active{background:var(--accent-soft)}.board-row>button{border:0;background:transparent;text-align:left}.board-kanban{display:flex;gap:8px;overflow:auto}.board-kanban .lane{min-width:240px}.mashup.swap{grid-template-columns:1fr}.mashup.swap .panel{min-height:42dvh}.mashup-toolbar{display:flex;justify-content:flex-end;margin-bottom:6px}@media(max-width:759px){.manage-layout{grid-template-columns:1fr}.board-list{max-height:230px}}
+</style>
+<style>
+/* ============================================================
+   Kanban-parity card layout, tag suggestions, compact status.
+   Layered on top of Mello's matrix so cards carry full info
+   while the matrix stays tight (truncate + open editor to read).
+   ============================================================ */
+.card{border-left:4px solid var(--ribbon,var(--card))!important;gap:6px}
+.kcard{display:flex;flex-direction:column}
+.kc-line{display:flex;align-items:center;gap:7px;min-width:0;width:100%}
+.kc-status{flex:0 0 auto;width:16px;height:16px;border:1px solid var(--line);border-radius:999px;background:#fff;display:grid;place-items:center;padding:0;min-height:0}
+.kc-status:hover{border-color:var(--accent)}
+.kc-status .kc-dot{width:9px;height:9px;border-radius:999px;background:#9ca3af}
+.kcard .card-title{flex:1 1 auto;min-width:0;color:var(--accent);font-weight:750;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding:0;text-align:left;background:none;border:0}
+.kc-links{display:inline-flex;gap:6px;flex:0 0 auto;align-items:center}
+.kc-links a{font-size:11px;color:var(--accent);text-decoration:none;font-weight:650}
+.kc-links a:hover{text-decoration:underline}
+.kc-links .empty{font-size:11px;color:#c2c8d4}
+.kc-copy,.kc-arch{flex:0 0 auto;width:22px;height:22px;border-radius:6px;color:var(--accent);display:grid;place-items:center;background:transparent;border:0;padding:0;min-height:0}
+.kc-copy:hover,.kc-arch:hover{background:var(--accent-soft)}
+.kc-copy svg,.kc-arch svg{width:14px;height:14px;fill:currentColor}
+.kc-tags{display:flex;gap:5px;flex-wrap:wrap;align-items:center}
+.kc-tags .chip{font-size:11px;border:1px solid var(--line);border-radius:999px;padding:2px 8px;background:#fff;color:var(--muted);max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-height:0}
+.kc-tags .kc-plat{color:#3457c7;background:#eef4ff;border-color:#dbe6ff}
+.kc-tags .kc-lin{color:#6b45c9;background:#f3eeff;border-color:#e7dcff}
+.kc-tags .kc-tag{cursor:pointer}
+.kc-tags .kc-tag:hover{border-color:var(--accent);color:var(--accent)}
+/* tight inside matrix cells: one info line, chips clipped; click title to read all */
+.matrix-cell .card{padding:5px 7px}
+.matrix-cell .kc-line{gap:5px}
+.matrix-cell .kc-tags{flex-wrap:nowrap;overflow:hidden;-webkit-mask-image:linear-gradient(90deg,#000 82%,transparent)}
+.matrix-cell .kc-tags .chip{flex:0 0 auto}
+.matrix-cell .kc-copy,.matrix-cell .kc-arch{display:none}
+.matrix-grid[data-context="mashup"] .kc-tags{display:none}
+.matrix-grid[data-context="mashup"] .kc-links{display:none}
+/* status color picker */
+.status-menu{position:fixed;z-index:120;display:grid;grid-template-columns:repeat(4,1fr);gap:7px;padding:10px;border:1px solid var(--line);border-radius:11px;background:#fff;box-shadow:var(--shadow)}
+.status-menu button{width:26px;height:26px;border-radius:999px;border:2px solid #fff;box-shadow:0 0 0 1px var(--line);cursor:pointer;min-height:0}
+.status-menu button.on{box-shadow:0 0 0 2px var(--accent)}
+/* editor: chip tag input + previously-used suggestions */
+#cardDialog .tag-chips{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:6px}
+#cardDialog .tag-chips:empty{display:none}
+#cardDialog .tag-chips .chip{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);border-radius:999px;padding:3px 10px;background:#fff;font-size:13px}
+#cardDialog .tag-chips .chip button{border:0;background:none;font-weight:800;color:#999;cursor:pointer;padding:0;min-height:0;line-height:1}
+#cardDialog .tag-chips .chip button:hover{color:var(--danger)}
+#cardDialog .tag-suggestions{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px}
+#cardDialog .tag-suggestions .chip{display:inline-flex;align-items:center;gap:6px;border:1px dashed var(--line);border-radius:999px;padding:3px 10px;background:var(--bg);font-size:12px;cursor:pointer;color:var(--muted)}
+#cardDialog .tag-suggestions .chip:hover{border-color:var(--accent);color:var(--accent)}
+#cardDialog .tag-suggestions .chip .sx{color:#bbb;font-weight:800}
+#cardDialog .note-prev{border:1px dashed var(--line);border-radius:8px;padding:8px 10px;font-size:12.5px;min-height:20px;background:var(--surface);margin-top:6px}
+#cardDialog .note-prev:empty{display:none}
+#cardDialog .note-prev p{margin:0 0 5px}
+.note-pop{position:fixed;z-index:130;max-width:340px;max-height:60vh;overflow:auto;padding:12px 14px;border:1px solid var(--line);border-radius:12px;background:#fff;box-shadow:var(--shadow);font-size:13px;line-height:1.5}
 </style>
 </head>
 <body>
-<div id="app" class="app">
-  <div class="brand"><span class="brand-mark">P</span><b id="brandName">Program</b></div>
-  <header class="topbar">
-    <button id="railToggle" class="icon-btn rail-toggle" aria-label="Toggle boards">☰</button>
-    <div class="seg" role="tablist" aria-label="View">
-      <button id="tabMatrix" role="tab">▦ Matrix</button>
-      <button id="tabBoard" role="tab">▤ Board</button>
-    </div>
-    <span id="topTitle" class="top-title"></span>
-    <span class="spacer"></span>
-    <span id="sync" class="sync" role="status" aria-live="polite">·</span>
-    <button id="btnSettings" class="icon-btn" aria-label="Settings" title="Settings">⚙</button>
-  </header>
-  <aside class="rail" id="rail" aria-label="Boards">
-    <div class="rail-search">
-      <input id="railSearch" placeholder="Filter boards…" aria-label="Filter boards">
-    </div>
-    <div class="rail-list" id="railList"></div>
-    <button class="rail-new" id="railNew">＋ New board</button>
-  </aside>
-  <main class="main" id="main"></main>
-</div>
-<div class="scrim" id="scrim"></div>
-<dialog id="dialog"></dialog>
-<div id="toast" class="toast" role="status" aria-live="polite"></div>
-
-<script>
+  <div class="portal">
+    <header class="topbar">
+      <button id="sidebarToggle" class="icon-btn" type="button" aria-label="Collapse application sidebar" aria-controls="sidebar" aria-expanded="true"><span aria-hidden="true">☰</span></button>
+      <strong id="headerTitle">Board Matrix</strong>
+      <div id="appControls" class="app-controls" aria-label="Application controls"></div>
+      <span id="syncState" class="sync-state" role="status" aria-live="polite"></span>
+    </header>
+    <aside id="sidebar" class="sidebar" aria-label="Applications">
+      <nav>
+        <button class="app-link" data-app="matrix"><span>▦</span><span>Board Matrix</span></button>
+        <button class="app-link" data-app="mashup"><span>▥</span><span>Matrix Mashup</span></button>
+        <button class="app-link" data-app="builder"><span>☷</span><span>Manage Board</span></button>
+        <button class="app-link" data-app="config"><span>⚙</span><span>Configuration</span></button>
+      </nav>
+    </aside>
+    <main id="view" class="view" tabindex="-1"></main>
+  </div>
+  <div id="scrim" class="scrim"></div>
+  <dialog id="nameDialog"></dialog>
+  <dialog id="confirmDialog"></dialog>
+  <dialog id="cardDialog"></dialog>
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+  <script>
 (() => {
-"use strict";
+  "use strict";
+  const FILES={index:"kanban-boards.json",switch:"kanban-switch.json"};
+  const KEY="program_configuration_v4", TOKEN_KEY="github_pat";
+  const AXES=["title","platform","stage","lineage","statusColor","cardColor","dev","live"];
+  const DISPLAY=["title","platform","stage","lineage","statusColor","dev","live","tags","notes"];
+  const APP_NAMES={builder:"Manage Board",matrix:"Board Matrix",mashup:"Matrix Mashup",config:"Configuration"};
+  const THEME={bg:"#f4f6fa",surface:"#ffffff",sidebar:"#101827",ink:"#142033",muted:"#667085",line:"#dfe4ec",accent:"#6658e8",accentSoft:"#eeecff",danger:"#cf3f4f",card:"#ffffff"};
+  const THEME_NAMES={bg:"Portal background",surface:"Surface / panel background",sidebar:"Sidebar background",ink:"Primary text",muted:"Muted text",line:"Border",accent:"Accent",accentSoft:"Accent hover / soft color",danger:"Danger",card:"Card default"};
+  const PRESETS=[{name:"Slate",color:"#64748b"},{name:"Red",color:"#ef4444"},{name:"Orange",color:"#f97316"},{name:"Yellow",color:"#eab308"},{name:"Green",color:"#22c55e"},{name:"Teal",color:"#14b8a6"},{name:"Blue",color:"#3b82f6"},{name:"Purple",color:"#8b5cf6"}];
+  const $=(s,r=document)=>r.querySelector(s), $$=(s,r=document)=>[...r.querySelectorAll(s)];
+  const esc=s=>String(s??"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  const uid=()=>`${Date.now().toString(36)}-${Math.random().toString(36).slice(2,8)}`;
+  const slug=s=>String(s||"").trim().toLowerCase().replace(/[^a-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"");
+  const read=(k,f)=>{try{return JSON.parse(localStorage.getItem(k))??f}catch{return f}};
+  const validHex=v=>/^#[0-9a-f]{6}$/i.test(v||"");
+  const defaults=()=>({version:3,portalName:"Program",github:{owner:"acmeproducts",repo:"stuff",branch:"main",pat:localStorage.getItem(TOKEN_KEY)||""},theme:{...THEME},cardColors:PRESETS.map(x=>({...x})),matrices:[],selectedApp:"matrix",selectedMatrix:"",mashupSwap:false,sidebarCollapsed:false});
+  let config=defaults(), index={boards:[]}, repoCfg={}, boardData={}, state={}, drag=null, touch=null, saveQueue=Promise.resolve(), toastTimer, pendingImport=null;
 
-/* ============ constants ============ */
-const FILES = { index:"kanban-boards.json", switch:"kanban-switch.json" };
-const CFG_KEY = "program_ui_v5", TOKEN_KEY = "github_pat";
-const CARD_LINEAGES = ["pre-base","base","pre-ship","ship","post-ship","post-ship-plus-1","post-ship-plus-x"];
-const STATUS_COLORS = ["gray","red","yellow","green","blue","orange","white","black"];
-const STATUS_MAP = {gray:"#9ca3af",red:"#ef4444",yellow:"#eab308",green:"#22c55e",blue:"#3b82f6",orange:"#f97316",white:"#ffffff",black:"#111827"};
-const BOARD_PHASES = ["dev","tst","prd"];
-const BOARD_STAGES = ["concept","alpha","pilot","beta","launch"];
-const DEFAULT_PLATFORMS = ["Default","Gemini","Claude","ChatGPT","Perplexity","Codex","Claude Code"];
-const DEFAULT_STAGES = ["Backlog","Next","Doing","Done"];
-const SIZE_BUCKETS = ["empty","1–10","11–30","31+"];
-const AGE_BUCKETS = ["today","this week","this month","older"];
-
-const sizeBucket = n => (n=+n||0, n===0?"empty":n<=10?"1–10":n<=30?"11–30":"31+");
-const ageBucket = ts => { const d=(Date.now()-(+ts||0))/864e5; return d<=1?"today":d<=7?"this week":d<=30?"this month":"older"; };
-
-// Board attributes usable as matrix axes / filters.
-const BOARD_FIELDS = {
-  phase:    {label:"Phase",    order:BOARD_PHASES,  get:b=>BOARD_PHASES.includes(b.phase)?b.phase:"dev", editable:true},
-  stage:    {label:"Stage",    order:BOARD_STAGES,  get:b=>BOARD_STAGES.includes(b.stage)?b.stage:"concept", editable:true},
-  status:   {label:"Archived", order:["active","archived"], get:b=>b.archived?"archived":"active", editable:true},
-  size:     {label:"Size",     order:SIZE_BUCKETS,  get:b=>sizeBucket(b.cardCount)},
-  activity: {label:"Activity", order:AGE_BUCKETS,   get:b=>ageBucket(b.lastUpdated)},
-  created:  {label:"Created",  order:AGE_BUCKETS,   get:b=>ageBucket(b.createdAt)},
-};
-
-/* ============ tiny helpers ============ */
-const $ = (s,r=document)=>r.querySelector(s);
-const $$ = (s,r=document)=>[...r.querySelectorAll(s)];
-const esc = s => String(s??"").replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
-const uid = ()=>`${Date.now().toString(36)}-${Math.random().toString(36).slice(2,7)}`;
-const slug = s=>String(s||"").trim().toLowerCase().replace(/[^a-z0-9_-]+/g,"-").replace(/-+/g,"-").replace(/^-|-$/g,"")||"board";
-const validHex = v=>/^#[0-9a-f]{6}$/i.test(v||"");
-const normStatus = c=>{c=String(c||"").toLowerCase().trim();return STATUS_COLORS.includes(c)?c:"gray";};
-const normLineage = v=>{v=String(v||"").toLowerCase().trim();return CARD_LINEAGES.includes(v)?v:"base";};
-
-/* ============ state ============ */
-let cfg, index={version:1,activeBoard:"",boards:[]}, repoCfg={}, boardData={};
-let loaded = new Set();               // boards whose card file is loaded
-let view = "matrix";                  // "matrix" | "board"
-let activeBoard = "";
-let openCards = new Set();            // inline-open card ids (per board render)
-let saveQueue = Promise.resolve();
-let toastT;
-
-/* ============ config ============ */
-function defaults(){
-  return {
-    portalName:"Program",
-    github:{owner:"acmeproducts",repo:"stuff",branch:"main",pat:localStorage.getItem(TOKEN_KEY)||""},
-    accent:"#6658e8",
-    matrix:{x:"size",y:"activity",filters:{},showArchived:false},
-    tagHistory:[],
-    railWidth:230
-  };
-}
-function loadCfg(){
-  let c=null; try{c=JSON.parse(localStorage.getItem(CFG_KEY));}catch{}
-  cfg = {...defaults(), ...(c||{})};
-  cfg.github = {...defaults().github, ...(c&&c.github||{})};
-  cfg.matrix = {...defaults().matrix, ...(c&&c.matrix||{})};
-  cfg.matrix.filters = (c&&c.matrix&&c.matrix.filters)||{};
-  if(!cfg.github.pat) cfg.github.pat = localStorage.getItem(TOKEN_KEY)||"";
-}
-function persist(){
-  localStorage.setItem(CFG_KEY, JSON.stringify(cfg));
-  if(cfg.github.pat) localStorage.setItem(TOKEN_KEY, cfg.github.pat);
-  document.documentElement.style.setProperty("--accent", cfg.accent);
-  $("#brandName").textContent = cfg.portalName;
-  document.title = cfg.portalName;
-}
-
-/* ============ toast / sync ============ */
-function toast(msg,err=false){const t=$("#toast");t.textContent=msg;t.className="toast show"+(err?" err":"");clearTimeout(toastT);toastT=setTimeout(()=>t.className="toast",2400);}
-function sync(msg,kind=""){const s=$("#sync");s.textContent=msg;s.className="sync "+kind;}
-
-/* ============ data / repo ============ */
-async function fetchJson(path){const r=await fetch(path,{cache:"no-store"});if(!r.ok)throw new Error("HTTP "+r.status);return r.json();}
-const boardPath = n => `${typeof repoCfg.pathPrefix==="string"?repoCfg.pathPrefix:""}${slug(n)}.json`;
-const activeBoards = ()=> (index.boards||[]).filter(b=>!b.archived);
-const findBoard = n => (index.boards||[]).find(b=>b.name===n);
-const cards = n => boardData[n]?.cards || [];
-const boardStages = n => {
-  const b=boardData[n]||{};
-  const set=[...(b.stages||[]).filter(Boolean)];
-  cards(n).forEach(c=>{const s=c.stage||c.lane||"Backlog"; if(!set.includes(s))set.push(s);});
-  return set.length?set:DEFAULT_STAGES.slice();
-};
-const boardPlatforms = n => {
-  const b=boardData[n]||{}; const set=[...(b.platforms||[]).filter(Boolean)];
-  cards(n).forEach(c=>{if(c.platform&&!set.includes(c.platform))set.push(c.platform);});
-  return set.length?set:DEFAULT_PLATFORMS.slice();
-};
-
-async function boot(){
-  loadCfg(); persist();
-  bindShell();
-  sync("Loading…");
-  try{ repoCfg = await fetchJson(FILES.switch); }catch{ repoCfg={}; }
-  try{
-    index = await fetchJson(FILES.index);
-    if(!Array.isArray(index.boards)) throw new Error("index has no boards[]");
-    index.boards.forEach(b=>{b.phase=b.phase||"dev";b.stage=b.stage||"concept";});
-    sync("Ready");
-  }catch(e){
-    index={version:1,activeBoard:"",boards:[]};
-    sync("Offline — "+e.message,"err");
+  function migrate(){
+    const modern=read(KEY,null)||read("mello_configuration_v1",null); if(modern&&modern.version===3)config={...defaults(),...modern,portalName:"Program",github:{...defaults().github,...modern.github},theme:{...THEME,...modern.theme}};
+    else {const old=read("program_portal_config_v2",{}),defs=read("program_matrix_definitions_v2",[]);config={...defaults(),portalName:old.portalName||"Mello",github:{...defaults().github,owner:old.owner||"acmeproducts",repo:old.repo||"stuff",branch:old.branch||"main"},cardColors:(old.colors||[]).filter(validHex).map((color,i)=>({name:`Color ${i+1}`,color})),matrices:defs.map(d=>({...d,intersection:d.intersection||"title",fields:d.fields||[],updatedAt:d.updatedAt||d.createdAt||Date.now()}))};}
+    if(!config.github.pat)config.github.pat=localStorage.getItem(TOKEN_KEY)||""; persist();
   }
-  activeBoard = (findBoard(index.activeBoard)&&index.activeBoard) || activeBoards()[0]?.name || index.boards[0]?.name || "";
-  const q=new URLSearchParams(location.search);
-  view = q.get("view")==="board" ? "board" : "matrix";
-  renderRail();
-  setView(view);
-}
+  function persist(){localStorage.setItem(KEY,JSON.stringify(config));localStorage.setItem(TOKEN_KEY,config.github.pat||"");applyTheme()}
+  function applyTheme(){Object.entries(config.theme||{}).forEach(([k,v])=>{const map={sidebar:"sidebar-bg",accentSoft:"accent-soft"};if(validHex(v))document.documentElement.style.setProperty(`--${map[k]||k}`,v)});document.title=`${config.portalName} Portal`}
+  function notify(s){const t=$("#toast");t.textContent=s;t.classList.add("show");clearTimeout(toastTimer);toastTimer=setTimeout(()=>t.classList.remove("show"),2600)}
+  function sync(s,kind=""){$("#syncState").textContent=s;$("#syncState").className=`sync-state ${kind}`}
+  async function fetchJson(path){const r=await fetch(path,{cache:"no-store"});if(!r.ok)throw new Error(`${r.status} loading ${path}`);return r.json()}
+  const boardPath=n=>`${typeof repoCfg.pathPrefix==="string"?repoCfg.pathPrefix:""}${slug(n)}.json`;
+  const indexedBoards=()=>Array.isArray(index.boards)?index.boards.filter(b=>!b.archived):[];
+  const boards=()=>indexedBoards().filter(b=>Object.hasOwn(boardData,b.name)), cards=n=>boardData[n]?.cards||[];
+  const defaultBoard=()=>boards().find(b=>b.name===index.activeBoard)?.name||boards()[0]?.name||"";
+  function stages(n){const b=boardData[n]||{};return [...new Set([...(b.stages||b.lanes||[]).map(x=>typeof x==="string"?x:x.name),...cards(n).map(c=>c.stage||c.lane||"Backlog")])].filter(Boolean)}
+  const options=(values,selected,blank="")=>`${blank?`<option value="">${esc(blank)}</option>`:""}${values.map(v=>`<option value="${esc(v)}" ${v===selected?"selected":""}>${esc(v)}</option>`).join("")}`;
+  const boardOptions=s=>`<option value="">Select board</option>${indexedBoards().map(b=>`<option value="${esc(b.name)}" ${b.name===s?"selected":""} ${Object.hasOwn(boardData,b.name)?"":"disabled"}>${esc(b.name)}${Object.hasOwn(boardData,b.name)?"":" (unavailable)"}</option>`).join("")}`;
+  const axisOptions=s=>options(AXES,s,"Select field");
+  const value=(c,f)=>String(c?.[f]??(f==="stage"?c?.lane:"")).trim()||"Unassigned";
+  const activeDefs=()=>config.matrices.filter(d=>!d.deletedAt&&Object.hasOwn(boardData,d.board));
 
-async function ensureBoard(name){
-  if(!name || loaded.has(name)) return;
-  try{
-    const data = await fetchJson(boardPath(name));
-    if(!data||typeof data!=="object"||!Array.isArray(data.cards)) throw new Error("bad board file");
-    boardData[name]=data; loaded.add(name);
-  }catch(e){
-    // create an empty local scaffold so the board is still usable
-    boardData[name] = boardData[name] || {version:1,cards:[],archive:[],stages:DEFAULT_STAGES.slice(),platforms:DEFAULT_PLATFORMS.slice(),layout:"auto",cardCollapsed:{},lastModified:Date.now(),_loadError:e.message};
-    loaded.add(name);
+  async function boot(){migrate();repoCfg=await fetchJson(FILES.switch).catch(()=>({}));index=await fetchJson(FILES.index);if(!Array.isArray(index.boards))throw new Error(`${FILES.index} does not contain a boards array.`);const failures=[];await Promise.all(indexedBoards().map(async b=>{const path=boardPath(b.name);try{const data=await fetchJson(path);if(!data||typeof data!=="object"||!Array.isArray(data.cards))throw new Error("invalid board data");boardData[b.name]=data}catch(e){failures.push(`${b.name} (${path}: ${e.message})`)}}));if(!boards().length)throw new Error(`No board data could be loaded.${failures.length?` ${failures.join("; ")}`:""}`);bindShell();setSidebar(!config.sidebarCollapsed);sync(failures.length?`${failures.length} unavailable`:"·",failures.length?"warning":"");$("#syncState").title=failures.join("\n");const query=new URLSearchParams(location.search),app=query.get('app');openApp(APP_NAMES[app]?app:(APP_NAMES[config.selectedApp]?config.selectedApp:"matrix"))}
+  function bindShell(){$("#sidebarToggle").onclick=()=>setSidebar(config.sidebarCollapsed);$("#scrim").onclick=()=>setSidebar(false);$$('[data-app]').forEach(b=>b.onclick=()=>openApp(b.dataset.app))}
+  function setSidebar(open){config.sidebarCollapsed=!open;persist();$(".portal").classList.toggle("sidebar-collapsed",!open);$("#sidebar").classList.toggle("open",open);$("#scrim").classList.toggle("open",open&&innerWidth<760);const b=$("#sidebarToggle");b.setAttribute("aria-expanded",String(open));b.setAttribute("aria-label",`${open?"Collapse":"Expand"} application sidebar`)}
+  function openApp(app){config.selectedApp=app;persist();$("#headerTitle").textContent=APP_NAMES[app];$("#appControls").replaceChildren();$$('[data-app]').forEach(b=>{const on=b.dataset.app===app;b.classList.toggle("active",on);b.setAttribute("aria-current",on?"page":"false")});if(innerWidth<760)setSidebar(false);state={};({builder:renderBuilder,matrix:renderBoardMatrix,mashup:renderMashup,config:renderConfig}[app])()}
+  const head=(title,sub)=>`<div class="view-head"><div><h1>${title}</h1><p>${sub}</p></div></div>`;
+  function rerender(){openApp(config.selectedApp)}
+
+  function fieldsPopover(selected=[]){return `<details class="field-pop"><summary>Card fields (${selected.length})</summary><div>${DISPLAY.filter(f=>f!=="title").map(f=>`<label class="check"><input type="checkbox" name="fields" value="${f}" ${selected.includes(f)?"checked":""}> ${f}</label>`).join("")}</div></details>`}
+  function matrixControls(s,{save=true,z=false}={}){return `<div class="command"><div class="control"><label data-label="Board">Board<select data-board>${boardOptions(s.board)}</select></label></div><div class="control"><label data-label="X">X axis<select data-x>${axisOptions(s.x)}</select></label></div><div class="control"><label data-label="Y">Y axis<select data-y>${axisOptions(s.y)}</select></label></div>${z?`<div class="control"><label data-label="Z">Z filter field<select data-z>${axisOptions(s.z)}</select></label></div>`:""}<div class="control"><label data-label="Name">Intersection name<select data-intersection>${options(DISPLAY,s.intersection||"title")}</select></label></div>${fieldsPopover(s.fields)}<button class="btn primary" data-go>Go</button>${save?`<button class="btn" data-save-matrix>Save Matrix</button>`:""}</div>`}
+  function readMatrixControls(root,s){s.board=$("[data-board]",root).value;s.x=$("[data-x]",root).value;s.y=$("[data-y]",root).value;s.z=$("[data-z]",root)?.value||"";s.intersection=$("[data-intersection]",root).value;s.fields=$$('input[name=fields]:checked',root).map(x=>x.value);return validateDefinition(s)}
+  function validateDefinition(d){if(!d.board)return "Board is required.";if(!AXES.includes(d.x)||!AXES.includes(d.y))return "X and Y axes are required.";if(d.x===d.y)return "X and Y axes must be different.";if(d.z&&!AXES.includes(d.z))return "Z filter must be a safe scalar field.";return ""}
+  function renderBoardMatrix(){const root=$("#view"),bar=$("#appControls"),s={board:defaultBoard(),x:"platform",y:"stage",intersection:"title",fields:["platform","stage"],rendered:true};state=s;bar.innerHTML=matrixControls(s);root.innerHTML=`<section class="panel matrix-panel"><div data-message></div><div class="matrix-scroll"><div class="matrix-grid"></div></div></section>`;const draw=()=>{const e=readMatrixControls(bar,s);if(e)return showMessage(root,e);showMessage(root,"");s.rendered=true;drawMatrix($(".matrix-grid",root),s)};$("[data-go]",bar).onclick=draw;$("[data-save-matrix]",bar).onclick=()=>{const e=readMatrixControls(bar,s);if(e)return showMessage(root,e);showMessage(root,"");askMatrixName(s)};draw() }
+  function showMessage(root,msg,error=true){const n=$("[data-message]",root);if(n)n.innerHTML=msg?`<p class="message ${error?"error":""}">${esc(msg)}</p>`:"";else if(msg)notify(msg)}
+  function askMatrixName(source){const d=$("#nameDialog");d.innerHTML=`<form method="dialog" class="dialog-body"><div class="dialog-head"><h2>Save matrix</h2><button class="icon-btn" value="cancel" aria-label="Close">×</button></div><div class="control"><label>Matrix name<input name="name" required></label></div><div class="dialog-actions"><button class="btn" value="cancel">Cancel</button><button class="btn primary" value="save">Save</button></div></form>`;d.onclose=()=>{if(d.returnValue!=="save")return;const name=$("[name=name]",d).value.trim();if(!name)return;const now=new Date().toISOString();config.matrices.push({id:uid(),name,board:source.board,x:source.x,y:source.y,z:source.z||"",intersection:source.intersection||"title",fields:[...source.fields],createdAt:now,updatedAt:now,deletedAt:null});persist();notify("Matrix definition saved")};d.showModal()}
+
+  function cardColor(c){return c.cardColor||config.cardColors[0]?.color||config.theme.card}
+  function legacyCardMarkup(c,board,def){const primary=value(c,def.intersection||"title"),more=(def.fields||[]).filter(f=>f!==def.intersection).map(f=>`${f}: ${value(c,f)}`).join(" · ");return `<article class="card"><button class="card-title" type="button">${esc(primary)}</button>${more?`<div class="card-meta">${esc(more)}</div>`:""}</article>`}
+  function matrixValues(list,f){return [...new Set(list.map(c=>value(c,f)))].sort((a,b)=>a.localeCompare(b))}
+  function drawMatrix(root,def,zValue="",context="matrix"){let list=cards(def.board);if(def.z&&zValue)list=list.filter(c=>value(c,def.z)===zValue);const xs=matrixValues(list,def.x),ys=matrixValues(list,def.y);if(!xs.length||!ys.length){root.innerHTML='<div class="empty">No cards match this matrix.</div>';return}root.dataset.context=context;root.style.setProperty("--matrix-columns",xs.length);root.style.setProperty("--matrix-rows",ys.length);root.innerHTML=`<div class="matrix-corner" title="${esc(def.y)} by ${esc(def.x)}">${esc(def.y)} ↓ / ${esc(def.x)} →</div>${xs.map(x=>`<div class="matrix-header" title="${esc(x)}">${esc(x)}</div>`).join("")}`;ys.forEach(y=>{root.insertAdjacentHTML("beforeend",`<div class="matrix-rowhead" title="${esc(y)}">${esc(y)}</div>`);xs.forEach(x=>{const cs=list.filter(c=>value(c,def.x)===x&&value(c,def.y)===y).sort((a,b)=>(a.matrixPosition??a.position??0)-(b.matrixPosition??b.position??0));root.insertAdjacentHTML("beforeend",`<div class="matrix-cell" data-board="${esc(def.board)}" data-x="${esc(x)}" data-y="${esc(y)}" data-context="${context}" aria-label="${esc(x)}, ${esc(y)}: ${cs.length} cards">${cs.map(c=>cardMarkup(c,def.board,def)).join("")}</div>`)})});wireCards(root);wireDrops(root,".matrix-cell",(el,d)=>moveMatrixCard(d,def,el.dataset.x,el.dataset.y))}
+  function legacyWireCards(){}
+  function wireDrops(root,selector,fn){$$(selector,root).forEach(el=>{el.ondragover=e=>{e.preventDefault();el.classList.add("over")};el.ondragleave=()=>el.classList.remove("over");el.ondrop=e=>{e.preventDefault();el.classList.remove("over");if(drag)fn(el,drag)};el.onclick=e=>{if(touch&&!e.target.closest(".card")){const d=touch;touch=null;fn(el,d)}}})}
+  function setAxis(card,field,val){if(field==="stage"){card.stage=val;if("lane" in card)card.lane=val}else card[field]=val}
+  function normalize(board){const by={};cards(board).forEach(c=>(by[c.stage||c.lane||"Backlog"]??=[]).push(c));Object.values(by).forEach(list=>list.sort((a,b)=>(a.position??a.pos??0)-(b.position??b.pos??0)).forEach((c,i)=>{c.position=i+1;if("pos" in c)c.pos=i+1}))}
+  function updateIndex(names){const now=Date.now();names.forEach(n=>{const b=index.boards.find(x=>x.name===n);if(b){b.cardCount=cards(n).length;b.lastUpdated=now}})}
+  function moveMatrixCard(d,def,x,y){if(d.board!==def.board)return transferAcrossMatrices(d,def,x,y);const c=cards(def.board).find(c=>String(c.id)===String(d.id));if(!c)return;setAxis(c,def.x,x);setAxis(c,def.y,y);c.matrixPosition=0;c.updatedAt=new Date().toISOString();normalize(def.board);saveBoards([def.board],`Move ${c.title||c.id} in matrix`);rerender()}
+  function transferAcrossMatrices(d,def,x,y){const from=d.board,to=def.board;if(from===to)return moveMatrixCard(d,def,x,y);const source=cards(from),i=source.findIndex(c=>String(c.id)===String(d.id));if(i<0)return;if(cards(to).some(c=>String(c.id)===String(d.id)))return notify("Transfer blocked: destination already has this card ID.");const [c]=source.splice(i,1),destStages=stages(to);let lane=c.stage||c.lane;if(!destStages.includes(lane))lane=destStages[0]||"Backlog";c.stage=lane;if("lane" in c)c.lane=lane;setAxis(c,def.x,x);setAxis(c,def.y,y);c.position=0;if("pos" in c)c.pos=0;c.updatedAt=new Date().toISOString();cards(to).unshift(c);normalize(from);normalize(to);updateIndex([from,to]);saveBoards([from,to],`Move ${c.title||c.id} from ${from} to ${to}`,true);rerender()}
+
+  function renderCreate(editId=""){const root=$("#view"),editing=config.matrices.find(d=>d.id===editId),s=editing?{...editing,fields:[...editing.fields]}:{board:boards()[0]?.name||"",x:"platform",y:"stage",z:"",intersection:"title",fields:["platform","stage"]};root.innerHTML=head("Create Matrix","Define and manage reusable matrix definitions.")+`<section class="panel"><form id="defForm"><div class="control"><label>Name<input name="name" required value="${esc(s.name||"")}"></label></div>${matrixControls(s,{save:false,z:true})}</form><div data-message></div><div class="definition-list">${config.matrices.map(d=>`<div class="definition"><span><b>${esc(d.name)}</b><br><small>${esc(d.board)} · ${esc(d.x)} × ${esc(d.y)}${d.deletedAt?" · Deleted":""}</small></span>${d.deletedAt?"":`<button class="btn" data-edit="${d.id}">Edit</button><button class="btn danger" data-delete="${d.id}" aria-label="Soft delete ${esc(d.name)}">×</button>`}</div>`).join("")||'<div class="empty">No saved definitions.</div>'}</div></section>`;$("[data-go]",root).textContent=editing?"Update definition":"Create definition";$("[data-go]",root).onclick=()=>{const e=readMatrixControls(root,s),name=$("[name=name]",root).value.trim();if(e||!name)return showMessage(root,e||"Name is required.");const now=new Date().toISOString();if(editing)Object.assign(editing,s,{name,updatedAt:now});else config.matrices.push({...s,id:uid(),name,createdAt:now,updatedAt:now,deletedAt:null});persist();renderCreate()};$$('[data-edit]',root).forEach(b=>b.onclick=()=>renderCreate(b.dataset.edit));$$('[data-delete]',root).forEach(b=>b.onclick=()=>{const d=config.matrices.find(x=>x.id===b.dataset.delete);d.deletedAt=new Date().toISOString();d.updatedAt=d.deletedAt;persist();renderCreate()})}
+  function renderUse(){const root=$("#view"),defs=activeDefs(),id=state.definitionId&&defs.some(d=>d.id===state.definitionId)?state.definitionId:defs[0]?.id,def=defs.find(d=>d.id===id);state.definitionId=id;root.innerHTML=head("Use Matrix","Open a saved definition and move cards.")+`<section class="panel"><div class="toolbar"><div class="control"><label>Saved matrix<select data-def>${options(defs.map(d=>d.id),id).replaceAll(/>([^<]+)</g,(m,v)=>`>${esc(defs.find(d=>d.id===v)?.name||v)}<`)}</select></label></div>${def?.z?`<div class="control"><label>${esc(def.z)} filter<select data-zvalue>${options(matrixValues(cards(def.board),def.z),"")}</select></label></div>`:""}</div><div class="matrix-scroll"><div class="matrix-grid"></div></div></section>`;$("[data-def]",root)?.addEventListener("change",e=>{state.definitionId=e.target.value;renderUse()});const draw=()=>def&&drawMatrix($(".matrix-grid",root),def,$("[data-zvalue]",root)?.value||"");$("[data-zvalue]",root)?.addEventListener("change",draw);draw()}
+  function defSelect(side,defs,id){return `<div class="control"><label>Matrix ${side}<select data-matrix="${side}">${defs.map(d=>`<option value="${d.id}" ${d.id===id?"selected":""}>${esc(d.name)}</option>`).join("")}</select></label></div>`}
+  function renderMashup(){const root=$("#view"),defs=activeDefs();state.one=state.one||defs[0]?.id;state.two=state.two||defs[1]?.id||defs[0]?.id;const one=defs.find(d=>d.id===state.one),two=defs.find(d=>d.id===state.two);root.innerHTML=head("Create Matrix Mashup","Move cards—not copies—between independently scrolling matrices.")+`<div class="mashup"><section class="panel">${defSelect("one",defs,state.one)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="one"></div></div></section><section class="panel">${defSelect("two",defs,state.two)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="two"></div></div></section></div>`;$$('[data-matrix]',root).forEach(s=>s.onchange=()=>{state[s.dataset.matrix]=s.value;renderMashup()});if(one)drawMatrix($('[data-grid=one]',root),one,"","mashup");if(two)drawMatrix($('[data-grid=two]',root),two,"","mashup")}
+
+  function renderTransfer(){const root=$("#view");state.left=state.left||boards()[0]?.name||"";state.right=state.right||boards().find(b=>b.name!==state.left)?.name||"";root.innerHTML=head("Card Transfer","Tap a card then a destination lane, or drag it.")+`<div class="split"><section class="panel" data-side="left"></section><section class="panel" data-side="right"></section></div>`;["left","right"].forEach(side=>drawPane(root,side));wireCards(root);wireDrops(root,".lane",(el,d)=>transferCard(d.board,el.dataset.board,d.id,el.dataset.stage))}
+  function drawPane(root,side){const board=state[side],other=state[side==="left"?"right":"left"],pane=$(`[data-side=${side}]`,root);pane.innerHTML=`<div class="control"><label>${side} board<select>${boards().map(b=>`<option value="${esc(b.name)}" ${b.name===board?"selected":""} ${b.name===other?"disabled":""}>${esc(b.name)}</option>`).join("")}</select></label></div><div class="mini-board">${stages(board).map(st=>`<div class="lane" data-board="${esc(board)}" data-stage="${esc(st)}"><h3>${esc(st)}</h3>${cards(board).filter(c=>(c.stage||c.lane||"Backlog")===st).sort((a,b)=>(a.position??a.pos??0)-(b.position??b.pos??0)).map(c=>cardMarkup(c,board,{intersection:"title",fields:["platform","stage"]})).join("")}</div>`).join("")}</div>`;$("select",pane).onchange=e=>{state[side]=e.target.value;renderTransfer()}}
+  function transferCard(from,to,id,explicitStage){if(from===to)return notify("Choose two different boards.");const src=cards(from),i=src.findIndex(c=>String(c.id)===String(id));if(i<0)return;if(cards(to).some(c=>String(c.id)===String(id)))return notify("Transfer blocked: duplicate card ID.");const [c]=src.splice(i,1),destStages=stages(to),old=c.stage||c.lane;c.stage=explicitStage||(destStages.includes(old)?old:destStages[0]||"Backlog");if("lane" in c)c.lane=c.stage;c.position=0;if("pos" in c)c.pos=0;c.updatedAt=new Date().toISOString();cards(to).unshift(c);normalize(from);normalize(to);updateIndex([from,to]);saveBoards([from,to],`Move ${c.title||c.id} from ${from} to ${to}`,true);renderTransfer()}
+  function showColorMenu(x,y,board,id){$(".color-menu")?.remove();const m=document.createElement("div");m.className="color-menu";m.setAttribute("role","menu");m.style.left=`${Math.min(x,innerWidth-205)}px`;m.style.top=`${Math.min(y,innerHeight-280)}px`;m.innerHTML=config.cardColors.map(p=>`<button class="color-choice" data-color="${esc(p.color)}"><span class="swatch" style="background:${esc(p.color)}"></span>${esc(p.name||p.color)}</button>`).join("")+`<label class="color-choice"><input type="color" value="#64748b"> Custom color</label>`;document.body.append(m);const apply=color=>{const c=cards(board).find(x=>String(x.id)===String(id));if(c){c.cardColor=color;c.updatedAt=new Date().toISOString();saveBoards([board],`Set card color for ${c.title||c.id}`);rerender()}m.remove()};$$('[data-color]',m).forEach(b=>b.onclick=()=>apply(b.dataset.color));$('input[type=color]',m).onchange=e=>apply(e.target.value);setTimeout(()=>document.addEventListener("pointerdown",e=>{if(!m.contains(e.target))m.remove()},{once:true}),0)}
+
+  function renderConfig(){const root=$("#view");root.innerHTML=head("Configuration","Portal, GitHub, theme, presets, and complete configuration backup.")+`<div class="config-grid"><section class="panel"><h2>Portal & GitHub</h2><form id="settings"><div class="control"><label>Portal name<input name="portalName" value="${esc(config.portalName)}"></label></div><div class="control"><label>GitHub owner<input name="owner" value="${esc(config.github.owner)}"></label></div><div class="control"><label>Repository<input name="repo" value="${esc(config.github.repo)}"></label></div><div class="control"><label>Branch<input name="branch" value="${esc(config.github.branch)}"></label></div><div class="control"><label>GitHub PAT<input name="pat" type="password" value="${esc(config.github.pat)}"><button class="btn" type="button" data-show-pat>Show PAT</button></label></div><button class="btn primary" type="submit">Save settings</button></form><hr><h2>Configuration JSON</h2><p class="warning"><b>Protect exports:</b> the downloaded file contains your GitHub PAT.</p><div class="actions"><button class="btn" data-export>Export Configuration JSON</button><label class="btn">Import Configuration JSON<input data-import type="file" accept="application/json" hidden></label></div><div data-import-message></div></section><section class="panel"><h2>UI colors</h2><div class="theme-list">${Object.entries(config.theme).map(([key,color])=>colorRow(key,THEME_NAMES[key],color,"theme")).join("")}</div><button class="btn" data-restore>Restore defaults</button><h2>Card-color presets</h2><div class="preset-list">${config.cardColors.map((p,i)=>presetRow(p,i)).join("")}</div><button class="btn" data-add-color>Add preset</button></section></div>`;
+    $("#settings",root).onsubmit=e=>{e.preventDefault();const f=new FormData(e.target);config.portalName=f.get("portalName").trim()||"Mello";config.github={owner:f.get("owner").trim(),repo:f.get("repo").trim(),branch:f.get("branch").trim()||"main",pat:f.get("pat").trim()};persist();notify("Settings saved")};$("[data-show-pat]",root).onclick=e=>{const i=$("[name=pat]",root);i.type=i.type==="password"?"text":"password";e.target.textContent=i.type==="password"?"Show PAT":"Hide PAT"};wireColors(root);const a=matrixPrefs().appearance,out=document.createElement('div');out.innerHTML=`<h2>Appearance</h2><div class=appearance-list><div class=appearance-row><strong>Colors</strong><label>Top ribbon<input type=color data-a=ribbon value=${a.ribbon}></label><label>Separators<input type=color data-a=separator value=${a.separator}></label></div>${[['Card','cardText','cardFontSize'],['Panel','panelText','panelFontSize'],['Matrix cells','matrixText','matrixFontSize'],['Headers','headerText','headerFontSize']].map(([n,c,z])=>`<div class=appearance-row><strong>${n}</strong><label>Font color<input type=color data-a=${c} value=${a[c]}></label><label>Font size<input type=number min=8 max=32 data-a=${z} value=${a[z]}></label></div>`).join('')}</div>`;$('.theme-list',root).after(out);const kanbanAppearance=document.createElement('div');kanbanAppearance.innerHTML=`<h2>Kanban appearance</h2><div class=control><label>Lane layout<select data-kanban-layout>${options(['auto','horizontal','vertical'],a.kanbanLayout)}</select></label></div>`;out.after(kanbanAppearance);$('[data-kanban-layout]',kanbanAppearance).onchange=e=>{a.kanbanLayout=e.target.value;persist()};$$('[data-a]',out).forEach(i=>i.oninput=()=>{a[i.dataset.a]=i.dataset.a.endsWith('Size')?Math.max(8,Math.min(32,+i.value)):i.value;persist()});$("[data-export]",root).onclick=exportConfig;$("[data-import]",root).onchange=importFile;$("[data-restore]",root).onclick=()=>confirmAction("Restore default UI colors and card presets?",()=>{config.theme={...THEME};config.cardColors=PRESETS.map(x=>({...x}));persist();renderConfig()});$("[data-add-color]",root).onclick=()=>{config.cardColors.push({name:"New preset",color:"#64748b"});persist();renderConfig()}}
+  function colorRow(key,name,color,type){return `<div class="color-row" data-${type}="${esc(key)}"><span class="swatch" style="background:${esc(color)}" aria-label="Current ${esc(name)}"></span><label>${esc(name)}<input type="text" value="${esc(color)}" aria-label="${esc(name)} hex"></label><input type="color" value="${esc(color)}" aria-label="Pick ${esc(name)}"></div>`}
+  function presetRow(p,i){return `<div class="color-row" data-preset="${i}"><button class="btn" data-up aria-label="Move preset up">↑</button><button class="btn" data-down aria-label="Move preset down">↓</button><span class="swatch" style="background:${esc(p.color)}"></span><input data-name value="${esc(p.name||"")}" aria-label="Preset name"><input data-hex value="${esc(p.color)}" aria-label="Preset hex"><input type="color" value="${esc(p.color)}" aria-label="Preset color"><button class="btn danger" data-remove aria-label="Remove preset">×</button></div>`}
+  function wireColors(root){$$('[data-theme]',root).forEach(row=>{const key=row.dataset.theme,text=$('input[type=text]',row),pick=$('input[type=color]',row),swatch=$(".swatch",row);const apply=v=>{if(!validHex(v)){text.setAttribute("aria-invalid","true");return}text.removeAttribute("aria-invalid");config.theme[key]=v.toLowerCase();pick.value=v;swatch.style.background=v;persist()};text.onchange=()=>apply(text.value);pick.oninput=()=>{text.value=pick.value;apply(pick.value)}});$$('[data-preset]',root).forEach(row=>{const i=+row.dataset.preset,name=$('[data-name]',row),hex=$('[data-hex]',row),pick=$('input[type=color]',row),swatch=$(".swatch",row);name.onchange=()=>{config.cardColors[i].name=name.value;persist()};const apply=v=>{if(!validHex(v)){hex.setAttribute("aria-invalid","true");return}hex.removeAttribute("aria-invalid");config.cardColors[i].color=v;hex.value=v;pick.value=v;swatch.style.background=v;persist()};hex.onchange=()=>apply(hex.value);pick.oninput=()=>apply(pick.value);$('[data-remove]',row).onclick=()=>{config.cardColors.splice(i,1);persist();renderConfig()};$('[data-up]',row).onclick=()=>reorderPreset(i,i-1);$('[data-down]',row).onclick=()=>reorderPreset(i,i+1)})}
+  function reorderPreset(from,to){if(to<0||to>=config.cardColors.length)return;config.cardColors.splice(to,0,config.cardColors.splice(from,1)[0]);persist();renderConfig()}
+  function confirmAction(message,fn){const d=$("#confirmDialog");d.innerHTML=`<form method="dialog" class="dialog-body"><h2>Confirm change</h2><p>${esc(message)}</p><div class="dialog-actions"><button class="btn" value="cancel">Cancel</button><button class="btn danger" value="yes">Confirm</button></div></form>`;d.onclose=()=>{if(d.returnValue==="yes")fn()};d.showModal()}
+  function exportConfig(){const blob=new Blob([JSON.stringify(config,null,2)+"\n"],{type:"application/json"}),a=document.createElement("a");a.href=URL.createObjectURL(blob);a.download=`${slug(config.portalName)||"program"}-configuration.json`;a.click();URL.revokeObjectURL(a.href)}
+  function validateImport(x){if(!x||typeof x!=="object"||x.version!==3)return "Expected a version 3 configuration object.";if(typeof x.portalName!=="string"||!x.github||typeof x.github!=="object")return "Portal name or GitHub settings are invalid.";if(!x.theme||Object.keys(THEME).some(k=>!validHex(x.theme[k])))return "Every theme color must be a six-digit hex color.";if(!Array.isArray(x.cardColors)||x.cardColors.some(p=>typeof p.name!=="string"||!validHex(p.color)))return "Card-color presets are invalid.";if(!Array.isArray(x.matrices)||x.matrices.some(d=>typeof d.id!=="string"||typeof d.name!=="string"||validateDefinition(d)))return "Matrix definitions are invalid.";if(!APP_NAMES[x.selectedApp]||typeof x.sidebarCollapsed!=="boolean")return "Selected application or sidebar state is invalid.";return ""}
+  async function importFile(e){const out=$("[data-import-message]",$("#view"));try{pendingImport=JSON.parse(await e.target.files[0].text());const error=validateImport(pendingImport);if(error)throw new Error(error);confirmAction("Replace all portal settings, matrix definitions, theme, and PAT with this file?",()=>{config=pendingImport;persist();setSidebar(!config.sidebarCollapsed);openApp(config.selectedApp);notify("Configuration imported")})}catch(err){out.innerHTML=`<p class="message error">Import failed: ${esc(err.message)}</p>`}finally{e.target.value=""}}
+
+  async function githubFetch(url,options={}){const token=config.github.pat?.trim()||localStorage.getItem(TOKEN_KEY)?.trim();if(!token)throw new Error("Add a GitHub PAT in Configuration and retry.");const r=await fetch(url,{...options,headers:{Accept:"application/vnd.github+json",Authorization:`Bearer ${token}`,...options.headers}});if(!r.ok)throw new Error(`GitHub returned ${r.status} ${r.statusText}`);return r.status===204?{}:r.json()}
+  const b64=s=>btoa(unescape(encodeURIComponent(s)));
+  async function putJson(path,data,message){const base=`https://api.github.com/repos/${encodeURIComponent(config.github.owner)}/${encodeURIComponent(config.github.repo)}/contents/${path.split("/").map(encodeURIComponent).join("/")}`,ref=`?ref=${encodeURIComponent(config.github.branch)}`;let sha;try{const remote=await githubFetch(base+ref);sha=remote.sha;const current=JSON.parse(decodeURIComponent(escape(atob(remote.content.replace(/\s/g,''))))),remoteTime=Number(current.lastModified||current.lastUpdated||0),localTime=Number(data.lastModified||data.lastUpdated||0);if(remoteTime>localTime)throw new Error(`${path} changed on GitHub; reload before saving`)}catch(e){if(!e.message.includes("404"))throw e}if(data&&typeof data==='object'&&!Array.isArray(data))data.lastModified=Date.now();await githubFetch(base,{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({message,content:b64(JSON.stringify(data,null,2)+"\n"),branch:config.github.branch,...(sha?{sha}:{})})})}
+  function saveBoards(names,message,withIndex=false){const unique=[...new Set(names)];saveQueue=saveQueue.catch(()=>{}).then(async()=>{sync("Saving…");for(const name of unique)await putJson(boardPath(name),boardData[name],message);if(withIndex)await putJson(FILES.index,index,message);sync("Saved");notify("Saved to GitHub")}).catch(e=>{sync(`Save failed — ${e.message}`,"error");notify("Save failed. Fix Configuration and retry by making another update.")});return saveQueue}
+
+  /* Mello interaction model -------------------------------------------------
+     Matrix axis order, lane visibility, and card visibility are deliberately
+     separate persisted maps. Closing a lane never changes any card's state. */
+  function melloState(){
+    config.matrixOrder ||= {};
+    config.cardOpen ||= {};
+    config.laneOpen ||= {};
+    return config;
   }
-}
+  function cardStateKey(board,id){return `${board}::${id}`}
+  function laneStateKey(board,stage){return `${board}::${stage}`}
+  function allFieldValues(board,field){return [...new Set(cards(board).map(c=>value(c,field)).filter(v=>v!=="Unassigned"))].sort()}
+  function matrixPrefs(){config.matrixOrder||={};config.appearance={ribbon:'#64748b',cardText:'#142033',cardFontSize:12,panelText:'#142033',panelFontSize:14,matrixText:'#142033',matrixFontSize:11,headerText:'#142033',headerFontSize:11,separator:'#dfe4ec',kanbanLayout:'auto',...(config.appearance||{})};return config}
+  function orderKey(def,axis){return `${def.id||def.board}::${axis}::${def[axis]}`}
+  function orderedValues(list,field,def,axis){const values=[...new Set(list.map(c=>value(c,field)))],saved=matrixPrefs().matrixOrder[orderKey(def,axis)]||[];return [...saved.filter(v=>values.includes(v)),...values.filter(v=>!saved.includes(v)).sort((a,b)=>a.localeCompare(b))]}
+  function applyAppearance(){const a=matrixPrefs().appearance,map={ribbon:'ribbon',cardText:'card-text',cardFontSize:'card-font-size',panelText:'panel-text',panelFontSize:'panel-font-size',matrixText:'matrix-text',matrixFontSize:'matrix-font-size',headerText:'header-text',headerFontSize:'header-font-size',separator:'separator'};Object.entries(map).forEach(([k,v])=>document.documentElement.style.setProperty(`--${v}`,k.endsWith('Size')?`${a[k]}px`:a[k]))}
+  const persistBase=persist;persist=function(){persistBase();applyAppearance()};
+  function cardMarkup(c,board,def){const primary=value(c,def.intersection||'title'),more=(def.fields||[]).filter(f=>f!==def.intersection).map(f=>`${f}: ${value(c,f)}`).join(' · ');return `<article class="card" draggable="true" tabindex="0" data-card="${esc(c.id)}" data-board="${esc(board)}" style="${c.cardColor?`--ribbon:${esc(c.cardColor)}`:''}"><button class="card-title" type="button">${esc(primary)}</button>${more?`<div class="card-meta">${esc(more)}</div>`:''}</article>`}
+  function openCardEditor(board,id){const c=cards(board).find(x=>String(x.id)===String(id));if(!c)return;const d=$('#cardDialog');d.innerHTML=`<form method="dialog" class="dialog-body" novalidate><div class="dialog-head"><h2>Edit card</h2><button class="icon-btn" value="close" aria-label="Save and close">×</button></div><div class="dialog-grid"><div class="control span-2"><label>Title<input name="title" required value="${esc(c.title)}"></label></div><div class="control"><label>Platform<input name="platform" value="${esc(c.platform)}"></label></div><div class="control"><label>Stage<select name="stage">${options(stages(board),c.stage||c.lane)}</select></label></div><div class="control"><label>Lineage<input name="lineage" value="${esc(c.lineage)}"></label></div><div class="control"><label>Status<select name="statusColor"><option value="">No status</option>${options(['green','yellow','red','blue'],c.statusColor)}</select></label></div><div class="control span-2"><label>Tags<input name="tags" value="${esc((c.tags||[]).join(', '))}"></label></div><div class="control span-2"><label>Development link<input name="dev" type="url" value="${esc(c.dev)}"></label></div><div class="control span-2"><label>Live link<input name="live" type="url" value="${esc(c.live)}"></label></div><div class="control span-2"><label>Notes<textarea name="notes">${esc(c.notes)}</textarea></label></div></div><div class="dialog-actions"><button class="btn primary" value="close">Save & close</button></div></form>`;const form=$('form',d);let dirty=false;const save=()=>{if(!dirty||!form.reportValidity())return;const f=new FormData(form);Object.assign(c,{title:f.get('title').trim(),platform:f.get('platform').trim(),stage:f.get('stage'),lineage:f.get('lineage').trim(),statusColor:f.get('statusColor'),tags:f.get('tags').split(',').map(x=>x.trim()).filter(Boolean),dev:f.get('dev').trim(),live:f.get('live').trim(),notes:f.get('notes'),updatedAt:new Date().toISOString()});if('lane' in c)c.lane=c.stage;dirty=false;saveBoards([board],`Update ${c.title||c.id}`);notify('Card saved')};form.oninput=()=>dirty=true;form.addEventListener('focusout',e=>{if(!form.contains(e.relatedTarget))save()});d.onclose=()=>{save();rerender()};d.showModal()}
+  function wireCards(root){$$('.card',root).forEach(el=>{$('.card-title',el).onclick=e=>{e.stopPropagation();openCardEditor(el.dataset.board,el.dataset.card)};el.ondragstart=()=>{drag={board:el.dataset.board,id:el.dataset.card};el.classList.add('selected')};el.ondragend=()=>{drag=null;el.classList.remove('selected')}})}
+  function drawMatrix(root,def,zValue='',context='matrix'){let list=cards(def.board);if(def.z&&zValue)list=list.filter(c=>value(c,def.z)===zValue);const xs=orderedValues(list,def.x,def,'x'),ys=orderedValues(list,def.y,def,'y');if(!xs.length||!ys.length){root.innerHTML='<div class="empty">No cards match this matrix.</div>';return}root.dataset.context=context;root.style.setProperty('--matrix-columns',xs.length);root.style.setProperty('--matrix-rows',ys.length);root.innerHTML=`<div class="matrix-corner"><button class="board-chip" type="button" data-board-axis>${esc(def.board)}</button></div>${xs.map(x=>`<div class="matrix-header" draggable="true" data-axis="x" data-value="${esc(x)}">${esc(x)}</div>`).join('')}`;ys.forEach(y=>{root.insertAdjacentHTML('beforeend',`<div class="matrix-rowhead" draggable="true" data-axis="y" data-value="${esc(y)}">${esc(y)}</div>`);xs.forEach(x=>{const cs=list.filter(c=>value(c,def.x)===x&&value(c,def.y)===y).sort((a,b)=>(a.matrixPosition??a.position??0)-(b.matrixPosition??b.position??0));root.insertAdjacentHTML('beforeend',`<div class="matrix-cell" data-board="${esc(def.board)}" data-x="${esc(x)}" data-y="${esc(y)}">${cs.map(c=>cardMarkup(c,def.board,def)).join('')}</div>`)})});wireCards(root);wireDrops(root,'.matrix-cell',(el,d)=>moveMatrixCard(d,def,el.dataset.x,el.dataset.y));wireAxisOrder(root,def,xs,ys,zValue)}
+  function wireAxisOrder(root,def,xs,ys,zValue){let moving;$$('[data-axis]',root).forEach(el=>{el.ondragstart=e=>{moving={axis:el.dataset.axis,value:el.dataset.value};e.stopPropagation();el.classList.add('axis-dragging')};el.ondragover=e=>{if(moving?.axis===el.dataset.axis){e.preventDefault();e.stopPropagation();el.classList.add('axis-drop')}};el.ondragleave=()=>el.classList.remove('axis-drop');el.ondrop=e=>{if(!moving||moving.axis!==el.dataset.axis)return;e.preventDefault();e.stopPropagation();const vals=[...(moving.axis==='x'?xs:ys)],from=vals.indexOf(moving.value),to=vals.indexOf(el.dataset.value);vals.splice(to,0,vals.splice(from,1)[0]);matrixPrefs().matrixOrder[orderKey(def,moving.axis)]=vals;persist();drawMatrix(root,def,zValue,root.dataset.context)};el.ondragend=()=>moving=null})}
+  function renderBuilder(){const root=$("#view");root.innerHTML=head("New Board / Card","Start a standard board or add a card to any available board.")+`<section class="panel board-builder"><h2>Create a board</h2><form data-new-board><div class="control"><label>Board name<input name="name" required placeholder="new-board"></label></div><p class="message">Default platforms: ${esc(DEFAULT_BOARD.platforms.join(', '))}<br>Default stages: ${esc(DEFAULT_BOARD.stages.join(', '))}<br>Layout: Horizontal</p><div class="builder-actions"><button class="btn primary">Create Board</button></div></form><hr class="builder-divider"><h2>Create a card</h2><form data-new-card><div class="form-grid"><div class="control wide"><label>Board<select name="board" required>${boardOptions(defaultBoard())}</select></label></div><div class="control wide"><label>Title<input name="title" required></label></div><div class="control"><label>Platform<select name="platform">${options(DEFAULT_BOARD.platforms,'Default')}</select></label></div><div class="control"><label>Stage<select name="stage">${options(stages(defaultBoard()),stages(defaultBoard())[0])}</select></label></div><div class="control wide"><label>Notes<textarea name="notes"></textarea></label></div></div><div class="builder-actions"><button class="btn primary">Create Card</button></div></form></section>`;const cardForm=$('[data-new-card]',root),boardSelect=$('[name=board]',cardForm),stageSelect=$('[name=stage]',cardForm);boardSelect.onchange=()=>stageSelect.innerHTML=options(stages(boardSelect.value),stages(boardSelect.value)[0]);$('[data-new-board]',root).onsubmit=async e=>{e.preventDefault();const name=e.target.elements.name.value.trim(),key=slug(name);if(!key)return notify('Enter a valid board name.');if(index.boards.some(b=>slug(b.name)===key))return notify('That board already exists.');const now=Date.now();boardData[name]={version:1,cards:[],archive:[],platforms:[...DEFAULT_BOARD.platforms],stages:[...DEFAULT_BOARD.stages],layout:DEFAULT_BOARD.layout,collapsed:{},cardCollapsed:{},lastModified:now};index.boards.push({name,archived:false,lastUpdated:now,createdAt:now,cardCount:0,phase:'dev',phaseUpdatedAt:now,stage:'concept',stageUpdatedAt:now});index.activeBoard=name;await saveBoards([name],`Create board ${name}`,true);state={};renderBuilder()};cardForm.onsubmit=async e=>{e.preventDefault();const f=new FormData(e.target),board=f.get('board'),stage=f.get('stage')||stages(board)[0]||'Backlog',now=Date.now(),title=f.get('title').trim();if(!board||!title)return;cards(board).push({id:uid(),title,platform:f.get('platform')||'Default',stage,lineage:'',statusColor:'',cardColor:'',dev:'',live:'',tags:[],notes:f.get('notes'),files:[],position:cards(board).filter(c=>(c.stage||c.lane)===stage).length+1,createdAt:now,updatedAt:now});updateIndex([board]);await saveBoards([board],`Create ${title}`,true);e.target.reset();notify('Card created')}}
 
-/* ---- github write ---- */
-async function ghFetch(url,opt={}){
-  const token=(cfg.github.pat||localStorage.getItem(TOKEN_KEY)||"").trim();
-  if(!token) throw new Error("Add a GitHub PAT in Settings to save.");
-  const r=await fetch(url,{...opt,headers:{Accept:"application/vnd.github+json",Authorization:"Bearer "+token,...(opt.headers||{})}});
-  if(!r.ok) throw new Error(`GitHub ${r.status}`);
-  return r.status===204?{}:r.json();
-}
-const b64 = s=>btoa(unescape(encodeURIComponent(s)));
-async function putJson(path,data,message){
-  const {owner,repo,branch}=cfg.github;
-  const base=`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path.split("/").map(encodeURIComponent).join("/")}`;
-  let sha;
-  try{ const r=await ghFetch(base+`?ref=${encodeURIComponent(branch)}`); sha=r.sha; }catch(e){ if(!String(e.message).includes("404"))throw e; }
-  if(data&&typeof data==="object"&&!Array.isArray(data)) data.lastModified=Date.now();
-  await ghFetch(base,{method:"PUT",headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({message,content:b64(JSON.stringify(data,null,2)+"\n"),branch,...(sha?{sha}:{})})});
-}
-function refreshIndexRecord(name){
-  const b=findBoard(name); if(!b)return;
-  const cs=cards(name); let last=null;
-  cs.forEach(c=>{if(!last||(+c.updatedAt||0)>(+last.updatedAt||0))last=c;});
-  b.cardCount=cs.length; b.lastUpdated=Date.now();
-  b.lastCardUpdatedId=last?.id||""; b.lastCardUpdatedAt=+last?.updatedAt||0;
-}
-function saveBoards(names,message,withIndex=false){
-  const uniq=[...new Set(names.filter(Boolean))];
-  uniq.forEach(refreshIndexRecord);
-  saveQueue = saveQueue.catch(()=>{}).then(async()=>{
-    sync("Saving…");
-    for(const n of uniq) await putJson(boardPath(n), boardData[n], message);
-    if(withIndex) await putJson(FILES.index, index, message);
-    sync("Saved","ok");
-  }).catch(e=>{ sync("Save failed — "+e.message,"err"); toast("Save failed: "+e.message,true); });
-  return saveQueue;
-}
+  /* Program integration: matrix definitions own the ribbon and board management
+     is a self-contained page.  The standalone kanban surface can therefore be
+     retired without losing board/card workflows. */
+  function matrixRibbon(defs,s){return `<div class="command"><div class="control"><label data-label="Matrix">Matrix<select data-def>${defs.map(d=>`<option value="${d.id}" ${d.id===s.id?'selected':''}>${esc(d.name)}</option>`).join('')}<option value="">＋ New matrix</option></select></label></div><div class="control"><label data-label="Board">Board<select data-board>${boardOptions(s.board)}</select></label></div><div class="control"><label data-label="Columns">Columns<select data-x>${axisOptions(s.x)}</select></label></div><div class="control"><label data-label="Rows">Rows<select data-y>${axisOptions(s.y)}</select></label></div><div class="control"><label data-label="Center">Center<select data-intersection>${options(DISPLAY,s.intersection||'title')}</select></label></div>${fieldsPopover(s.fields)}${s.id?'<button class="btn danger" data-delete-matrix aria-label="Delete matrix">×</button>':''}</div>`}
+  function deletedMatrices(){return config.matrices.filter(d=>d.deletedAt)}
+  function matrixTrash(){const gone=deletedMatrices();return `<details class="trash-panel panel"><summary>▾ Deleted matrices (${gone.length})</summary>${gone.map(d=>`<div class="trash-item"><span>${esc(d.name)}</span><button class="btn" data-restore-matrix="${d.id}">Restore</button><button class="btn danger" data-purge-matrix="${d.id}">Delete forever</button></div>`).join('')||'<p class="empty">Recycle bin is empty.</p>'}</details>`}
+  function renderBoardMatrix(){const root=$("#view"),bar=$("#appControls"),defs=activeDefs();let saved=defs.find(d=>d.id===config.selectedMatrix);if(!saved){saved=defs[0]||{id:'',name:'New matrix',board:defaultBoard(),x:'platform',y:'stage',z:'',intersection:'title',fields:['platform','stage']};config.selectedMatrix=saved.id||''}state.def={...saved,fields:[...(saved.fields||[])]};const s=state.def;bar.innerHTML=matrixRibbon(defs,s);root.innerHTML=matrixTrash()+`<section class="panel matrix-panel"><h1 class="matrix-title"><input data-matrix-name aria-label="Matrix name" value="${esc(s.name)}"></h1><div data-message></div><div class="matrix-scroll"><div class="matrix-grid"></div></div></section>`;
+    const commit=()=>{readMatrixControls(bar,s);s.name=$('[data-matrix-name]',root).value.trim()||'Untitled matrix';const error=validateDefinition(s);if(error)return showMessage(root,error);const now=new Date().toISOString();if(!s.id){s.id=uid();s.createdAt=now;s.deletedAt=null;config.matrices.push({...s,fields:[...s.fields]});config.selectedMatrix=s.id}else Object.assign(config.matrices.find(d=>d.id===s.id),s,{updatedAt:now});persist();showMessage(root,'');drawMatrix($('.matrix-grid',root),s)};
+    $$('select,input[type=checkbox]',bar).forEach(el=>el.onchange=commit);$('[data-matrix-name]',root).onchange=commit;$('[data-matrix-name]',root).onblur=commit;$('[data-def]',bar).onchange=e=>{config.selectedMatrix=e.target.value;persist();renderBoardMatrix()};$('[data-delete-matrix]',bar)?.addEventListener('click',()=>confirmAction(`Move ${s.name} to the matrix recycle bin?`,()=>{const d=config.matrices.find(x=>x.id===s.id);d.deletedAt=new Date().toISOString();config.selectedMatrix='';persist();renderBoardMatrix()}));$$('[data-restore-matrix]',root).forEach(b=>b.onclick=()=>{const d=config.matrices.find(x=>x.id===b.dataset.restoreMatrix);d.deletedAt=null;persist();renderBoardMatrix()});$$('[data-purge-matrix]',root).forEach(b=>b.onclick=()=>confirmAction('Permanently delete this matrix? This cannot be undone.',()=>{config.matrices=config.matrices.filter(x=>x.id!==b.dataset.purgeMatrix);persist();renderBoardMatrix()}));if(s.board&&s.x&&s.y)drawMatrix($('.matrix-grid',root),s)}
+  function openBoardSurface(board,newTab=false){const url=`program.html?app=builder&board=${encodeURIComponent(board)}`;if(newTab)return window.open(url,'_blank','noopener');state.manageBoard=board;openApp('builder')}
+  function drawMatrix(root,def,zValue='',context='matrix'){let list=cards(def.board);if(def.z&&zValue)list=list.filter(c=>value(c,def.z)===zValue);const xs=orderedValues(list,def.x,def,'x'),ys=orderedValues(list,def.y,def,'y');if(!xs.length||!ys.length){root.innerHTML='<div class="empty">No cards match this matrix.</div>';return}root.dataset.context=context;root.style.setProperty('--matrix-columns',xs.length);root.style.setProperty('--matrix-rows',ys.length);root.innerHTML=`<div class="matrix-corner"><button class="board-chip" type="button" data-board-axis>${esc(def.board)}</button></div>${xs.map(x=>`<div class="matrix-header" draggable="true" data-axis="x" data-value="${esc(x)}">${esc(x)}</div>`).join('')}`;ys.forEach(y=>{root.insertAdjacentHTML('beforeend',`<div class="matrix-rowhead" draggable="true" data-axis="y" data-value="${esc(y)}">${esc(y)}</div>`);xs.forEach(x=>{const cs=list.filter(c=>value(c,def.x)===x&&value(c,def.y)===y).sort((a,b)=>(a.matrixPosition??a.position??0)-(b.matrixPosition??b.position??0));root.insertAdjacentHTML('beforeend',`<div class="matrix-cell" data-board="${esc(def.board)}" data-x="${esc(x)}" data-y="${esc(y)}">${cs.map(c=>cardMarkup(c,def.board,def)).join('')}</div>`)})});wireCards(root);wireDrops(root,'.matrix-cell',(el,d)=>moveMatrixCard(d,def,el.dataset.x,el.dataset.y));wireAxisOrder(root,def,xs,ys,zValue);let tap;const chip=$('[data-board-axis]',root);chip.onclick=()=>{clearTimeout(tap);tap=setTimeout(()=>{[def.x,def.y]=[def.y,def.x];const saved=config.matrices.find(d=>d.id===def.id);if(saved)Object.assign(saved,{x:def.x,y:def.y,updatedAt:new Date().toISOString()});persist();config.selectedApp==='mashup'?renderMashup():renderBoardMatrix()},240)};chip.ondblclick=e=>{e.preventDefault();clearTimeout(tap);openBoardSurface(def.board,true)}}
+  function wireAxisOrder(root,def,xs,ys,zValue){$$('[data-axis]',root).forEach(el=>{el.ondragstart=e=>{state.axisDrag={def,axis:el.dataset.axis,value:el.dataset.value};e.stopPropagation();el.classList.add('axis-dragging')};el.ondragover=e=>{if(state.axisDrag?.axis===el.dataset.axis){e.preventDefault();e.stopPropagation();el.classList.add('axis-drop')}};el.ondragleave=()=>el.classList.remove('axis-drop');el.ondrop=e=>{const moving=state.axisDrag;if(!moving||moving.axis!==el.dataset.axis)return;e.preventDefault();e.stopPropagation();el.classList.remove('axis-drop');if(moving.def.id===def.id){const vals=[...(moving.axis==='x'?xs:ys)],from=vals.indexOf(moving.value),to=vals.indexOf(el.dataset.value);vals.splice(to,0,vals.splice(from,1)[0]);matrixPrefs().matrixOrder[orderKey(def,moving.axis)]=vals;persist();drawMatrix(root,def,zValue,root.dataset.context);return}askAxisTransfer(moving,def,el.dataset.axis)};el.ondragend=()=>{el.classList.remove('axis-dragging');setTimeout(()=>state.axisDrag=null,0)}})}
+  function askAxisTransfer(source,target,targetAxis){const d=$("#confirmDialog");d.innerHTML=`<form method="dialog" class="dialog-body"><h2>Transfer ${esc(source.value)}</h2><p>Copy or move this entire ${source.axis==='x'?'column':'row'} into ${esc(target.name)}?</p><div class="dialog-actions"><button class="btn" value="cancel" autofocus>Cancel</button><button class="btn" value="copy">Copy</button><button class="btn primary" value="move">Move</button></div></form>`;d.onclose=()=>{if(d.returnValue==='copy'||d.returnValue==='move')transferAxis(source,target,targetAxis,d.returnValue)};d.showModal()}
+  function transferAxis(source,target,targetAxis,mode){const sourceField=source.def[source.axis],targetField=target[targetAxis],matches=cards(source.def.board).filter(c=>value(c,sourceField)===source.value),existing=new Set(cards(target.board).map(c=>value(c,targetField))),qualified=existing.has(source.value)?`${source.value} (${source.def.board})`:source.value,added=[];matches.forEach(c=>{const clone=mode==='copy'?structuredClone(c):c;if(mode==='copy'&&cards(target.board).some(x=>String(x.id)===String(clone.id)))clone.id=`${clone.id}-${slug(source.def.board)}`;setAxis(clone,targetField,qualified);clone.sourceBoard=clone.sourceBoard||source.def.board;clone.position=1;added.push(clone)});if(mode==='move')boardData[source.def.board].cards=cards(source.def.board).filter(c=>!matches.includes(c));cards(target.board).unshift(...added);normalize(source.def.board);normalize(target.board);updateIndex([source.def.board,target.board]);saveBoards(mode==='move'?[source.def.board,target.board]:[target.board],`${mode} ${source.value} from ${source.def.board} to ${target.board}`,true);renderMashup()}
+  function renderMashup(){const root=$("#view"),defs=activeDefs();state.one=state.one||config.mashupOne||defs[0]?.id;state.two=state.two||config.mashupTwo||state.one;config.mashupOne=state.one;config.mashupTwo=state.two;persist();const one=defs.find(d=>d.id===state.one),two=defs.find(d=>d.id===state.two);root.innerHTML=`<div class="mashup-toolbar"><button class="btn" data-swap>Swap viewports ${config.mashupSwap?'↕':'↔'}</button></div><div class="mashup ${config.mashupSwap?'swap':''}"><section class="panel">${defSelect('one',defs,state.one)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="one"></div></div></section><section class="panel">${defSelect('two',defs,state.two)}<div class="matrix-scroll"><div class="matrix-grid" data-grid="two"></div></div></section></div>`;$$('[data-matrix]',root).forEach(s=>s.onchange=()=>{state[s.dataset.matrix]=s.value;config[`mashup${s.dataset.matrix[0].toUpperCase()+s.dataset.matrix.slice(1)}`]=s.value;persist();renderMashup()});$('[data-swap]',root).onclick=()=>{config.mashupSwap=!config.mashupSwap;persist();renderMashup()};if(one)drawMatrix($('[data-grid=one]',root),one,'','mashup');if(two)drawMatrix($('[data-grid=two]',root),two,'','mashup')}
+  function renderBuilder(){const root=$("#view"),requested=new URLSearchParams(location.search).get('board'),available=boards(),board=(state.manageBoard&&boardData[state.manageBoard]?state.manageBoard:null)||(requested&&boardData[requested]?requested:null)||index.activeBoard||available[0]?.name;state.manageBoard=board;const deleted=index.boards.filter(b=>b.archived);root.innerHTML=`<button class="btn" data-back>← Back to matrices</button><div class="manage-layout"><aside class="panel board-list"><details class="trash-panel"><summary>▾ Deleted boards (${deleted.length})</summary>${deleted.map(b=>`<div class="trash-item"><span>${esc(b.name)}</span><button class="btn" data-restore-board="${esc(b.name)}">Restore</button><button class="btn danger" data-purge-board="${esc(b.name)}">Delete forever</button></div>`).join('')||'<p class="empty">Recycle bin is empty.</p>'}</details><form data-new-board><div class="control"><label>New board<input name="name" required></label></div><button class="btn primary">Create board</button></form>${available.map(b=>`<div class="board-row ${b.name===board?'active':''}" data-board-drop="${esc(b.name)}"><button data-select-board="${esc(b.name)}"><b>${esc(b.name)}</b><br><small>${cards(b.name).length} cards</small></button><button class="btn danger" data-delete-board="${esc(b.name)}" aria-label="Delete ${esc(b.name)}">×</button></div>`).join('')}</aside><section class="panel"><div class="view-head"><h1>${esc(board)}</h1><button class="btn primary" data-new-card>＋ Card</button></div><div class="board-kanban" style="flex-direction:${matrixPrefs().appearance.kanbanLayout==='vertical'?'column':'row'}">${stages(board).map(st=>`<div class="lane" data-board="${esc(board)}" data-stage="${esc(st)}"><div class="lane-head"><h3>${esc(st)}</h3></div><div class="lane-cards">${cards(board).filter(c=>(c.stage||c.lane)===st).sort((a,b)=>(a.position??a.pos??0)-(b.position??b.pos??0)).map(c=>cardMarkup(c,board,{intersection:'title',fields:['platform','tags']})).join('')}</div></div>`).join('')}</div></section></div>`;
+    $('[data-back]',root).onclick=()=>openApp('matrix');$$('[data-select-board]',root).forEach(b=>b.onclick=()=>{state.manageBoard=b.dataset.selectBoard;index.activeBoard=state.manageBoard;renderBuilder()});$$('[data-delete-board]',root).forEach(b=>b.onclick=()=>confirmAction(`Move ${b.dataset.deleteBoard} to the board recycle bin?`,()=>{index.boards.find(x=>x.name===b.dataset.deleteBoard).archived=true;saveBoards([],`Archive board ${b.dataset.deleteBoard}`,true);state.manageBoard='';renderBuilder()}));$$('[data-restore-board]',root).forEach(b=>b.onclick=()=>{index.boards.find(x=>x.name===b.dataset.restoreBoard).archived=false;saveBoards([],`Restore board ${b.dataset.restoreBoard}`,true);renderBuilder()});$$('[data-purge-board]',root).forEach(b=>b.onclick=()=>confirmAction('Permanently delete this board from the index? Its JSON file will remain recoverable in Git history.',()=>{index.boards=index.boards.filter(x=>x.name!==b.dataset.purgeBoard);delete boardData[b.dataset.purgeBoard];saveBoards([],`Permanently remove board ${b.dataset.purgeBoard}`,true);renderBuilder()}));$('[data-new-board]',root).onsubmit=e=>{e.preventDefault();const name=e.target.name.value.trim(),now=Date.now();if(!name||index.boards.some(b=>slug(b.name)===slug(name)))return notify('Enter a unique board name.');boardData[name]={version:1,cards:[],archive:[],platforms:[...DEFAULT_BOARD.platforms],stages:[...DEFAULT_BOARD.stages],layout:'horizontal',collapsed:{},cardCollapsed:{},lastModified:now};index.boards.push({name,archived:false,createdAt:now,lastUpdated:now,cardCount:0});state.manageBoard=name;saveBoards([name],`Create board ${name}`,true);renderBuilder()};const add=()=>{const stage=stages(board)[0]||'Backlog',now=Date.now(),c={id:uid(),title:'New card',platform:'Default',stage,tags:[],notes:'',position:1,createdAt:now,updatedAt:now};cards(board).unshift(c);normalize(board);updateIndex([board]);saveBoards([board],`Create card in ${board}`,true);renderBuilder();openCardEditor(board,c.id)};$('[data-new-card]',root)?.addEventListener('click',add);wireCards(root);wireDrops(root,'.lane',(el,d)=>{if(d.board===board)moveMatrixCard(d,{board,x:'platform',y:'stage'},value(cards(board).find(c=>String(c.id)===String(d.id)),'platform'),el.dataset.stage)});$$('[data-board-drop]',root).forEach(el=>{el.ondragover=e=>e.preventDefault();el.ondrop=e=>{e.preventDefault();if(!drag||drag.board===el.dataset.boardDrop)return;const dest=el.dataset.boardDrop;transferCard(drag.board,dest,drag.id,stages(dest)[0]||'Backlog');state.manageBoard=dest;renderBuilder()}})}
+  /* ==========================================================================
+     KANBAN PARITY LAYER (overrides cardMarkup/wireCards/openCardEditor)
+     These re-declarations win over the earlier ones (function hoisting: last
+     declaration in scope is the live binding). Matrix / DnD / mashup / axis
+     transfer logic above is untouched — cards just carry kanban's full info,
+     the tag-suggestion scheme, a compact status dot, and duplicate/archive.
+     ========================================================================== */
+  const CARD_LINEAGES=["pre-base","base","pre-ship","ship","post-ship","post-ship-plus-1","post-ship-plus-x"];
+  const STATUS_COLORS=["gray","red","yellow","green","blue","orange","white","black"];
+  const STATUS_MAP={gray:"#9ca3af",red:"#ef4444",yellow:"#eab308",green:"#22c55e",blue:"#3b82f6",orange:"#f97316",white:"#ffffff",black:"#111827"};
+  const normStatus=v=>{v=String(v||"").toLowerCase().trim();return STATUS_COLORS.includes(v)?v:"gray";};
+  const normLineage=v=>{v=String(v||"").toLowerCase().trim();return CARD_LINEAGES.includes(v)?v:"base";};
+  const normUrlKC=u=>{u=String(u||"").trim();if(!u)return"";if(/^[a-z][a-z\d+.\-]*:\/\//i.test(u))return u;if(/^[\w.\-]+\.[a-z]{2,}/i.test(u))return"https://"+u;return u;};
 
-/* ============ shell ============ */
-function bindShell(){
-  $("#tabMatrix").onclick=()=>setView("matrix");
-  $("#tabBoard").onclick=()=>setView("board");
-  $("#btnSettings").onclick=openSettings;
-  $("#railNew").onclick=()=>createBoardDialog();
-  $("#railSearch").oninput=renderRail;
-  $("#railToggle").onclick=()=>$("#app").classList.toggle("rail-open");
-  $("#scrim").onclick=()=>$("#app").classList.remove("rail-open");
-}
-function setView(v){
-  view=v;
-  $("#tabMatrix").classList.toggle("on",v==="matrix");
-  $("#tabBoard").classList.toggle("on",v==="board");
-  const u=new URL(location.href);u.searchParams.set("view",v);history.replaceState(null,"",u);
-  if(v==="matrix"){ $("#topTitle").textContent="All boards"; renderMatrix(); }
-  else { openBoardView(activeBoard); }
-}
+  /* previously-used tags: history + every tag already on a card */
+  const TAG_KEY="program_tag_history_v1";
+  function tagHistRead(){try{const a=JSON.parse(localStorage.getItem(TAG_KEY)||"[]");return Array.isArray(a)?a:[];}catch{return[];}}
+  function tagHistWrite(a){localStorage.setItem(TAG_KEY,JSON.stringify([...new Set(a.map(String))]));}
+  function tagHistAdd(tags){if(tags&&tags.length)tagHistWrite([...tagHistRead(),...tags]);}
+  function tagHistDel(t){tagHistWrite(tagHistRead().filter(x=>x!==t));}
+  function allKnownTags(){const s=new Set(tagHistRead());Object.values(boardData).forEach(b=>((b&&b.cards)||[]).forEach(c=>(c.tags||[]).forEach(t=>t&&s.add(String(t)))));return[...s].sort((a,b)=>a.localeCompare(b));}
 
-/* ============ rail (boards on the left) ============ */
-function boardColor(b){
-  // colour by phase for quick scanning
-  return {dev:"#6658e8",tst:"#f97316",prd:"#22c55e"}[b.phase]||"#9ca3af";
-}
-function renderRail(){
-  const q=($("#railSearch").value||"").toLowerCase();
-  const list=$("#railList");
-  const all=(index.boards||[]).filter(b=>!q||b.name.toLowerCase().includes(q));
-  const active=all.filter(b=>!b.archived).sort((a,b)=>(b.lastUpdated||0)-(a.lastUpdated||0));
-  const arch=all.filter(b=>b.archived);
-  const row=b=>`<div class="brow ${b.name===activeBoard?"on":""}" data-b="${esc(b.name)}">
-      <span class="bdot" style="background:${boardColor(b)}"></span>
-      <span class="bname" title="${esc(b.name)}">${esc(b.name)}</span>
-      <span class="bcount">${b.cardCount??0}</span>
-      <button class="bx" data-arch="${esc(b.name)}" title="${b.archived?"Restore":"Archive"} board" aria-label="Archive board">${b.archived?"↩":"×"}</button>
-    </div>`;
-  list.innerHTML =
-    (active.length?`<div class="rail-sec">Boards (${active.length})</div>`+active.map(row).join(""):`<div class="rail-sec">Boards</div><div class="mx-empty-note" style="padding:16px">No boards yet.</div>`)+
-    (arch.length?`<div class="rail-sec">Archived (${arch.length})</div>`+arch.map(row).join(""):"");
-  $$(".brow",list).forEach(el=>{
-    el.onclick=e=>{ if(e.target.closest("[data-arch]"))return; openBoardView(el.dataset.b); if(innerWidth<=820)$("#app").classList.remove("rail-open"); };
-  });
-  $$("[data-arch]",list).forEach(b=>b.onclick=e=>{e.stopPropagation();toggleArchiveBoard(b.dataset.arch);});
-}
-function toggleArchiveBoard(name){
-  const b=findBoard(name); if(!b)return;
-  b.archived=!b.archived; b.lastUpdated=Date.now();
-  saveBoards([],`${b.archived?"Archive":"Restore"} board ${name}`,true);
-  if(b.archived&&activeBoard===name) activeBoard=activeBoards()[0]?.name||"";
-  renderRail(); if(view==="matrix")renderMatrix();
-  toast(`${b.archived?"Archived":"Restored"} ${name}`);
-}
+  /* minimal markdown (Mello notes: markdown + text--url shorthand) */
+  const kEsc=s=>String(s??"").replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[m]));
+  function kShortUrl(u){u=String(u||"").trim();if(!u)return"";if(/^[a-z][a-z\d+.\-]*:\/\//i.test(u))return u;const m=u.match(/^([^\/?#]+)(.*)$/);if(!m)return"https://"+u;let[,h,r]=m;if(!h.includes("."))h+=".com";return`https://${h}${r}`;}
+  function kShort(t){return String(t||"").replace(/(^|[\s(>])([A-Za-z0-9][^\n<>()\[\]]*?\S)\s*--\s*([^\s<>()]+)(?=$|[\s),.!?])/g,(m,p,l,r)=>{const L=l.trim(),U=kShortUrl(r);return(!L||!U)?m:`${p}[**${L}**](${U})`;});}
+  function kPre(s){const src=String(s||"");const ch=[];const tk=src.replace(/!?\[[^\]]+\]\([^\)]+\)/g,m=>{const t=`__K${ch.length}__`;ch.push(m);return t;});const sh=kShort(tk);const re=sh.replace(/!?\[[^\]]+\]\([^\)]+\)/g,m=>{const t=`__K${ch.length}__`;ch.push(m);return t;});const nm=re.replace(/https?:\/\/[^\s<>"]+/g,raw=>{const tr=raw.replace(/[),.;!?]+$/g,"");const sf=raw.slice(tr.length);let lb="link";try{lb=(new URL(tr).hostname||"").replace(/^www\./i,"")||"link";}catch{return raw;}return`[${lb}](${tr})${sf}`;});return nm.replace(/__K(\d+)__/g,(_,i)=>ch[+i]??"");}
+  function kInline(t){return String(t||"").replace(/\*\*([^*]+)\*\*/g,"<strong>$1</strong>").replace(/\*([^*]+)\*/g,"<em>$1</em>").replace(/`([^`]+)`/g,"<code>$1</code>").replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,'<a href="$2" target="_blank" rel="noopener">$1</a>');}
+  function kLink(s){return String(s||"").replace(/(?<!\]\()https?:\/\/[^\s)]+(?![^<]*>)/g,'<a href="$&" target="_blank" rel="noopener">$&</a>');}
+  function renderMd(src){const w=kEsc(kPre(src||""));const ls=w.split(/\r?\n/);let h="",inL=false,inC=false;for(const rw of ls){const ln=rw||"";if(ln.startsWith("```")){h+=inC?"</code></pre>":"<pre><code>";inC=!inC;continue;}if(inC){h+=ln+"\n";continue;}const li=ln.match(/^\s*[-*]\s+(.*)$/);if(li){if(!inL){h+="<ul>";inL=true;}h+=`<li>${kInline(kLink(li[1]))}</li>`;continue;}if(inL){h+="</ul>";inL=false;}if(/^\s*$/.test(ln))continue;if(ln.startsWith("### ")){h+=`<p><strong>${kInline(kLink(ln.slice(4)))}</strong></p>`;continue;}if(ln.startsWith("## ")){h+=`<p><strong>${kInline(kLink(ln.slice(3)))}</strong></p>`;continue;}if(ln.startsWith("# ")){h+=`<p><strong>${kInline(kLink(ln.slice(2)))}</strong></p>`;continue;}h+=`<p>${kInline(kLink(ln))}</p>`;}if(inL)h+="</ul>";if(inC)h+="</code></pre>";return h;}
 
-/* ============ MATRIX (boards in 2D) ============ */
-function matrixAxisFields(){ return Object.keys(BOARD_FIELDS); }
-function orderedValues(field, present){
-  const f=BOARD_FIELDS[field]; const order=f.order||[];
-  const seen=[...new Set(present)];
-  return [...order.filter(v=>seen.includes(v)), ...seen.filter(v=>!order.includes(v)).sort()];
-}
-function matrixBoards(){
-  const m=cfg.matrix;
-  let list=(index.boards||[]).slice();
-  if(!m.showArchived) list=list.filter(b=>!b.archived);
-  // apply attribute filters (non-axis)
-  Object.entries(m.filters||{}).forEach(([field,vals])=>{
-    if(field===m.x||field===m.y) return;
-    if(!vals||!vals.length) return;
-    const f=BOARD_FIELDS[field]; if(!f)return;
-    list=list.filter(b=>vals.includes(f.get(b)));
-  });
-  return list;
-}
-function renderMatrix(){
-  const m=cfg.matrix;
-  if(m.x===m.y) m.y = matrixAxisFields().find(f=>f!==m.x);
-  const main=$("#main");
-  main.innerHTML = `
-    <div class="toolbar">
-      <div class="field"><label>Columns (X)</label><select id="mxX">${axisOpts(m.x)}</select></div>
-      <div class="field"><label>Rows (Y)</label><select id="mxY">${axisOpts(m.y)}</select></div>
-      <div class="pop-anchor"><button class="chipbtn" id="mxFilters">⛃ Filters</button></div>
-      <label class="chipbtn ${m.showArchived?"active":""}" id="mxArch" style="cursor:pointer"><input type="checkbox" ${m.showArchived?"checked":""} style="display:none">Include archived</label>
-      <span class="spacer"></span>
-      <span class="field" style="color:var(--muted);font-size:12px;align-self:center" id="mxCountNote"></span>
-    </div>
-    <div class="content"><div class="mx-wrap"><div class="mx-scroll"><div class="mx-grid" id="mxGrid"></div></div></div></div>`;
-  $("#mxX").onchange=e=>{ if(e.target.value===m.y)m.y=m.x; m.x=e.target.value; persist(); renderMatrix(); };
-  $("#mxY").onchange=e=>{ if(e.target.value===m.x)m.x=m.y; m.y=e.target.value; persist(); renderMatrix(); };
-  $("#mxArch").onclick=e=>{ if(e.target.tagName==="INPUT")return; m.showArchived=!m.showArchived; persist(); renderMatrix(); };
-  $("#mxFilters").onclick=e=>openFilters(e.currentTarget);
-  drawMatrixGrid();
-}
-function axisOpts(sel){ return matrixAxisFields().map(f=>`<option value="${f}" ${f===sel?"selected":""}>${esc(BOARD_FIELDS[f].label)}</option>`).join(""); }
-
-function openFilters(anchor){
-  const m=cfg.matrix;
-  const fields=matrixAxisFields().filter(f=>f!==m.x&&f!==m.y);
-  const body=fields.map(f=>{
-    const F=BOARD_FIELDS[f];
-    const vals=orderedValues(f, (index.boards||[]).map(b=>F.get(b)));
-    const chosen=m.filters[f]||[];
-    return `<h4>${esc(F.label)}</h4>`+vals.map(v=>`<label class="check"><input type="checkbox" data-f="${f}" value="${esc(v)}" ${chosen.includes(v)?"checked":""}> ${esc(v)}</label>`).join("");
-  }).join("") || `<p class="pop-note">Both axes are in use — no extra attributes to filter.</p>`;
-  const pop=popover(`<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px"><strong>Filter boards</strong><button class="btn small" id="fClear">Clear</button></div>${body}`,anchor);
-  $$("input[data-f]",pop).forEach(i=>i.onchange=()=>{
-    const f=i.dataset.f; const set=new Set(m.filters[f]||[]);
-    i.checked?set.add(i.value):set.delete(i.value);
-    m.filters[f]=[...set]; if(!m.filters[f].length)delete m.filters[f];
-    persist(); drawMatrixGrid();
-  });
-  $("#fClear",pop).onclick=()=>{ m.filters={}; persist(); closePops(); drawMatrixGrid(); };
-}
-
-let mxDrag=null;
-function drawMatrixGrid(){
-  const m=cfg.matrix, grid=$("#mxGrid"); if(!grid)return;
-  const list=matrixBoards();
-  const fx=BOARD_FIELDS[m.x], fy=BOARD_FIELDS[m.y];
-  const xs=orderedValues(m.x, list.map(fx.get));
-  const ys=orderedValues(m.y, list.map(fy.get));
-  const note=$("#mxCountNote"); if(note)note.textContent=`${list.length} board${list.length===1?"":"s"}`;
-  if(!list.length){ grid.style.gridTemplateColumns="1fr"; grid.innerHTML=`<div class="mx-empty-note">No boards match. Adjust filters, or create one.</div>`; return; }
-  grid.style.gridTemplateColumns=`minmax(80px,104px) repeat(${xs.length},minmax(160px,208px))`;
-  const editable = fx.editable && fy.editable;
-  let html=`<div class="mx-corner">${esc(fy.label)} \\ ${esc(fx.label)}</div>`;
-  xs.forEach(x=>html+=`<div class="mx-colh" title="${esc(x)}">${esc(x)}</div>`);
-  ys.forEach(y=>{
-    html+=`<div class="mx-rowh" title="${esc(y)}">${esc(y)}</div>`;
-    xs.forEach(x=>{
-      const inCell=list.filter(b=>fx.get(b)===x&&fy.get(b)===y).sort((a,b)=>(b.lastUpdated||0)-(a.lastUpdated||0));
-      const CAP=5;
-      const shown=inCell.slice(0,CAP), extra=inCell.length-shown.length;
-      const chips=shown.map(b=>`<div class="bchip" draggable="${editable}" data-chip="${esc(b.name)}" style="--chip:${boardColor(b)}">
-          <span class="n" title="${esc(b.name)}">${esc(b.name)}</span><span class="c">${b.cardCount??0}</span></div>`).join("");
-      const more=extra>0?`<button class="mx-more" data-more="${esc(x)}|${esc(y)}">+${extra} more…</button>`:"";
-      html+=`<div class="mx-cell ${inCell.length?"":"empty"}" data-x="${esc(x)}" data-y="${esc(y)}">${chips}${more}</div>`;
-    });
-  });
-  grid.innerHTML=html;
-
-  // open board on click, drag to reassign
-  $$(".bchip",grid).forEach(el=>{
-    el.addEventListener("click",()=>openBoardView(el.dataset.chip));
-    if(editable){
-      el.addEventListener("dragstart",e=>{mxDrag=el.dataset.chip;e.dataTransfer.effectAllowed="move";});
-      el.addEventListener("dragend",()=>mxDrag=null);
-    }
-  });
-  if(editable){
-    $$(".mx-cell",grid).forEach(cell=>{
-      cell.addEventListener("dragover",e=>{e.preventDefault();cell.classList.add("drop");});
-      cell.addEventListener("dragleave",()=>cell.classList.remove("drop"));
-      cell.addEventListener("drop",e=>{
-        e.preventDefault();cell.classList.remove("drop");
-        if(!mxDrag)return;
-        const b=findBoard(mxDrag); if(!b)return;
-        applyBoardField(b,m.x,cell.dataset.x); applyBoardField(b,m.y,cell.dataset.y);
-        b.lastUpdated=Date.now();
-        saveBoards([],`Set ${b.name} ${m.x}=${cell.dataset.x}, ${m.y}=${cell.dataset.y}`,true);
-        renderRail(); drawMatrixGrid();
-        toast(`${b.name}: ${cell.dataset.y} · ${cell.dataset.x}`);
-      });
-    });
+  /* rich card — keeps the matrix CENTER value as the title so that feature
+     still works, then always shows status dot + platform/lineage/tags +
+     dev/live + duplicate/archive (the info I had stripped) */
+  function cardMarkup(c,board,def){
+    def=def||{intersection:"title",fields:[]};
+    const primary=(def.intersection&&def.intersection!=="title")?value(c,def.intersection):(c.title||"(untitled)");
+    const dev=(c.dev||"").trim(), live=(c.live||"").trim();
+    const status=normStatus(c.statusColor), ribbon=c.cardColor||STATUS_MAP[status];
+    const shown=new Set(["title",def.intersection,"platform","lineage","tags","stage"]);
+    const extra=(def.fields||[]).filter(f=>!shown.has(f)).map(f=>`<span class="chip">${esc(f)}: ${esc(value(c,f))}</span>`).join("");
+    const tags=(c.tags||[]).map(t=>`<span class="chip kc-tag" data-tag="${esc(t)}" title="${esc(t)}">${esc(t)}</span>`).join("");
+    return `<article class="card kcard" draggable="true" tabindex="0" data-card="${esc(c.id)}" data-board="${esc(board)}" style="--ribbon:${esc(ribbon)}">`+
+      `<div class="kc-line">`+
+        `<button class="kc-status" type="button" data-kstatus title="Status: ${esc(status)}"><span class="kc-dot" style="background:${esc(STATUS_MAP[status])}"></span></button>`+
+        `<button class="card-title" type="button" title="${esc(primary)}">${esc(primary)}</button>`+
+        `<span class="kc-links">${dev?`<a href="${esc(normUrlKC(dev))}" target="_blank" rel="noopener" data-stop>Dev</a>`:`<span class="empty">Dev</span>`}${live?`<a href="${esc(normUrlKC(live))}" target="_blank" rel="noopener" data-stop>Live</a>`:`<span class="empty">Live</span>`}</span>`+
+        `<button class="kc-copy" type="button" data-kcopy title="Duplicate card"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 8h11v13H8V8Zm-3-5h11v3H8a3 3 0 0 0-3 3v8H5V3Z"/></svg></button>`+
+        `<button class="kc-arch" type="button" data-karch title="Archive card"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 7H4V5h16v2Zm-2 2v10a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V9h12Zm-8 2v6h1v-6h-1Zm3 0v6h1v-6h-1Z"/></svg></button>`+
+      `</div>`+
+      `<div class="kc-tags"><span class="chip kc-plat">${esc(c.platform||"—")}</span><span class="chip kc-lin">${esc(normLineage(c.lineage))}</span>${tags}${extra}</div>`+
+    `</article>`;
   }
-  $$("[data-more]",grid).forEach(btn=>btn.onclick=e=>{
-    const [x,y]=btn.dataset.more.split("|");
-    const inCell=list.filter(b=>fx.get(b)===x&&fy.get(b)===y).sort((a,b)=>(b.lastUpdated||0)-(a.lastUpdated||0));
-    const pop=popover(`<h4>${esc(y)} · ${esc(x)} — ${inCell.length} boards</h4>`+
-      inCell.map(b=>`<div class="bchip" data-open="${esc(b.name)}" style="--chip:${boardColor(b)};cursor:pointer"><span class="n">${esc(b.name)}</span><span class="c">${b.cardCount??0}</span></div>`).join(""), btn);
-    $$("[data-open]",pop).forEach(x2=>x2.onclick=()=>{closePops();openBoardView(x2.dataset.open);});
-  });
-}
-function applyBoardField(b,field,val){
-  if(field==="phase"){b.phase=val;b.phaseUpdatedAt=Date.now();}
-  else if(field==="stage"){b.stage=val;b.stageUpdatedAt=Date.now();}
-  else if(field==="status"){b.archived=(val==="archived");}
-}
 
-/* ============ BOARD VIEW (cards on the right) ============ */
-async function openBoardView(name){
-  if(!name){ setView("matrix"); return; }
-  activeBoard=name; index.activeBoard=name;
-  view="board";
-  $("#tabMatrix").classList.toggle("on",false);
-  $("#tabBoard").classList.toggle("on",true);
-  $("#topTitle").textContent=name;
-  const u=new URL(location.href);u.searchParams.set("view","board");history.replaceState(null,"",u);
-  renderRail();
-  $("#main").innerHTML=`<div class="content"><div class="mx-empty-note">Loading ${esc(name)}…</div></div>`;
-  await ensureBoard(name);
-  openCards.clear();
-  renderBoard();
-}
-function tagHistory(){ return Array.isArray(cfg.tagHistory)?cfg.tagHistory:[]; }
-function bumpTags(tags){
-  const set=new Set(tagHistory());
-  (tags||[]).forEach(t=>t&&set.add(t));
-  cfg.tagHistory=[...set].slice(0,80); persist();
-}
-function renderBoard(){
-  const name=activeBoard, main=$("#main");
-  const b=boardData[name]||{};
-  const layout=b.layout||"auto";
-  const stages=boardStages(name);
-  main.innerHTML=`
-    <div class="kb-head">
-      <input class="kb-title" id="kbTitle" value="${esc(name)}" aria-label="Board name">
-      <div class="kb-meta">
-        <div class="field"><label>Phase</label><select id="kbPhase">${BOARD_PHASES.map(p=>`<option ${findBoard(name)?.phase===p?"selected":""}>${p}</option>`).join("")}</select></div>
-        <div class="field"><label>Stage</label><select id="kbStage">${BOARD_STAGES.map(s=>`<option ${findBoard(name)?.stage===s?"selected":""}>${s}</option>`).join("")}</select></div>
-        <div class="field"><label>Layout</label><select id="kbLayout">${["auto","horizontal","vertical"].map(l=>`<option ${layout===l?"selected":""}>${l}</option>`).join("")}</select></div>
-      </div>
-      <span class="spacer"></span>
-      <button class="btn small" id="kbArchived">⌦ Archived (${(b.archive||[]).length})</button>
-      <button class="btn small" id="kbSettings">⚙ Board</button>
-      <button class="btn primary small" id="kbNew">＋ Card</button>
-    </div>
-    <div class="kb-board" id="kbBoard" data-layout="${esc(layout)}"></div>`;
-  if(b._loadError) sync("Board not on server yet — new/local","");
-  const kb=$("#kbBoard");
-  kb.innerHTML=stages.map(st=>{
-    const cs=cards(name).filter(c=>(c.stage||c.lane||"Backlog")===st).sort((a,b)=>(a.pos??a.position??0)-(b.pos??b.position??0));
-    return `<div class="lane" data-stage="${esc(st)}">
-        <div class="lane-head"><h3>${esc(st)}</h3><span class="n">${cs.length}</span><button class="lane-add" data-add="${esc(st)}" title="Add card">＋</button></div>
-        <div class="lane-cards" data-stage="${esc(st)}">${cs.map(c=>cardHTML(c,name)).join("")}</div>
-      </div>`;
-  }).join("");
-  // header wiring
-  $("#kbTitle").onchange=e=>renameBoard(name,e.target.value);
-  $("#kbTitle").onkeydown=e=>{if(e.key==="Enter"){e.preventDefault();e.target.blur();}};
-  $("#kbPhase").onchange=e=>{const bd=findBoard(name);applyBoardField(bd,"phase",e.target.value);saveBoards([],`Phase ${name}`,true);renderRail();};
-  $("#kbStage").onchange=e=>{const bd=findBoard(name);applyBoardField(bd,"stage",e.target.value);saveBoards([],`Stage ${name}`,true);renderRail();};
-  $("#kbLayout").onchange=e=>{boardData[name].layout=e.target.value;$("#kbBoard").dataset.layout=e.target.value;saveBoards([name],`Layout ${name}`);};
-  $("#kbNew").onclick=()=>addCard(name,stages[0]);
-  $("#kbArchived").onclick=e=>openArchivedCards(name,e.currentTarget);
-  $("#kbSettings").onclick=openBoardSettings;
-  $$("[data-add]",kb).forEach(b2=>b2.onclick=()=>addCard(name,b2.dataset.add));
-  wireCards();
-  wireLaneDnD();
-}
-function renameBoard(oldName,raw){
-  const nn=raw.trim();
-  if(!nn||nn===oldName){ if($("#kbTitle"))$("#kbTitle").value=oldName; return; }
-  if(findBoard(nn)){ toast("A board with that name exists",true); $("#kbTitle").value=oldName; return; }
-  const b=findBoard(oldName); if(b)b.name=nn;
-  boardData[nn]=boardData[oldName]; delete boardData[oldName];
-  loaded.delete(oldName); loaded.add(nn);
-  activeBoard=nn; index.activeBoard=nn;
-  // write new file + index; leave old file (git history keeps it)
-  saveBoards([nn],`Rename board ${oldName} → ${nn}`,true);
-  $("#topTitle").textContent=nn; renderRail();
-  toast("Board renamed");
-}
+  function wireCards(root){$$(".card",root).forEach(el=>{
+    const board=el.dataset.board,id=el.dataset.card;
+    const title=$(".card-title",el); if(title)title.onclick=e=>{e.stopPropagation();openCardEditor(board,id);};
+    const st=$("[data-kstatus]",el); if(st)st.onclick=e=>{e.stopPropagation();showStatusMenu(st,board,id);};
+    const cp=$("[data-kcopy]",el); if(cp)cp.onclick=e=>{e.stopPropagation();duplicateCard(board,id);};
+    const ar=$("[data-karch]",el); if(ar)ar.onclick=e=>{e.stopPropagation();archiveCard(board,id);};
+    $$("[data-stop]",el).forEach(a=>{a.addEventListener("click",e=>e.stopPropagation());a.addEventListener("pointerdown",e=>e.stopPropagation());a.addEventListener("dragstart",e=>e.stopPropagation());});
+    $$(".kc-tag",el).forEach(tg=>tg.addEventListener("click",e=>{e.stopPropagation();notify("Tag: "+tg.dataset.tag);}));
+    el.ondragstart=e=>{drag={board,id};el.classList.add("selected");if(e.dataTransfer)e.dataTransfer.effectAllowed="move";};
+    el.ondragend=()=>{drag=null;el.classList.remove("selected");};
+  });}
 
-/* ---- card markup (collapsed summary) ---- */
-function statusColorOf(c){ return STATUS_MAP[normStatus(c.statusColor)]; }
-function ribbonOf(c){ return c.cardColor||statusColorOf(c); }
-function cardHTML(c,board){
-  const open=openCards.has(c.id);
-  if(open) return cardEditorHTML(c,board);
-  const dev=(c.dev||"").trim(), live=(c.live||"").trim();
-  const tags=(c.tags||[]).map(t=>`<button class="chip tag" data-tag="${esc(t)}">${esc(t)}</button>`).join("");
-  const notes=(c.notes||"").trim();
-  const notesHtml=notes?`<div class="card-notes clamped">${renderMarkdown(notes)}</div>`:"";
-  return `<article class="card collapsed" data-card="${esc(c.id)}" data-board="${esc(board)}" draggable="true" style="--chip:${ribbonOf(c)}">
-    <div class="card-top">
-      <span class="status-dot" title="Status: ${normStatus(c.statusColor)}" style="background:${statusColorOf(c)}" data-status></span>
-      <button class="card-title" title="Open card">${esc(c.title||"(untitled)")}</button>
-      <span class="card-links">
-        ${dev?`<a href="${esc(normUrl(dev))}" target="_blank" rel="noopener" data-stop>Dev</a>`:`<span>Dev</span>`}
-        ${live?`<a href="${esc(normUrl(live))}" target="_blank" rel="noopener" data-stop>Live</a>`:`<span>Live</span>`}
-      </span>
-      <button class="ic" data-dup title="Duplicate"><svg viewBox="0 0 24 24"><path d="M8 8h11v13H8V8Zm-3-5h11v3H8a3 3 0 0 0-3 3v8H5V3Z"/></svg></button>
-      <button class="ic" data-arch title="Archive"><svg viewBox="0 0 24 24"><path d="M20 7H4V5h16v2Zm-2 2v10a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V9h12Zm-8 2v6h1v-6h-1Zm3 0v6h1v-6h-1Z"/></svg></button>
-    </div>
-    <div class="card-chips">
-      <span class="chip plat">${esc(c.platform||"Default")}</span>
-      <span class="chip lin">${esc(normLineage(c.lineage))}</span>
-      ${tags}
-    </div>
-    ${notesHtml}
-  </article>`;
-}
-
-/* ---- inline editor (card IS the editor) ---- */
-function cardEditorHTML(c,board){
-  const stages=boardStages(board), plats=boardPlatforms(board);
-  const opt=(arr,v)=>arr.map(o=>`<option ${o===v?"selected":""}>${esc(o)}</option>`).join("");
-  const tags=(c.tags||[]);
-  const sug=tagHistory().filter(t=>!tags.includes(t)).slice(0,10);
-  return `<article class="card open" data-card="${esc(c.id)}" data-board="${esc(board)}" style="--chip:${ribbonOf(c)}">
-    <div class="card-top">
-      <span class="status-dot" style="background:${statusColorOf(c)}"></span>
-      <button class="card-title" title="Collapse">${esc(c.title||"(untitled)")}</button>
-      <button class="ic" data-collapse title="Close">▾</button>
-    </div>
-    <div class="card-edit">
-      <div class="fld wide"><label>Title</label><input data-f="title" value="${esc(c.title||"")}" placeholder="Card title"></div>
-      <div class="fld"><label>Platform</label><select data-f="platform">${opt(plats,c.platform||"Default")}</select></div>
-      <div class="fld"><label>Stage</label><select data-f="stage">${opt(stages,c.stage||c.lane||stages[0])}</select></div>
-      <div class="fld"><label>Lineage</label><select data-f="lineage">${opt(CARD_LINEAGES,normLineage(c.lineage))}</select></div>
-      <div class="fld"><label>Status</label><div class="swatches" data-swatches>${STATUS_COLORS.map(s=>`<button type="button" data-status="${s}" class="${normStatus(c.statusColor)===s?"on":""}" style="background:${STATUS_MAP[s]}" title="${s}"></button>`).join("")}</div></div>
-      <div class="fld"><label>Dev link</label><input data-f="dev" value="${esc(c.dev||"")}" placeholder="https://…"></div>
-      <div class="fld"><label>Live link</label><input data-f="live" value="${esc(c.live||"")}" placeholder="https://…"></div>
-      <div class="fld wide"><label>Tags</label>
-        <div class="tag-edit" data-tagedit>${tags.map(t=>tagChip(t)).join("")}<input data-taginput placeholder="add tag, Enter"></div>
-        ${sug.length?`<div class="tag-sug">${sug.map(t=>`<button type="button" data-sug="${esc(t)}">${esc(t)}</button>`).join("")}</div>`:""}
-      </div>
-      <div class="fld wide"><label>Notes (Markdown · text--url shorthand)</label>
-        <textarea data-f="notes" placeholder="Type markdown or text--url…">${esc(c.notes||"")}</textarea>
-        <div class="note-prev" data-noteprev data-ph="Live preview">${c.notes?renderMarkdown(c.notes):""}</div>
-      </div>
-      <div class="edit-actions">
-        <button class="btn small danger" data-del>Archive card</button>
-        <button class="btn small" data-dup2>Duplicate</button>
-        <button class="btn primary small" data-close2>Done</button>
-      </div>
-    </div>
-  </article>`;
-}
-const tagChip = t=>`<span class="chip">${esc(t)}<b data-rmtag="${esc(t)}" title="Remove">×</b></span>`;
-function normUrl(u){u=String(u||"").trim();if(!u)return"";if(/^[a-z]+:\/\//i.test(u))return u;if(/^[\w.-]+\.[a-z]{2,}/i.test(u))return"https://"+u;return u;}
-
-/* ---- card wiring ---- */
-function wireCards(){
-  $$(".card",$("#kbBoard")).forEach(el=>{
-    const id=el.dataset.card, board=el.dataset.board;
+  function duplicateCard(board,id){
+    const o=cards(board).find(c=>String(c.id)===String(id)); if(!o)return;
+    const now=new Date().toISOString();
+    const clone={...o,id:uid(),title:(o.title||"(untitled)")+" (copy)",createdAt:now,updatedAt:now,tags:(o.tags||[]).slice(),files:Array.isArray(o.files)?o.files.map(f=>({...f})):[]};
+    const list=cards(board),i=list.findIndex(c=>c===o);
+    list.splice(i+1,0,clone); normalize(board); updateIndex([board]);
+    saveBoards([board],`Duplicate ${o.title||id}`,true); notify("Card duplicated"); rerender();
+  }
+  function archiveCard(board,id){
+    const list=cards(board),i=list.findIndex(c=>String(c.id)===String(id)); if(i<0)return;
+    const [c]=list.splice(i,1); const b=boardData[board]; b.archive=Array.isArray(b.archive)?b.archive:[];
+    c.archivedAt=Date.now(); b.archive.unshift(c); normalize(board); updateIndex([board]);
+    saveBoards([board],`Archive ${c.title||id}`,true); notify("Card archived"); rerender();
+  }
+  function showStatusMenu(anchor,board,id){
+    document.querySelector(".status-menu")?.remove();
     const c=cards(board).find(x=>String(x.id)===String(id)); if(!c)return;
-    if(el.classList.contains("open")){ wireEditor(el,c,board); return; }
-    // collapsed interactions
-    $(".card-title",el).onclick=e=>{e.stopPropagation();toggleCard(id);};
-    $("[data-dup]",el).onclick=e=>{e.stopPropagation();duplicateCard(board,id);};
-    $("[data-arch]",el).onclick=e=>{e.stopPropagation();archiveCard(board,id);};
-    $("[data-status]",el).onclick=e=>{e.stopPropagation();cycleStatus(board,id);};
-    $$("[data-tag]",el).forEach(t=>t.onclick=e=>{e.stopPropagation();/* future: filter */ toast("Tag: "+t.dataset.tag);});
-    $$("[data-stop]",el).forEach(a=>a.onclick=e=>e.stopPropagation());
-    const nt=$(".card-notes",el);
-    if(nt && nt.scrollHeight>nt.clientHeight+4){
-      nt.style.cursor="pointer";
-      nt.title="Read full note";
-      nt.onclick=e=>{if(e.target.tagName==="A")return; e.stopPropagation(); notePopover(c,nt);};
-    }
-    // drag
-    el.addEventListener("dragstart",e=>{drag={board,id};el.classList.add("dragging");e.dataTransfer.effectAllowed="move";e.dataTransfer.setData("text/plain",id);});
-    el.addEventListener("dragend",()=>{drag=null;el.classList.remove("dragging");});
-  });
-}
-function wireEditor(el,c,board){
-  const save=(field,val,commit=true)=>{
-    if(c[field]===val)return;
-    c[field]=val; c.updatedAt=Date.now();
-    if(field==="stage"&&"lane"in c)c.lane=val;
-    if(commit) saveBoards([board],`Update ${c.title||c.id}`,true);
-  };
-  $(".card-title",el).onclick=()=>toggleCard(c.id);
-  $("[data-collapse]",el).onclick=()=>toggleCard(c.id);
-  $("[data-close2]",el).onclick=()=>toggleCard(c.id);
-  $("[data-del]",el).onclick=()=>archiveCard(board,c.id);
-  $("[data-dup2]",el).onclick=()=>duplicateCard(board,c.id);
-
-  // text/select fields: update on blur + Enter
-  $$("[data-f]",el).forEach(inp=>{
-    const f=inp.dataset.f;
-    if(inp.tagName==="SELECT"){ inp.onchange=()=>save(f,inp.value); return; }
-    if(f==="notes"){
-      const prev=$("[data-noteprev]",el);
-      inp.oninput=()=>{ prev.innerHTML=inp.value?renderMarkdown(inp.value):""; };
-      inp.onblur=()=>save("notes",inp.value);
-      return;
-    }
-    inp.onblur=()=>save(f, f==="title"?inp.value.trim():inp.value.trim());
-    inp.onkeydown=e=>{ if(e.key==="Enter"){e.preventDefault();inp.blur();} };
-  });
-  // status swatches
-  $$("[data-status]",$("[data-swatches]",el)).forEach(b=>b.onclick=()=>{
-    c.statusColor=b.dataset.status; c.updatedAt=Date.now();
-    $$("[data-status]",el).forEach(x=>x.classList.toggle("on",x===b));
-    $(".status-dot",el).style.background=STATUS_MAP[c.statusColor];
-    el.style.setProperty("--chip",ribbonOf(c));
-    save("_",null,false); saveBoards([board],`Status ${c.title||c.id}`);
-  });
-  // tags
-  const wrap=$("[data-tagedit]",el), input=$("[data-taginput]",el);
-  const addTag=t=>{ t=t.trim(); if(!t||(c.tags||[]).includes(t))return; c.tags=[...(c.tags||[]),t]; c.updatedAt=Date.now(); bumpTags([t]); input.insertAdjacentHTML("beforebegin",tagChip(t)); wireTagRemovals(); saveBoards([board],`Tag ${c.title||c.id}`); };
-  const wireTagRemovals=()=>$$("[data-rmtag]",wrap).forEach(x=>x.onclick=()=>{ c.tags=(c.tags||[]).filter(t=>t!==x.dataset.rmtag); c.updatedAt=Date.now(); x.parentElement.remove(); saveBoards([board],`Untag ${c.title||c.id}`); });
-  wireTagRemovals();
-  input.onkeydown=e=>{ if(e.key==="Enter"||e.key===","){e.preventDefault();addTag(input.value);input.value="";} else if(e.key==="Backspace"&&!input.value){const chips=$$(".chip b",wrap);chips.length&&chips[chips.length-1].click();} };
-  input.onblur=()=>{ if(input.value.trim()){addTag(input.value);input.value="";} };
-  $$("[data-sug]",el).forEach(s=>s.onclick=()=>{addTag(s.dataset.sug);s.remove();});
-}
-function toggleCard(id){
-  openCards.has(id)?openCards.delete(id):openCards.add(id);
-  // re-render just the board area (not mid-typing since this is a deliberate toggle)
-  const board=activeBoard;
-  const el=$(`.card[data-card="${CSS.escape(id)}"]`,$("#kbBoard"));
-  const c=cards(board).find(x=>String(x.id)===String(id));
-  if(el&&c){
-    const tmp=document.createElement("div");
-    tmp.innerHTML=cardHTML(c,board);
-    const fresh=tmp.firstElementChild;
-    el.replaceWith(fresh);
-    wireCards();
-    if(openCards.has(id)){ const t=$(`.card[data-card="${CSS.escape(id)}"] [data-f="title"]`); t&&t.focus(); }
-  } else renderBoard();
-}
-
-/* ---- card ops ---- */
-let drag=null;
-function addCard(board,stage){
-  const now=Date.now(), st=stage||boardStages(board)[0]||"Backlog";
-  const c={id:uid(),title:"",platform:boardPlatforms(board)[0]||"Default",stage:st,lineage:"base",dev:"",live:"",statusColor:"gray",cardColor:"",tags:[],notes:"",files:[],pos:topPos(board,st),position:1,createdAt:now,updatedAt:now};
-  cards(board).unshift(c);
-  refreshIndexRecord(board);
-  openCards.add(c.id);
-  renderBoard();
-  const t=$(`.card[data-card="${CSS.escape(c.id)}"] [data-f="title"]`); t&&t.focus();
-  saveBoards([board],"Add card",true);
-}
-function topPos(board,stage){ const list=cards(board).filter(c=>(c.stage||c.lane)===stage); const min=Math.min(...list.map(c=>c.pos??c.position??1000),1000); return min-1000; }
-function duplicateCard(board,id){
-  const o=cards(board).find(c=>String(c.id)===String(id)); if(!o)return;
-  const now=Date.now();
-  const clone={...o,id:uid(),title:(o.title||"(untitled)")+" (copy)",createdAt:now,updatedAt:now,pos:topPos(board,o.stage||o.lane),files:(o.files||[]).map(f=>({...f}))};
-  cards(board).unshift(clone); refreshIndexRecord(board); renderBoard();
-  saveBoards([board],"Duplicate card",true); toast("Duplicated");
-}
-function archiveCard(board,id){
-  const list=cards(board), i=list.findIndex(c=>String(c.id)===String(id)); if(i<0)return;
-  const [c]=list.splice(i,1); c.archivedAt=Date.now();
-  (boardData[board].archive=boardData[board].archive||[]).unshift(c);
-  openCards.delete(id); refreshIndexRecord(board); renderBoard();
-  saveBoards([board],`Archive card ${c.title||id}`,true); toast("Archived card");
-}
-function cycleStatus(board,id){
-  const c=cards(board).find(x=>String(x.id)===String(id)); if(!c)return;
-  const i=STATUS_COLORS.indexOf(normStatus(c.statusColor));
-  c.statusColor=STATUS_COLORS[(i+1)%STATUS_COLORS.length]; c.updatedAt=Date.now();
-  const el=$(`.card[data-card="${CSS.escape(id)}"]`,$("#kbBoard"));
-  if(el){$(".status-dot",el).style.background=STATUS_MAP[c.statusColor];el.style.setProperty("--chip",ribbonOf(c));$(".status-dot",el).title="Status: "+c.statusColor;}
-  saveBoards([board],`Status ${c.title||id}`);
-}
-
-/* ---- lane drag & drop (move + reorder) ---- */
-function wireLaneDnD(){
-  $$(".lane-cards",$("#kbBoard")).forEach(lane=>{
-    lane.addEventListener("dragover",e=>{e.preventDefault();lane.parentElement.classList.add("drop");});
-    lane.addEventListener("dragleave",e=>{if(!lane.contains(e.relatedTarget))lane.parentElement.classList.remove("drop");});
-    lane.addEventListener("drop",e=>{
-      e.preventDefault();lane.parentElement.classList.remove("drop");
-      if(!drag)return;
-      const stage=lane.dataset.stage;
-      const after=[...$$(".card",lane)].find(el=>{const r=el.getBoundingClientRect();return e.clientY < r.top+r.height/2;});
-      moveCard(drag.board,drag.id,stage,after?after.dataset.card:null);
-    });
-  });
-}
-function moveCard(board,id,stage,beforeId){
-  const list=cards(board), c=list.find(x=>String(x.id)===String(id)); if(!c)return;
-  c.stage=stage; if("lane"in c)c.lane=stage; c.updatedAt=Date.now();
-  // recompute positions within stage based on DOM-ish order
-  const inStage=list.filter(x=>(x.stage||x.lane)===stage&&x.id!==id);
-  let idx=beforeId?inStage.findIndex(x=>String(x.id)===String(beforeId)):inStage.length;
-  if(idx<0)idx=inStage.length;
-  inStage.splice(idx,0,c);
-  inStage.forEach((x,i)=>{x.pos=(i+1)*1000; if("position"in x)x.position=i+1;});
-  refreshIndexRecord(board); renderBoard();
-  saveBoards([board],`Move ${c.title||id}`,true);
-}
-
-function openArchivedCards(board,anchor){
-  const arch=boardData[board]?.archive||[];
-  const body = arch.length
-    ? arch.map(c=>`<div class="bchip" style="--chip:${ribbonOf(c)};cursor:default">
-        <span class="n" title="${esc(c.title||"")}">${esc(c.title||"(untitled)")}</span>
-        <button class="btn small" data-restore="${esc(c.id)}">Restore</button>
-        <button class="ic" data-purge="${esc(c.id)}" title="Delete permanently">×</button></div>`).join("")
-    : `<p class="pop-note">No archived cards.</p>`;
-  const pop=popover(`<h4>Archived cards — ${board}</h4>${body}`,anchor,340);
-  $$("[data-restore]",pop).forEach(b=>b.onclick=()=>{
-    const i=arch.findIndex(c=>String(c.id)===String(b.dataset.restore)); if(i<0)return;
-    const [c]=arch.splice(i,1); delete c.archivedAt; c.updatedAt=Date.now();
-    if(!boardStages(board).includes(c.stage||c.lane))c.stage=boardStages(board)[0]||"Backlog";
-    cards(board).unshift(c); refreshIndexRecord(board); closePops(); renderBoard();
-    saveBoards([board],`Restore card ${c.title||c.id}`,true); toast("Restored");
-  });
-  $$("[data-purge]",pop).forEach(b=>b.onclick=()=>{
-    const i=arch.findIndex(c=>String(c.id)===String(b.dataset.purge)); if(i<0)return;
-    arch.splice(i,1); closePops(); renderBoard();
-    saveBoards([board],"Delete archived card"); toast("Deleted");
-  });
-}
-
-/* ---- note popover (read truncated) ---- */
-function notePopover(c,anchor){
-  popover(`<h4>${esc(c.title||"Note")}</h4><div class="pop-note">${renderMarkdown(c.notes||"")}</div>`,anchor,340);
-}
-
-/* ============ board create / settings dialogs ============ */
-function createBoardDialog(){
-  const d=$("#dialog");
-  d.innerHTML=`<form method="dialog" class="dlg">
-    <h2>New board</h2>
-    <div class="row"><label>Board name</label><input name="name" required placeholder="my-board" autofocus></div>
-    <div class="row"><label>Platforms (comma separated)</label><input name="platforms" value="${esc(DEFAULT_PLATFORMS.join(", "))}"></div>
-    <div class="row"><label>Stages / lanes (comma separated)</label><input name="stages" value="${esc(DEFAULT_STAGES.join(", "))}"></div>
-    <div class="two">
-      <div class="row"><label>Phase</label><select name="phase">${BOARD_PHASES.map(p=>`<option>${p}</option>`).join("")}</select></div>
-      <div class="row"><label>Stage</label><select name="bstage">${BOARD_STAGES.map(s=>`<option>${s}</option>`).join("")}</select></div>
-    </div>
-    <div class="row"><label>Layout</label><select name="layout"><option>auto</option><option>horizontal</option><option>vertical</option></select></div>
-    <div class="actions"><button class="btn" value="cancel">Cancel</button><button class="btn primary" value="ok">Create</button></div>
-  </form>`;
-  d.onclose=()=>{
-    if(d.returnValue!=="ok")return;
-    const f=new FormData($("form",d));
-    const name=String(f.get("name")||"").trim();
-    if(!name)return;
-    if(findBoard(name)||findBoard(slug(name))){toast("Board exists",true);return;}
-    const now=Date.now();
-    boardData[name]={version:1,cards:[],archive:[],
-      platforms:splitList(f.get("platforms"),DEFAULT_PLATFORMS),
-      stages:splitList(f.get("stages"),DEFAULT_STAGES),
-      layout:f.get("layout")||"auto",cardCollapsed:{},lastModified:now};
-    loaded.add(name);
-    index.boards.push({name,archived:false,createdAt:now,lastUpdated:now,cardCount:0,
-      phase:f.get("phase")||"dev",phaseUpdatedAt:now,stage:f.get("bstage")||"concept",stageUpdatedAt:now,lastCardUpdatedId:"",lastCardUpdatedAt:0});
-    index.activeBoard=name;
-    saveBoards([name],`Create board ${name}`,true);
-    renderRail(); openBoardView(name);
-    toast("Board created");
-  };
-  d.showModal();
-}
-const splitList=(v,fb)=>{const a=String(v||"").split(",").map(s=>s.trim()).filter(Boolean);return a.length?a:fb.slice();};
-
-function openBoardSettings(){
-  const name=activeBoard, b=boardData[name]||{};
-  const d=$("#dialog");
-  d.innerHTML=`<form method="dialog" class="dlg">
-    <h2>Board settings — ${esc(name)}</h2>
-    <div class="row"><label>Platforms</label><input name="platforms" value="${esc((b.platforms||DEFAULT_PLATFORMS).join(", "))}"></div>
-    <div class="row"><label>Stages / lanes</label><input name="stages" value="${esc((b.stages||DEFAULT_STAGES).join(", "))}"></div>
-    <div class="actions">
-      <button class="btn danger" value="delete" formnovalidate>Archive board</button>
-      <span class="spacer" style="flex:1"></span>
-      <button class="btn" value="cancel">Cancel</button><button class="btn primary" value="ok">Save</button>
-    </div>
-  </form>`;
-  d.onclose=()=>{
-    if(d.returnValue==="delete"){ toggleArchiveBoard(name); setView("matrix"); return; }
-    if(d.returnValue!=="ok")return;
-    const f=new FormData($("form",d));
-    b.platforms=splitList(f.get("platforms"),DEFAULT_PLATFORMS);
-    b.stages=splitList(f.get("stages"),DEFAULT_STAGES);
-    // move orphaned cards to first stage
-    const first=b.stages[0]||"Backlog";
-    cards(name).forEach(c=>{if(!b.stages.includes(c.stage||c.lane)){c.stage=first;if("lane"in c)c.lane=first;}});
-    saveBoards([name],`Board settings ${name}`,true); renderBoard(); toast("Saved");
-  };
-  d.showModal();
-}
-
-/* ============ settings (github / theme) ============ */
-function openSettings(){
-  const d=$("#dialog"), g=cfg.github;
-  d.innerHTML=`<form method="dialog" class="dlg">
-    <h2>Settings</h2>
-    <div class="row"><label>Portal name</label><input name="portalName" value="${esc(cfg.portalName)}"></div>
-    <div class="two">
-      <div class="row"><label>GitHub owner</label><input name="owner" value="${esc(g.owner)}"></div>
-      <div class="row"><label>Repository</label><input name="repo" value="${esc(g.repo)}"></div>
-    </div>
-    <div class="two">
-      <div class="row"><label>Branch</label><input name="branch" value="${esc(g.branch)}"></div>
-      <div class="row"><label>Accent color</label><input name="accent" type="color" value="${esc(cfg.accent)}"></div>
-    </div>
-    <div class="row"><label>GitHub PAT (stored locally; needed to save)</label><input name="pat" type="password" value="${esc(g.pat)}" placeholder="ghp_…"></div>
-    <div class="actions">
-      <button class="btn" value="export" formnovalidate>Export config</button>
-      <span style="flex:1"></span>
-      <button class="btn" value="cancel">Cancel</button><button class="btn primary" value="ok">Save</button>
-    </div>
-  </form>`;
-  d.onclose=()=>{
-    if(d.returnValue==="export"){ exportCfg(); return; }
-    if(d.returnValue!=="ok")return;
-    const f=new FormData($("form",d));
-    cfg.portalName=String(f.get("portalName")||"Program").trim()||"Program";
-    cfg.github={owner:String(f.get("owner")||"").trim(),repo:String(f.get("repo")||"").trim(),branch:String(f.get("branch")||"main").trim()||"main",pat:String(f.get("pat")||"").trim()};
-    if(validHex(f.get("accent")))cfg.accent=f.get("accent");
-    persist(); toast("Settings saved");
-  };
-  d.showModal();
-}
-function exportCfg(){
-  const blob=new Blob([JSON.stringify(cfg,null,2)],{type:"application/json"});
-  const a=document.createElement("a");a.href=URL.createObjectURL(blob);a.download=(slug(cfg.portalName)||"program")+"-config.json";a.click();URL.revokeObjectURL(a.href);
-}
-
-/* ============ popover infrastructure ============ */
-function closePops(){ $$(".pop").forEach(p=>p.remove()); }
-function popover(html,anchor,width){
-  closePops();
-  const p=document.createElement("div");p.className="pop";if(width)p.style.maxWidth=width+"px";p.innerHTML=html;
-  document.body.append(p);
-  const r=anchor.getBoundingClientRect(), pw=p.offsetWidth, ph=p.offsetHeight;
-  let left=Math.min(r.left, innerWidth-pw-8), top=r.bottom+6;
-  if(top+ph>innerHeight-8) top=Math.max(8,r.top-ph-6);
-  p.style.left=Math.max(8,left)+"px"; p.style.top=top+"px";
-  setTimeout(()=>document.addEventListener("pointerdown",function h(e){ if(!p.contains(e.target)){p.remove();document.removeEventListener("pointerdown",h);} }),0);
-  return p;
-}
-document.addEventListener("keydown",e=>{if(e.key==="Escape")closePops();});
-
-/* ============ markdown (from kanban) ============ */
-function escapeHtml(s){return String(s||"").replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[m]));}
-function normalizeShorthandUrl(url){const raw=String(url||"").trim();if(!raw)return"";if(/^[a-z][a-z\d+\-.]*:\/\//i.test(raw))return raw;const m=raw.match(/^([^\/?#]+)(.*)$/);if(!m)return"https://"+raw;let[,host,rest]=m;if(!host.includes("."))host+=".com";return`https://${host}${rest}`;}
-function shorthandToMarkdown(t){return String(t||"").replace(/(^|[\s(>])([A-Za-z0-9][^\n<>()\[\]]*?\S)\s*--\s*([^\s<>()]+)(?=$|[\s),.!?])/g,(m,pre,label,raw)=>{const L=label.trim(),U=normalizeShorthandUrl(raw);return(!L||!U)?m:`${pre}[**${L}**](${U})`;});}
-function preprocessNotes(s){const src=String(s||"");const chunks=[];const tok=src.replace(/!?\[[^\]]+\]\([^\)]+\)/g,m=>{const t=`__L${chunks.length}__`;chunks.push(m);return t;});const sh=shorthandToMarkdown(tok);const re=sh.replace(/!?\[[^\]]+\]\([^\)]+\)/g,m=>{const t=`__L${chunks.length}__`;chunks.push(m);return t;});const norm=re.replace(/https?:\/\/[^\s<>"]+/g,raw=>{const trim=raw.replace(/[),.;!?]+$/g,"");const suf=raw.slice(trim.length);let label="link";try{label=(new URL(trim).hostname||"").replace(/^www\./i,"")||"link";}catch{return raw;}return`[${label}](${trim})${suf}`;});return norm.replace(/__L(\d+)__/g,(_,i)=>chunks[+i]??"");}
-function inlineMd(t){return String(t||"").replace(/\*\*([^*]+)\*\*/g,"<strong>$1</strong>").replace(/\*([^*]+)\*/g,"<em>$1</em>").replace(/`([^`]+)`/g,"<code>$1</code>").replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,'<a href="$2" target="_blank" rel="noopener">$1</a>');}
-function linkify(s){return String(s||"").replace(/(?<!\]\()https?:\/\/[^\s)]+(?![^<]*>)/g,'<a href="$&" target="_blank" rel="noopener">$&</a>');}
-function renderMarkdown(source){
-  const withImg=escapeHtml(preprocessNotes(source||"")).replace(/!\[[^\]]*\]\((data:image\/[a-zA-Z0-9+.\-]+;base64,[^\)]+)\)/g,(m,src)=>`<img src="${src}" alt="pasted" style="max-width:100%">`);
-  const lines=withImg.split(/\r?\n/); let html="",inList=false,inCode=false;
-  for(const raw of lines){const line=raw||"";
-    if(line.startsWith("```")){html+=inCode?"</code></pre>":"<pre><code>";inCode=!inCode;continue;}
-    if(inCode){html+=line+"\n";continue;}
-    const li=line.match(/^\s*[-*]\s+(.*)$/);
-    if(li){if(!inList){html+="<ul>";inList=true;}html+=`<li>${inlineMd(linkify(li[1]))}</li>`;continue;}
-    if(inList){html+="</ul>";inList=false;}
-    if(/^\s*$/.test(line))continue;
-    if(line.startsWith("### ")){html+=`<p><strong>${inlineMd(linkify(line.slice(4)))}</strong></p>`;continue;}
-    if(line.startsWith("## ")){html+=`<p><strong>${inlineMd(linkify(line.slice(3)))}</strong></p>`;continue;}
-    if(line.startsWith("# ")){html+=`<p><strong>${inlineMd(linkify(line.slice(2)))}</strong></p>`;continue;}
-    html+=`<p>${inlineMd(linkify(line))}</p>`;
+    const cur=normStatus(c.statusColor);
+    const m=document.createElement("div"); m.className="status-menu"; m.setAttribute("role","menu");
+    const r=anchor.getBoundingClientRect();
+    m.style.left=Math.min(r.left,innerWidth-170)+"px"; m.style.top=Math.min(r.bottom+6,innerHeight-160)+"px";
+    m.innerHTML=STATUS_COLORS.map(s=>`<button type="button" data-s="${s}" class="${s===cur?"on":""}" title="${s}" style="background:${STATUS_MAP[s]}"></button>`).join("");
+    document.body.append(m);
+    m.querySelectorAll("[data-s]").forEach(b=>b.onclick=()=>{c.statusColor=b.dataset.s;c.updatedAt=new Date().toISOString();saveBoards([board],`Status ${c.title||id}`);m.remove();rerender();});
+    setTimeout(()=>document.addEventListener("pointerdown",function h(e){if(!m.contains(e.target)){m.remove();document.removeEventListener("pointerdown",h);}}),0);
   }
-  if(inList)html+="</ul>"; if(inCode)html+="</code></pre>";
-  return html;
-}
 
-/* ============ go ============ */
-boot().catch(e=>{ sync("Failed to start","err"); $("#main").innerHTML=`<div class="content"><div class="mx-empty-note"><b>Could not start.</b><br>${esc(e.message)}</div></div>`; });
+  function openCardEditor(board,id){
+    const c=cards(board).find(x=>String(x.id)===String(id)); if(!c)return;
+    const d=$("#cardDialog");
+    const plats=[...new Set([...(boardData[board]?.platforms||[]),c.platform].filter(Boolean))];
+    let activeTags=(c.tags||[]).map(String), dirty=false;
+    d.innerHTML=`<form method="dialog" class="dialog-body" novalidate><div class="dialog-head"><h2>Edit card</h2><button class="icon-btn" value="close" aria-label="Save and close">×</button></div>`+
+      `<div class="dialog-grid">`+
+        `<div class="control span-2"><label>Title<input name="title" required value="${esc(c.title)}"></label></div>`+
+        `<div class="control"><label>Platform<select name="platform">${options(plats,c.platform)}</select></label></div>`+
+        `<div class="control"><label>Stage<select name="stage">${options(stages(board),c.stage||c.lane)}</select></label></div>`+
+        `<div class="control"><label>Lineage<select name="lineage">${options(CARD_LINEAGES,normLineage(c.lineage))}</select></label></div>`+
+        `<div class="control"><label>Status<select name="statusColor">${options(STATUS_COLORS,normStatus(c.statusColor))}</select></label></div>`+
+        `<div class="control span-2"><label>Tags</label><div class="tag-chips" data-chips></div><input data-taginput placeholder="type a tag, press Enter"><div class="tag-suggestions" data-sug aria-label="Previously used tags"></div></div>`+
+        `<div class="control span-2"><label>Development link<input name="dev" type="url" value="${esc(c.dev)}"></label></div>`+
+        `<div class="control span-2"><label>Live link<input name="live" type="url" value="${esc(c.live)}"></label></div>`+
+        `<div class="control span-2"><label>Notes (Markdown · text--url shorthand)<textarea name="notes">${esc(c.notes)}</textarea></label><div class="note-prev" data-noteprev></div></div>`+
+      `</div>`+
+      `<div class="dialog-actions"><button class="btn primary" value="close">Save &amp; close</button><button type="button" class="btn" data-dup>Duplicate</button><span style="flex:1"></span><button type="button" class="btn danger" data-archive>Archive</button></div>`+
+    `</form>`;
+    const form=$("form",d), chipsEl=$("[data-chips]",d), inputEl=$("[data-taginput]",d), sugEl=$("[data-sug]",d), prev=$("[data-noteprev]",d);
+    const mark=()=>dirty=true;
+    const drawChips=()=>{chipsEl.innerHTML=activeTags.map(t=>`<span class="chip">${esc(t)}<button type="button" data-x="${esc(t)}" aria-label="Remove ${esc(t)}">×</button></span>`).join("");chipsEl.querySelectorAll("[data-x]").forEach(b=>b.onclick=()=>{activeTags=activeTags.filter(x=>x!==b.dataset.x);drawChips();drawSug();mark();});};
+    const drawSug=()=>{const q=inputEl.value.trim().toLowerCase(),seen=new Set();sugEl.innerHTML=allKnownTags().filter(t=>{const k=t.toLowerCase();if(activeTags.includes(t)||seen.has(k))return false;if(q&&!k.includes(q))return false;seen.add(k);return true;}).slice(0,14).map(t=>`<span class="chip" data-add="${esc(t)}">${esc(t)}<span class="sx" data-del="${esc(t)}" title="Remove from history">×</span></span>`).join("");sugEl.querySelectorAll("[data-add]").forEach(el=>el.onclick=e=>{if(e.target.dataset.del!==undefined){tagHistDel(el.dataset.add);drawSug();return;}if(!activeTags.includes(el.dataset.add)){activeTags.push(el.dataset.add);drawChips();drawSug();mark();}});};
+    const commitInput=()=>{const raw=inputEl.value.trim();if(!raw){drawSug();return;}raw.split(/[,\n]+/).forEach(p=>{const t=p.trim();if(t&&!activeTags.includes(t))activeTags.push(t);});inputEl.value="";drawChips();drawSug();mark();};
+    inputEl.onkeydown=e=>{if(e.key==="Enter"||e.key===","){e.preventDefault();commitInput();}else if(e.key==="Backspace"&&!inputEl.value&&activeTags.length){activeTags.pop();drawChips();drawSug();mark();}};
+    inputEl.oninput=drawSug; inputEl.onblur=commitInput;
+    const save=()=>{if(!form.reportValidity())return false;const f=new FormData(form);Object.assign(c,{title:(f.get("title")||"").trim()||"(untitled)",platform:(f.get("platform")||"").trim(),stage:f.get("stage"),lineage:f.get("lineage"),statusColor:f.get("statusColor"),dev:(f.get("dev")||"").trim(),live:(f.get("live")||"").trim(),notes:f.get("notes")||"",tags:activeTags.slice(),updatedAt:new Date().toISOString()});if("lane" in c)c.lane=c.stage;tagHistAdd(activeTags);dirty=false;saveBoards([board],`Update ${c.title||c.id}`);return true;};
+    form.addEventListener("input",()=>{mark();if(prev)prev.innerHTML=renderMd($("[name=notes]",form).value);});
+    form.addEventListener("focusout",e=>{if(!form.contains(e.relatedTarget)&&dirty)save();});
+    $("[data-dup]",d).onclick=()=>{if(dirty)save();d.close();duplicateCard(board,id);};
+    $("[data-archive]",d).onclick=()=>{d.close("archive");};
+    d.onclose=()=>{if(d.returnValue==="archive"){archiveCard(board,id);return;}if(dirty)save();rerender();};
+    d.showModal(); drawChips(); drawSug(); if(prev)prev.innerHTML=renderMd(c.notes||"");
+  }
+
+  window.addEventListener("keydown",e=>{if(e.key==="Escape"){$(".color-menu")?.remove();document.querySelector(".status-menu")?.remove();document.querySelector(".note-pop")?.remove();}});
+  boot().catch(e=>{sync("Portal failed to load","error");$("#view").innerHTML=`<div class="panel empty"><b>Mello could not start.</b><br>${esc(e.message)}</div>`;bindShell()});
 })();
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Combines **kanban.html** (rich card detail) and **mello.html** (board matrix) into a single app in **program.html**. The matrix is the view layer; the kanban card is the detail standard.

## What this does
- **Matrix = a view of boards** (from mello): create matrices on the fly; moving cards reorganizes inter/intra-board and the underlying card data follows.
- **Views of the same board are grouped** in the matrix picker (`<optgroup>` by board).
- **Transpose** control swaps X/Y axes and persists to the saved matrix.
- **Collapsed kanban card** is the representation in each X/Y intersection.
- **Single tap a card → expands to the full kanban card in an anchored popover** (no page scroll) with every feature intact: status, platform, stage, lineage, tags with history/suggestions, dev/live links, markdown notes, **file attachments**, duplicate, archive, color, inline edit. Edits persist and the matrix re-renders live on close.
- **Right-click a matrix card → change its color.**
- **Drill down to the board** via the board chip → add / copy / delete / edit cards in full kanban lanes → returning reactivates the matrix from shared data.
- **kanban's rich card detail is the standard editor**, shared by the modal editor and the expand popover via one field-builder (incl. attachments + markdown).

## Persistence
- Matrix definitions persist to **GitHub** (`program-matrices.json`) **and locally**, using the same fetch(read)/`putJson`(write) method as kanban boards.
- **GitHub is source-of-truth unless the local copy is newer**; `putJson` only updates (sha-based) and refuses to overwrite a newer remote. Requires a PAT in Configuration to sync (same as kanban); otherwise matrices persist locally and sync once a PAT is set.

## Verification
Loaded against real board data in a headless browser: matrix renders (25 cells / 19 cards), transpose swaps axes + headers, single-tap expand shows all fields, edits persist to the matrix, right-click color menu opens, matrices group by board, and drill-down → board → back round-trips — with **zero page errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyC6boTMTNR1obXZdvHoRe)_