### PR TITLE
Fix tag entry: keep focus after Enter

### DIFF
--- a/kanban.html
+++ b/kanban.html
@@ -1589,7 +1589,7 @@ function commitTagFromInput(){
   bumpTagHistory(activeTags);
   renderTagSuggestions();
 }
-tagInput.addEventListener("keydown", (e)=>{ if(e.key==="Enter" || e.key===","){ e.preventDefault(); commitTagFromInput(); } });
+tagInput.addEventListener("keydown", (e)=>{ if(e.key==="Enter" || e.key===","){ e.preventDefault(); commitTagFromInput(); tagInput.focus(); } });
 tagInput.addEventListener("blur", ()=>{ commitTagFromInput(); });
 tagInput.addEventListener("input", ()=> renderTagSuggestions());
 function renderTagChips(){


### PR DESCRIPTION
### Motivation
- Keep focus on the tag input after committing a tag so users can continue typing tags without the cursor moving away and so suggestions stay current.

### Description
- Replace the keydown listener line in `kanban.html` to call `tagInput.focus()` immediately after `commitTagFromInput()`, modifying only that single line.

### Testing
- Verified the one-line replacement and ran `git diff --check`, which passed, while attempts to push to the remote and create a PR failed due to network/GitHub authentication errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8252ad34cc832dbc858df5958f9add)